### PR TITLE
pull to refresh on goal vc

### DIFF
--- a/BeeSwift/AppDelegate.swift
+++ b/BeeSwift/AppDelegate.swift
@@ -18,8 +18,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
 
-        UINavigationBar.appearance().titleTextAttributes = [NSAttributedStringKey.font : UIFont(name: "Avenir", size: 20)!]
-        UIBarButtonItem.appearance().setTitleTextAttributes([NSAttributedStringKey.font : UIFont(name: "Avenir", size: 18)!], for: UIControlState())
+        UINavigationBar.appearance().titleTextAttributes = [NSAttributedStringKey.font :
+            UIFont.beeminder.defaultFontPlain.withSize(20)]
+        UIBarButtonItem.appearance().setTitleTextAttributes([NSAttributedStringKey.font : UIFont.beeminder.defaultFontPlain.withSize(18)], for: UIControlState())
         IQKeyboardManager.shared().isEnableAutoToolbar = false
 
         if HKHealthStore.isHealthDataAvailable() {

--- a/BeeSwift/DatapointTableViewCell.swift
+++ b/BeeSwift/DatapointTableViewCell.swift
@@ -30,7 +30,7 @@ class DatapointTableViewCell : UITableViewCell {
     }
     
     func setup() {
-        self.datapointLabel.font = UIFont(name: "Avenir", size: Constants.defaultFontSize)
+        self.datapointLabel.font = UIFont.beeminder.defaultFontPlain.withSize(Constants.defaultFontSize)
         self.datapointLabel.lineBreakMode = .byTruncatingTail
         self.contentView.addSubview(self.datapointLabel)
         self.selectionStyle = .none

--- a/BeeSwift/EditNotificationsViewController.swift
+++ b/BeeSwift/EditNotificationsViewController.swift
@@ -222,7 +222,7 @@ extension EditNotificationsViewController : UIPickerViewDataSource, UIPickerView
             make.left.equalTo(10)
             make.right.equalTo(-20)
         }
-        label.font = UIFont(name: "Avenir", size: 17)
+        label.font = UIFont.beeminder.defaultFontPlain.withSize(17)
         
         var text = ""
         var alignment = NSTextAlignment.center

--- a/BeeSwift/GalleryViewController.swift
+++ b/BeeSwift/GalleryViewController.swift
@@ -73,7 +73,7 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
         
         self.lastUpdatedView.addSubview(self.lastUpdatedLabel)
         self.lastUpdatedLabel.text = "Last updated:"
-        self.lastUpdatedLabel.font = UIFont(name: "Avenir", size: Constants.defaultFontSize)
+        self.lastUpdatedLabel.font = UIFont.beeminder.defaultFontPlain.withSize(Constants.defaultFontSize)
         self.lastUpdatedLabel.textAlignment = NSTextAlignment.center
         self.lastUpdatedLabel.snp.makeConstraints { (make) -> Void in
             make.top.equalTo(3)

--- a/BeeSwift/GalleryViewController.swift
+++ b/BeeSwift/GalleryViewController.swift
@@ -21,7 +21,6 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
     let lastUpdatedLabel = BSLabel()
     let cellReuseIdentifier = "Cell"
     let newGoalCellReuseIdentifier = "NewGoalCell"
-    var refreshControl = UIRefreshControl()
     var deadbeatView = UIView()
     var outofdateView = UIView()
     let noGoalsLabel = BSLabel()
@@ -147,8 +146,11 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
         self.collectionView!.register(NewGoalCollectionViewCell.self, forCellWithReuseIdentifier: self.newGoalCellReuseIdentifier)
         self.view.addSubview(self.collectionView!)
         
-        self.refreshControl.addTarget(self, action: #selector(self.fetchGoals), for: UIControlEvents.valueChanged)
-        self.collectionView!.addSubview(self.refreshControl)
+        self.collectionView?.refreshControl = {
+            let refreshControl = UIRefreshControl()
+            refreshControl.addTarget(self, action: #selector(self.fetchGoals), for: UIControlEvents.valueChanged)
+            return refreshControl
+        }()
         
         self.collectionView!.snp.makeConstraints { (make) -> Void in
             make.top.equalTo(self.searchBar.snp.bottom)
@@ -373,7 +375,7 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
     @objc func didFetchGoals() {
         self.sortGoals()
         self.setupHealthKit()
-        self.refreshControl.endRefreshing()
+        self.collectionView?.refreshControl?.endRefreshing()
         MBProgressHUD.hideAllHUDs(for: self.view, animated: true)
         self.collectionView!.reloadData()
         self.updateDeadbeatHeight()
@@ -419,7 +421,7 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
                     self.present(alert, animated: true, completion: nil)
                 }
             }
-            self.refreshControl.endRefreshing()
+            self.collectionView?.refreshControl?.endRefreshing()
             MBProgressHUD.hideAllHUDs(for: self.view, animated: true)
             self.collectionView!.reloadData()
         }

--- a/BeeSwift/GoalViewController.swift
+++ b/BeeSwift/GoalViewController.swift
@@ -56,6 +56,13 @@ class GoalViewController: UIViewController, UITableViewDelegate, UITableViewData
             make.bottom.equalTo(0)
         }
         
+        
+        self.scrollView.refreshControl = {
+            let refreshControl = UIRefreshControl()
+            refreshControl.addTarget(self, action: #selector(refreshButtonPressed), for: .valueChanged)
+            return refreshControl
+        }()
+        
         let countdownView = UIView()
         self.scrollView.addSubview(countdownView)
         countdownView.snp.makeConstraints { (make) -> Void in
@@ -342,7 +349,7 @@ class GoalViewController: UIViewController, UITableViewDelegate, UITableViewData
             syncWeekButton.addTarget(self, action: #selector(self.syncWeekButtonPressed), for: .touchUpInside)
         }
         
-        var items = [UIBarButtonItem(barButtonSystemItem: .refresh, target: self, action: #selector(self.refreshButtonPressed)), UIBarButtonItem(barButtonSystemItem: .action, target: self, action: #selector(self.actionButtonPressed))]
+        var items = [UIBarButtonItem(barButtonSystemItem: .action, target: self, action: #selector(self.actionButtonPressed))]
         
         if (!self.goal.hideDataEntry()) {
             items.append(UIBarButtonItem.init(image: UIImage.init(named: "Timer"), style: .plain, target: self, action: #selector(self.timerButtonPressed)))
@@ -430,6 +437,9 @@ class GoalViewController: UIViewController, UITableViewDelegate, UITableViewData
     }
     
     @objc func refreshButtonPressed() {
+        self.scrollView.refreshControl?.endRefreshing()
+        MBProgressHUD.showAdded(to: self.view, animated: true)?.mode = .indeterminate
+
         RequestManager.get(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.goal.slug)/refresh_graph.json", parameters: nil, success: { (responseObject) in
             self.pollUntilGraphUpdates()
         }) { (error) in

--- a/BeeSwift/GoalViewController.swift
+++ b/BeeSwift/GoalViewController.swift
@@ -141,9 +141,7 @@ class GoalViewController: UIViewController, UITableViewDelegate, UITableViewData
         }
         
         let dataEntryView = UIView()
-        if (self.goal.hideDataEntry()) {
-            dataEntryView.isHidden = true
-        }
+        dataEntryView.isHidden = self.goal.hideDataEntry()
 
         self.scrollView.addSubview(dataEntryView)
         dataEntryView.snp.makeConstraints { (make) -> Void in

--- a/BeeSwift/GoalViewController.swift
+++ b/BeeSwift/GoalViewController.swift
@@ -359,13 +359,20 @@ class GoalViewController: UIViewController, UITableViewDelegate, UITableViewData
         self.syncHealthDataButtonPressed(numDays: 7)
     }
     
+    private var previouslySeenSyncDayAmount: [Int] {
+        [
+            1, /*a day; today*/
+            7 /*a week; the past seven days*/
+        ]
+    }
     /// expecting 1 for today button and 7 for week button
-    private func syncHealthDataButtonPressed(numDays: Int) {
-        precondition(numDays == 1 || numDays == 7, "only designed to handle the values 1 and 7")
+    private func syncHealthDataButtonPressed(numDays: Int = 1) {
+        assert(previouslySeenSyncDayAmount.contains(numDays), "previously only handled values \(previouslySeenSyncDayAmount); hic sunt dracones!")
+        let daysBackToSync = previouslySeenSyncDayAmount.contains(numDays) ? numDays : 1
         
         let hud = MBProgressHUD.showAdded(to: self.view, animated: true)
         hud?.mode = .indeterminate
-        self.goal.hkQueryForLast(days: numDays, success: {
+        self.goal.hkQueryForLast(days: daysBackToSync, success: {
             DispatchQueue.main.asyncAfter(deadline: .now() + 1, execute: {
                 hud?.mode = .customView
                 hud?.customView = UIImageView(image: UIImage(named: "checkmark"))

--- a/BeeSwift/GoalViewController.swift
+++ b/BeeSwift/GoalViewController.swift
@@ -14,11 +14,7 @@ import SafariServices
 
 class GoalViewController: UIViewController, UITableViewDelegate, UITableViewDataSource, UIScrollViewDelegate, UITextFieldDelegate, SFSafariViewControllerDelegate {
     
-    var goal : JSONGoal! {
-        didSet {
-            
-        }
-    }
+    var goal : JSONGoal!
     
     fileprivate var cellIdentifier = "datapointCell"
     fileprivate var goalImageView = UIImageView()

--- a/BeeSwift/GoalViewController.swift
+++ b/BeeSwift/GoalViewController.swift
@@ -159,7 +159,7 @@ class GoalViewController: UIViewController, UITableViewDelegate, UITableViewData
         }
         
         dataEntryView.addSubview(self.dateTextField)
-        self.dateTextField.font = UIFont(name: "Avenir", size: 16)
+        self.dateTextField.font = UIFont.beeminder.defaultFontPlain.withSize(16)
         self.dateTextField.tintColor = UIColor.beeminder.gray
         self.dateTextField.layer.borderColor = UIColor.beeminder.gray.cgColor
         self.dateTextField.layer.borderWidth = 1
@@ -174,7 +174,7 @@ class GoalViewController: UIViewController, UITableViewDelegate, UITableViewData
         }
         
         dataEntryView.addSubview(self.valueTextField)
-        self.valueTextField.font = UIFont(name: "Avenir", size: 16)
+        self.valueTextField.font = UIFont.beeminder.defaultFontPlain.withSize(16)
         self.valueTextField.tintColor = UIColor.beeminder.gray
         self.valueTextField.layer.borderColor = UIColor.beeminder.gray.cgColor
         self.valueTextField.layer.borderWidth = 1
@@ -213,7 +213,7 @@ class GoalViewController: UIViewController, UITableViewDelegate, UITableViewData
         let commentLeftPaddingView = UIView(frame: CGRect(x: 0, y: 0, width: 5, height: 1))
         
         dataEntryView.addSubview(self.commentTextField)
-        self.commentTextField.font = UIFont(name: "Avenir", size: 16)
+        self.commentTextField.font = UIFont.beeminder.defaultFontPlain.withSize(16)
         self.commentTextField.leftView = commentLeftPaddingView
         self.commentTextField.leftViewMode = .always
         self.commentTextField.tintColor = UIColor.beeminder.gray
@@ -282,7 +282,7 @@ class GoalViewController: UIViewController, UITableViewDelegate, UITableViewData
         let dateLabel = BSLabel()
         dataEntryView.addSubview(dateLabel)
         dateLabel.text = "Date"
-        dateLabel.font = UIFont(name: "Avenir", size: Constants.defaultFontSize)
+        dateLabel.font = UIFont.beeminder.defaultFontPlain.withSize(Constants.defaultFontSize)
         dateLabel.textAlignment = .center
         dateLabel.snp.makeConstraints { (make) -> Void in
             make.left.equalTo(self.dateStepper)
@@ -304,7 +304,7 @@ class GoalViewController: UIViewController, UITableViewDelegate, UITableViewData
         let valueLabel = BSLabel()
         dataEntryView.addSubview(valueLabel)
         valueLabel.text = "Value"
-        valueLabel.font = UIFont(name: "Avenir", size: Constants.defaultFontSize)
+        valueLabel.font = UIFont.beeminder.defaultFontPlain.withSize(Constants.defaultFontSize)
         valueLabel.textAlignment = .center
         valueLabel.snp.makeConstraints { (make) -> Void in
             make.left.equalTo(self.valueStepper)

--- a/BeeSwift/GoalViewController.swift
+++ b/BeeSwift/GoalViewController.swift
@@ -349,13 +349,11 @@ class GoalViewController: UIViewController, UITableViewDelegate, UITableViewData
             syncWeekButton.addTarget(self, action: #selector(self.syncWeekButtonPressed), for: .touchUpInside)
         }
         
-        var items = [UIBarButtonItem(barButtonSystemItem: .action, target: self, action: #selector(self.actionButtonPressed))]
-        
+        self.navigationItem.rightBarButtonItems = [UIBarButtonItem(barButtonSystemItem: .action, target: self, action: #selector(self.actionButtonPressed))]
         if (!self.goal.hideDataEntry()) {
-            items.append(UIBarButtonItem.init(image: UIImage.init(named: "Timer"), style: .plain, target: self, action: #selector(self.timerButtonPressed)))
+            self.navigationItem.rightBarButtonItems?.append(UIBarButtonItem(image: UIImage.init(named: "Timer"), style: .plain, target: self, action: #selector(self.timerButtonPressed)))
         }
         
-        self.navigationItem.rightBarButtonItems = items
     }
     
     @objc func syncTodayButtonPressed() {
@@ -439,7 +437,7 @@ class GoalViewController: UIViewController, UITableViewDelegate, UITableViewData
     @objc func refreshButtonPressed() {
         self.scrollView.refreshControl?.endRefreshing()
         MBProgressHUD.showAdded(to: self.view, animated: true)?.mode = .indeterminate
-
+        
         RequestManager.get(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.goal.slug)/refresh_graph.json", parameters: nil, success: { (responseObject) in
             self.pollUntilGraphUpdates()
         }) { (error) in

--- a/BeeSwift/GoalViewController.swift
+++ b/BeeSwift/GoalViewController.swift
@@ -446,7 +446,7 @@ class GoalViewController: UIViewController, UITableViewDelegate, UITableViewData
     }
     
     @objc func colonButtonPressed() {
-        self.valueTextField.text = "\(self.valueTextField.text!):"
+        self.valueTextField.text?.append(":")
     }
     
     @objc func refreshCountdown() {

--- a/BeeSwift/GoalViewController.swift
+++ b/BeeSwift/GoalViewController.swift
@@ -352,25 +352,20 @@ class GoalViewController: UIViewController, UITableViewDelegate, UITableViewData
     }
     
     @objc func syncTodayButtonPressed() {
-        let hud = MBProgressHUD.showAdded(to: self.view, animated: true)
-        hud?.mode = .indeterminate
-        self.goal.hkQueryForLast(days: 1, success: {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1, execute: {
-                hud?.mode = .customView
-                hud?.customView = UIImageView(image: UIImage(named: "checkmark"))
-                hud?.hide(true, afterDelay: 2)
-            })
-        }) {
-            DispatchQueue.main.async {
-                MBProgressHUD.hideAllHUDs(for: self.view, animated: true)
-            }
-        }
+        self.syncHealthDataButtonPressed(numDays: 1)
     }
     
     @objc func syncWeekButtonPressed() {
+        self.syncHealthDataButtonPressed(numDays: 7)
+    }
+    
+    /// expecting 1 for today button and 7 for week button
+    private func syncHealthDataButtonPressed(numDays: Int) {
+        precondition(numDays == 1 || numDays == 7, "only designed to handle the values 1 and 7")
+        
         let hud = MBProgressHUD.showAdded(to: self.view, animated: true)
         hud?.mode = .indeterminate
-        self.goal.hkQueryForLast(days: 7, success: {
+        self.goal.hkQueryForLast(days: numDays, success: {
             DispatchQueue.main.asyncAfter(deadline: .now() + 1, execute: {
                 hud?.mode = .customView
                 hud?.customView = UIImageView(image: UIImage(named: "checkmark"))

--- a/BeeSwift/SignInViewController.swift
+++ b/BeeSwift/SignInViewController.swift
@@ -110,7 +110,7 @@ class SignInViewController : UIViewController, UITextFieldDelegate {
         self.signInButton.isHidden = true
         self.signInButton.setTitle("Sign In", for: UIControlState())
         self.signInButton.backgroundColor = UIColor.beeminder.gray
-        self.signInButton.titleLabel?.font = UIFont(name: "Avenir", size: 20)
+        self.signInButton.titleLabel?.font = UIFont.beeminder.defaultFontPlain.withSize(20)
         self.signInButton.titleLabel?.textColor = UIColor.white
         self.signInButton.addTarget(self, action: #selector(SignInViewController.signInButtonPressed), for: UIControlEvents.touchUpInside)
         self.signInButton.snp.makeConstraints { (make) -> Void in
@@ -174,7 +174,7 @@ class SignInViewController : UIViewController, UITextFieldDelegate {
         scrollView.addSubview(self.signUpButton)
         self.signUpButton.isHidden = true
         self.signUpButton.setTitle("Sign Up", for: .normal)
-        self.signUpButton.titleLabel?.font = UIFont(name: "Avenir", size: 20)
+        self.signUpButton.titleLabel?.font = UIFont.beeminder.defaultFontPlain.withSize(20)
         self.signUpButton.addTarget(self, action: #selector(SignInViewController.signUpButtonPressed), for: .touchUpInside)
         self.signUpButton.snp.makeConstraints { (make) in
             make.top.equalTo(self.newPasswordTextField.snp.bottom).offset(15)


### PR DESCRIPTION
fixed #84 

provides the scrollView with a refreshControl and configures the refreshControl to refresh (poll for the changes to the graph, then refresh the goal; same as before via the navBarItem) on valueChanged

removes the now redundant refresh navBarItem

little bit of 'clean code' around the code touched