### PR TITLE
show placeholder graph right away

### DIFF
--- a/BeeSwift/GoalViewController.swift
+++ b/BeeSwift/GoalViewController.swift
@@ -111,6 +111,8 @@ class GoalViewController: UIViewController, UITableViewDelegate, UITableViewData
             make.left.equalTo(self.goalImageScrollView)
             make.right.equalTo(self.goalImageScrollView)
         }
+        self.goalImageView.image = UIImage(named: "GraphPlaceholder")
+
         
         self.view.addSubview(self.deltasLabel)
         self.deltasLabel.snp.makeConstraints { (make) in
@@ -394,6 +396,7 @@ class GoalViewController: UIViewController, UITableViewDelegate, UITableViewData
     }
     
     override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
         self.refreshGoal()
     }
     


### PR DESCRIPTION
a placeholder image is being used until the goal is loaded however this is set relatively late - in `viewDidAppear`, which means the user sees the view containing a large white/blank area where the graph will appear, then sees the placeholder, then sees the updated graph

with this change, the placeholder is set right straight away and thus is seen as the goalVC is being slid into view