### PR TITLE
[#92] fix today widget's bias toward compact view

### DIFF
--- a/BeeSwiftToday/TodayViewController.swift
+++ b/BeeSwiftToday/TodayViewController.swift
@@ -22,13 +22,13 @@ class TodayViewController: UIViewController {
     override func viewDidLoad() {
         NotificationCenter.default.addObserver(self, selector: #selector(self.updateDataSource), name: UserDefaults.didChangeNotification, object: nil)
         
+        self.updateDataSource()
+        
         self.preferredContentSize = CGSize.init(width: 0, height: self.rowHeight)
         
         if self.goalDictionaries.count > 1 {
             self.extensionContext?.widgetLargestAvailableDisplayMode = .expanded
         }
-        
-        self.updateDataSource()
         
         self.view.addSubview(self.tableView)
         self.tableView.dataSource = self

--- a/BeeSwiftToday/TodayViewController.swift
+++ b/BeeSwiftToday/TodayViewController.swift
@@ -12,8 +12,11 @@ import SnapKit
 import NotificationCenter
 
 class TodayViewController: UIViewController {
-    
-    var goalDictionaries : Array<NSDictionary> = []
+    var goalDictionaries: [NSDictionary] = [] {
+        didSet {
+            self.extensionContext?.widgetLargestAvailableDisplayMode = self.goalDictionaries.count > 1 ? .expanded : .compact
+        }
+    }
     var tableView = UITableView()
     
     fileprivate let rowHeight = Constants.thumbnailHeight + 40
@@ -25,10 +28,6 @@ class TodayViewController: UIViewController {
         self.updateDataSource()
         
         self.preferredContentSize = CGSize.init(width: 0, height: self.rowHeight)
-        
-        if self.goalDictionaries.count > 1 {
-            self.extensionContext?.widgetLargestAvailableDisplayMode = .expanded
-        }
         
         self.view.addSubview(self.tableView)
         self.tableView.dataSource = self


### PR DESCRIPTION
allowing for expanded was calculated and set before obtaining the data;
now grabbing the data/dictionaries first; if they contain more than one
entry, the expanded display mode is marked as available