### PR TITLE
clean code: using IndexPath directly

### DIFF
--- a/BeeSwift/ConfigureNotificationsViewController.swift
+++ b/BeeSwift/ConfigureNotificationsViewController.swift
@@ -122,19 +122,20 @@ extension ConfigureNotificationsViewController : UITableViewDataSource, UITableV
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: self.cellReuseIdentifier) as! SettingsTableViewCell!
-        if (indexPath as NSIndexPath).section == 0 {
+        if indexPath.section == 0 {
             cell?.title = "Default notification settings"
             return cell!
         }
-        let goal = self.goals[(indexPath as NSIndexPath).row]
+        let goal = self.goals[indexPath.row]
         cell?.title = goal.slug
         return cell!
     }
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        if (indexPath as NSIndexPath).section == 0 {        self.navigationController?.pushViewController(EditDefaultNotificationsViewController(), animated: true)
+        if indexPath.section == 0 {
+            self.navigationController?.pushViewController(EditDefaultNotificationsViewController(), animated: true)
         } else {
-            let goal = self.goals[(indexPath as NSIndexPath).row]
+            let goal = self.goals[indexPath.row]
             self.navigationController?.pushViewController(EditGoalNotificationsViewController(goal: goal), animated: true)
         }
         self.tableView.deselectRow(at: indexPath, animated: true)

--- a/BeeSwift/GalleryViewController.swift
+++ b/BeeSwift/GalleryViewController.swift
@@ -445,13 +445,13 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        if (indexPath as NSIndexPath).row >= self.filteredGoals.count {
+        if indexPath.row >= self.filteredGoals.count {
             let cell:NewGoalCollectionViewCell = self.collectionView!.dequeueReusableCell(withReuseIdentifier: self.newGoalCellReuseIdentifier, for: indexPath) as! NewGoalCollectionViewCell
             return cell
         }
         let cell:GoalCollectionViewCell = self.collectionView!.dequeueReusableCell(withReuseIdentifier: self.cellReuseIdentifier, for: indexPath) as! GoalCollectionViewCell
         
-        let goal:JSONGoal = self.filteredGoals[(indexPath as NSIndexPath).row]
+        let goal:JSONGoal = self.filteredGoals[indexPath.row]
         
         cell.goal = goal
         
@@ -463,7 +463,7 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
     }
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        let row = (indexPath as NSIndexPath).row
+        let row = indexPath.row
         if row < self.filteredGoals.count { self.openGoal(self.filteredGoals[row]) }
     }
 

--- a/BeeSwift/GoalViewController.swift
+++ b/BeeSwift/GoalViewController.swift
@@ -597,8 +597,8 @@ class GoalViewController: UIViewController, UITableViewDelegate, UITableViewData
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         self.view.endEditing(true)
         if (self.goal.hideDataEntry()) { return }
-        if ((indexPath as NSIndexPath).row >= self.goal!.recent_data!.count) { return }
-        let datapointJSON : JSON = (self.goal!.recent_data![(indexPath as NSIndexPath).row] as? JSON)!
+        if (indexPath.row >= self.goal!.recent_data!.count) { return }
+        let datapointJSON : JSON = (self.goal!.recent_data![indexPath.row] as? JSON)!
         let editDatapointViewController = EditDatapointViewController()
         editDatapointViewController.datapointJSON = datapointJSON
         editDatapointViewController.goalSlug = self.goal.slug
@@ -607,9 +607,9 @@ class GoalViewController: UIViewController, UITableViewDelegate, UITableViewData
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: self.cellIdentifier) as! DatapointTableViewCell
-        if (indexPath as NSIndexPath).row < self.goal!.recent_data!.count {
+        if indexPath.row < self.goal!.recent_data!.count {
             
-            let datapoint : JSON = (self.goal!.recent_data![(indexPath as NSIndexPath).row] as? JSON)!
+            let datapoint : JSON = (self.goal!.recent_data![indexPath.row] as? JSON)!
             let text = datapoint["canonical"].string
             cell.datapointText = text
         }

--- a/BeeSwift/HealthKitConfigViewController.swift
+++ b/BeeSwift/HealthKitConfigViewController.swift
@@ -133,14 +133,14 @@ extension HealthKitConfigViewController : UITableViewDelegate, UITableViewDataSo
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: self.cellReuseIdentifier) as! HealthKitConfigTableViewCell!
 
-        let goal = self.goals[(indexPath as NSIndexPath).row]
+        let goal = self.goals[indexPath.row]
         cell!.goal = goal
         
         return cell!
     }
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        let goal = self.goals[(indexPath as NSIndexPath).row]
+        let goal = self.goals[indexPath.row]
         
         if goal.autodata.count == 0 {
             let chooseHKMetricViewController = ChooseHKMetricViewController()


### PR DESCRIPTION
can avoid casting as NSIndexPath since we are not
interested in the reference semantics or Foundation-
specific behavior provided by the NSIndexPath.
Instead we really just want the row and and section.