### PR TITLE
entering app from notification/widget does open screen of that goal

### DIFF
--- a/BeeSwift/AppDelegate.swift
+++ b/BeeSwift/AppDelegate.swift
@@ -40,6 +40,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             UserDefaults.standard.set(true, forKey: Constants.healthSyncRemindersPreferenceKey)
         }
         
+        UNUserNotificationCenter.current().delegate = self
         NotificationCenter.default.addObserver(self, selector: #selector(self.updateBadgeCount), name: NSNotification.Name(rawValue: CurrentUserManager.goalsFetchedNotificationName), object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(self.updateBadgeCount), name: NSNotification.Name(rawValue: CurrentUserManager.signedOutNotificationName), object: nil)
 
@@ -47,15 +48,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         
         return true
     }
-
-    func application(_ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable : Any]) {
-        CurrentUserManager.sharedManager.fetchGoals(success: { (goals) in
-            //
-        }) { (error, errorMessage) in
-            //
-        }
-    }
-
+    
     func applicationWillResignActive(_ application: UIApplication) {
         // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
         // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
@@ -94,26 +87,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     
 
     func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey : Any]) -> Bool {
-        if url.scheme == "beeminder" {
-            if let query = url.query {
-                let slugKeyIndex = query.components(separatedBy: "=").index(of: "slug")
-                let slug = query.components(separatedBy: "=")[(slugKeyIndex?.advanced(by: 1))!]
-
-                NotificationCenter.default.post(name: Notification.Name(rawValue: "openGoal"), object: nil, userInfo: ["slug": slug])
-            }
-        }
+        guard url.scheme == "beeminder", let slug = url.getSlug() else { return false }
+        
+        self.fetchGoalsIfNeededThenViewMatchingGoalWith(slug: slug)
         return true
     }
 
     func application(_ application: UIApplication, open url: URL, sourceApplication: String?, annotation: Any) -> Bool {
-        if url.scheme == "beeminder" {
-            if let query = url.query {
-                let slugKeyIndex = query.components(separatedBy: "=").index(of: "slug")
-                let slug = query.components(separatedBy: "=")[(slugKeyIndex?.advanced(by: 1))!]
-
-                NotificationCenter.default.post(name: Notification.Name(rawValue: "openGoal"), object: nil, userInfo: ["slug": slug])
-            }
-        }
+        guard url.scheme == "beeminder", let slug = url.getSlug() else { return false }
+        
+        self.fetchGoalsIfNeededThenViewMatchingGoalWith(slug: slug)
         return true
     }
     
@@ -154,5 +137,146 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         if ProcessInfo.processInfo.arguments.contains("UI-Testing") {
             UserDefaults.standard.removePersistentDomain(forName: Bundle.main.bundleIdentifier!)
         }
