### PR TITLE
app has no use for HealthKit Capabilities Entitlement

### DIFF
--- a/BeeSwift/BeeSwift.entitlements
+++ b/BeeSwift/BeeSwift.entitlements
@@ -10,8 +10,6 @@
 	</array>
 	<key>com.apple.developer.healthkit</key>
 	<true/>
-	<key>com.apple.developer.healthkit.access</key>
-	<array/>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.beeminder.beeminder</string>


### PR DESCRIPTION
(which provides access to FHIR-backed medical records)

Instead the app  makes use of HealthKit Entitlement
(which provides access to most HealthKit data types)

Removed the spurious entitlement