+    }
+    
+    // processing user's response to a notification
+    func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
+        
+        guard response.actionIdentifier == UNNotificationDefaultActionIdentifier else {
+            completionHandler()
+            return
+        }
+        
+        guard let slug = response.notification.request.getSlug() else {
+            completionHandler()
+            return
+        }
+        
+        print("found slug: \(slug)")
+        
+        self.fetchGoalsIfNeededThenViewMatchingGoalWith(slug: slug)
+        
+        completionHandler()
+    }
+    
+    // MARK: opening goals
+    
+    private func fetchGoalsIfNeededThenViewMatchingGoalWith(slug: String) {
+        if CurrentUserManager.sharedManager.goals.isEmpty || CurrentUserManager.sharedManager.goalsFetchedAt.timeIntervalSinceNow < -3600 {
+            // apparently no data or stale data
+            
+            CurrentUserManager.sharedManager.fetchGoals(success: { goals in
+                CurrentUserManager.sharedManager.goals = goals
+                self.openGoalWith(slug)
+            }, error: nil)
+            
+        } else {
+            self.openGoalWith(slug)
+        }
+    }
+    
+    /// given a goal we shall navigate to it
+    private func openGoal(goal: JSONGoal) {
+        guard let navigationController = window?.rootViewController as? UINavigationController else { return }
+        
+        let alreadyShowingGoal = { () -> Bool in
+            guard let topVC = navigationController.topViewController as? GoalViewController else { return false }
+            return topVC.goal.slug == goal.slug
+        }()
+        
+        if !alreadyShowingGoal {
+            let goalVC: GoalViewController = {
+                let goalVC = GoalViewController()
+                goalVC.goal = goal
+                return goalVC
+            }()
+            navigationController.popToRootViewController(animated: true)
+            navigationController.pushViewController(goalVC, animated: true)
+        }
+    }
+    
+    /// for viewing, open goal with slug
+    /// - Parameter slug: slug of the goal to open
+    private func openGoalWith(_ slug: String) {
+        guard let goal = CurrentUserManager.sharedManager.goals.last(where: { $0.slug == slug }) else {
+            print("no goal matching slug: \(slug)")
+            
+            guard let navigationController = window?.rootViewController as? UINavigationController else { return }
+            navigationController.popToRootViewController(animated: true)
+            
+            return
+        }
+        self.openGoal(goal: goal)
+    }
+
+}
+
+// MARK: - private extensions for extracting slugs
+
+private extension UNNotificationRequest {
+    func getSlug() -> String? {
+        return self.content.body.getSlug()
+    }
+}
+
+private extension Dictionary where Key == AnyHashable, Value == Any {
+    func getSlug() -> String? {
+        guard let alert = self.getNotificiationAlert() else { return nil }
+        
+        return alert.getSlug()
+    }
+    
+    func getNotificiationAlert() -> String? {
+        guard let aps = self["aps"] as? [String:Any] else { return nil }
+        
+        return aps["alert"] as? String
+    }
+}
+
+private extension String {
+    
+    static let beemergencyEepPrefix = "Eep! "
+    static let beemergencyTodayPrefix = "Beemergency today for "
+    
+    /// returns the slug found in notifications
+    ///
+    /// - note:
+    /// following format expected/supported:
+    /// - "Beemergency today for _slug-of-goal_"
+    /// - "Eep! _slug-of-goal_ needs _quantity_ _unit_ by _deadline_"
+    /// - "_slug-of-goal_ needs _quantity_ _unit_ by _deadline_"
+    func getSlug() -> String? {
+        let slugStart: String.Index = {
+            if self.starts(with: String.beemergencyTodayPrefix) {
+                return String.beemergencyTodayPrefix.endIndex
+            } else if self.starts(with: String.beemergencyEepPrefix) {
+                return String.beemergencyEepPrefix.endIndex
+            } else {
+                return self.startIndex
+            }
+        }()
+        
+        return self
+            .suffix(from: slugStart)
+            .split(separator: " ")
+            .first?
+            .trimmingCharacters(in: .whitespaces)
+    }
+}
+
+private extension URL {
+    /// obtains the slug, if found, from an URL
+    ///
+    /// - Note: currently supports URL "_beeminder://?slug=myslughere_"
+    func getSlug() -> String? {
+        guard
+            self.scheme == "beeminder",
+            let elements = self.query?.components(separatedBy: "="),
+            let slugKeyIndex = elements.index(of: "slug")
+            else { return nil }
+        
+        let slug = elements[(slugKeyIndex.advanced(by: 1))]
+        
+        return slug
     }
 }

--- a/BeeSwift/GalleryViewController.swift
+++ b/BeeSwift/GalleryViewController.swift
@@ -490,13 +490,13 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
             return
         }
         
-        let matchingGoal = self.goals.last(where: { $0.slug == slug })
+        guard let matchingGoal = self.goals.last(where: { $0.slug == slug }) else {
+            return
+        }
         
-        if matchingGoal != nil {
-            DispatchQueue.main.async {
-                self.navigationController?.popToRootViewController(animated: false)
-                self.openGoal(matchingGoal!)
-            }
+        DispatchQueue.main.async {
+            self.navigationController?.popToRootViewController(animated: false)
+            self.openGoal(matchingGoal)
         }
     }
     

--- a/BeeSwift/GalleryViewController.swift
+++ b/BeeSwift/GalleryViewController.swift
@@ -486,18 +486,18 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
     }
     
     @objc func openGoalFromNotification(_ notification: Notification) {
-        guard let slug = (notification as NSNotification).userInfo?["slug"] as? String else {
+        self.navigationController?.popToRootViewController(animated: false)
+
+        guard let slug = notification.userInfo?["slug"] as? String,
+            let matchingGoal = self.goals.last(where: { $0.slug == slug }) else {
+                
+                let alert = UIAlertController(title: "Goal not found", message: "no goal matching notification's goal was found", preferredStyle: .alert)
+                alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
+                self.present(alert, animated: true, completion: nil)
             return
         }
-        
-        guard let matchingGoal = self.goals.last(where: { $0.slug == slug }) else {
-            return
-        }
-        
-        DispatchQueue.main.async {
-            self.navigationController?.popToRootViewController(animated: false)
-            self.openGoal(matchingGoal)
-        }
+
+        self.openGoal(matchingGoal)
     }
     
     func openGoal(_ goal: JSONGoal) {

--- a/BeeSwift/GalleryViewController.swift
+++ b/BeeSwift/GalleryViewController.swift
@@ -486,13 +486,17 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
     }
     
     @objc func openGoalFromNotification(_ notification: Notification) {
-        let slug = (notification as NSNotification).userInfo!["slug"] as! String
-        let matchingGoal = self.goals.filter({ (goal) -> Bool in
-            return goal.slug == slug
-        }).last
+        guard let slug = (notification as NSNotification).userInfo?["slug"] as? String else {
+            return
+        }
+        
+        let matchingGoal = self.goals.last(where: { $0.slug == slug })
+        
         if matchingGoal != nil {
-            self.navigationController?.popToRootViewController(animated: false)
-            self.openGoal(matchingGoal!)
+            DispatchQueue.main.async {
+                self.navigationController?.popToRootViewController(animated: false)
+                self.openGoal(matchingGoal!)
+            }
         }
     }
     

--- a/BeeSwift/GoalViewController.swift
+++ b/BeeSwift/GoalViewController.swift
@@ -557,7 +557,7 @@ class GoalViewController: UIViewController, UITableViewDelegate, UITableViewData
         }) { (error, errorMessage) in
             self.submitButton.isUserInteractionEnabled = true
             MBProgressHUD.hideAllHUDs(for: self.view, animated: true)
-            UIAlertView(title: "Error", message: "Failed to add datapoint", delegate: nil, cancelButtonTitle: "OK").show()
+            self.present(self.failedToAddDatapointAlert, animated: true, completion: nil)
         }
     }
     
@@ -644,5 +644,14 @@ class GoalViewController: UIViewController, UITableViewDelegate, UITableViewData
     
     func safariViewControllerDidFinish(_ controller: SFSafariViewController) {
         controller.dismiss(animated: true, completion: nil)
+    }
+}
+
+
+extension GoalViewController {
+    var failedToAddDatapointAlert: UIAlertController {
+        let alert = UIAlertController(title: "Error", message: "Failed to add datapoint", preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
+        return alert
     }
 }

--- a/BeeSwift/GoalViewController.swift
+++ b/BeeSwift/GoalViewController.swift
@@ -570,14 +570,14 @@ class GoalViewController: UIViewController, UITableViewDelegate, UITableViewData
     }
     
     @objc func refreshGoal() {
-        RequestManager.get(url: "/api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.goal.slug)?access_token=\(CurrentUserManager.sharedManager.accessToken!)&datapoints_count=5", parameters: nil, success: { (responseObject) in
-            self.goal = JSONGoal(json: JSON(responseObject!))
+        CurrentUserManager.sharedManager.fetchGoal(self.goal.slug, success: { jsonGoal in
+            self.goal = jsonGoal
             self.datapointsTableView.reloadData()
             self.refreshCountdown()
             self.setValueTextField()
             self.valueTextFieldValueChanged()
             self.deltasLabel.attributedText = self.goal!.attributedDeltaText
-            if (!self.goal.queued!) {
+            if (!(jsonGoal.queued ?? false)) {
                 self.setGraphImage()
                 MBProgressHUD.hideAllHUDs(for: self.view, animated: true)
                 self.pollTimer?.invalidate()

--- a/BeeSwift/TimerViewController.swift
+++ b/BeeSwift/TimerViewController.swift
@@ -190,8 +190,17 @@ class TimerViewController: UIViewController {
             self.resetButtonPressed()
         }) { (error, errorMessage) in
             MBProgressHUD.hideAllHUDs(for: self.view, animated: true)
-            UIAlertView(title: "Error", message: "Failed to add datapoint", delegate: nil, cancelButtonTitle: "OK").show()
+
+            self.present(self.failedToAddDatapointAlert, animated: true, completion: nil)
         }
         
+    }
+}
+
+extension TimerViewController {
+    var failedToAddDatapointAlert: UIAlertController {
+        let alert = UIAlertController(title: "Error", message: "Failed to add datapoint", preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
+        return alert
     }
 }


### PR DESCRIPTION
fixes #97 
 - attach the 'open goal' at the end of a fetchIfNeeded

fixes #41 
 - implements `userNotificationCenter( :didReceive...` for processing user's response to notification
 - as is, appdelegate handles adjusting viewcontrollers such that expected controller is displayed

 This works with the push/remote notifications as they are now by reading the text displayed (in the aps/alert string). Given the few known formats, the slug is extracted and the corresponding goal requested to be opened.

##### supports the following three formats:
 * "slug-of-some-goal needs +2 by 00:00"
 * "Eep! slug-of-some-goal needs +2 by 00:00"
 * "Beemergency today for (slug)"

Longer term it be wise to adjust the format of the push message being sent from the backend so that the relevant data is made available in the userInfo, setting a field containing the slug directly.


As mentioned elsewhere, the #96 was fixed in #44 by implementing the `userNotificationCenter(_ center: UNUserNotificationCenter, willPresent...` by calling the completionHandler with options. 
A previous but partial solution at #41 was made in #60. The implementation in this PR is more robust and handles more, if not all, cases.




### Testing
 * tested in the simulator
 * using mocked data which the simulator presented as though a push message had arrived

example - "eep steps.apns"
```
{
  "aps": {
    "alert": "Eep! steps needs +2 by 00:00",
    "sound": "default"
  },
  "Simulator Target Bundle": "com.beeminder.beeminder"
}

```

 * tested when app was in foreground and background
 * tested when app had been force-closed
 * tested with existing goals and slugs that could not be matched to goals