### PR TITLE
use `me` instead of username when using access token

### DIFF
--- a/BeeSwift/ChooseHKMetricViewController.swift
+++ b/BeeSwift/ChooseHKMetricViewController.swift
@@ -103,7 +103,7 @@ class ChooseHKMetricViewController: UIViewController {
         var params : [String : [String : String]] = [:]
         params = ["ii_params" : ["name" : "apple", "metric" : self.goal!.healthKitMetric!]]
         
-        RequestManager.put(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.goal!.slug).json", parameters: params, success: { (responseObject) -> Void in
+        RequestManager.put(url: "api/v1/users/me/goals/\(self.goal!.slug).json", parameters: params, success: { (responseObject) -> Void in
                 let hud = MBProgressHUD.allHUDs(for: self.view).first as? MBProgressHUD
                 hud?.mode = .customView
                 hud?.customView = UIImageView(image: UIImage(named: "checkmark"))

--- a/BeeSwift/CurrentUserManager.swift
+++ b/BeeSwift/CurrentUserManager.swift
@@ -120,7 +120,7 @@ class CurrentUserManager : NSObject {
     }
     
     func syncNotificationDefaults(_ success: (() -> Void)?, failure: (() -> Void)?) {
-        RequestManager.get(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!).json", parameters: [:],
+        RequestManager.get(url: "api/v1/users/me.json", parameters: [:],
             success: { (responseObject) -> Void in
                 let responseJSON = JSON(responseObject!)
                 UserDefaults.standard.set(responseJSON["default_alertstart"].number!, forKey: "default_alertstart")

--- a/BeeSwift/EditDatapointViewController.swift
+++ b/BeeSwift/EditDatapointViewController.swift
@@ -191,7 +191,7 @@ class EditDatapointViewController: UIViewController, UITextFieldDelegate {
             "access_token": CurrentUserManager.sharedManager.accessToken!,
             "urtext": self.urtext()
         ]
-        RequestManager.put(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.goalSlug!)/datapoints/\(self.datapointJSON!["id"]["$oid"].string!).json", parameters: params, success: { (response) in
+        RequestManager.put(url: "api/v1/users/me/goals/\(self.goalSlug!)/datapoints/\(self.datapointJSON!["id"]["$oid"].string!).json", parameters: params, success: { (response) in
             let hud = MBProgressHUD.allHUDs(for: self.view).first as? MBProgressHUD
             hud?.mode = .customView
             hud?.customView = UIImageView(image: UIImage(named: "checkmark"))
@@ -208,7 +208,7 @@ class EditDatapointViewController: UIViewController, UITextFieldDelegate {
         ]
         let hud = MBProgressHUD.showAdded(to: self.view, animated: true)
         hud?.mode = .indeterminate
-        RequestManager.delete(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.goalSlug!)/datapoints/\(self.datapointJSON!["id"]["$oid"].string!).json", parameters: params, success: { (response) in
+        RequestManager.delete(url: "api/v1/users/me/goals/\(self.goalSlug!)/datapoints/\(self.datapointJSON!["id"]["$oid"].string!).json", parameters: params, success: { (response) in
             let hud = MBProgressHUD.allHUDs(for: self.view).first as? MBProgressHUD
             hud?.mode = .customView
             hud?.customView = UIImageView(image: UIImage(named: "checkmark"))

--- a/BeeSwift/EditDefaultNotificationsViewController.swift
+++ b/BeeSwift/EditDefaultNotificationsViewController.swift
@@ -25,7 +25,7 @@ class EditDefaultNotificationsViewController: EditNotificationsViewController {
         var userInfo = timer.userInfo! as! Dictionary<String, NSNumber>
         guard let leadtime = userInfo["leadtime"] as? NSNumber else { return }
         let params = [ "default_leadtime" : leadtime ]
-        RequestManager.put(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!).json", parameters: params,
+        RequestManager.put(url: "api/v1/users/me.json", parameters: params,
             success: { (responseObject) -> Void in
                 CurrentUserManager.sharedManager.setDefaultLeadTime(leadtime)
             }) { (error) -> Void in
@@ -42,7 +42,7 @@ class EditDefaultNotificationsViewController: EditNotificationsViewController {
         if self.timePickerEditingMode == .alertstart {
             self.updateAlertstartLabel(self.midnightOffsetFromTimePickerView())
             let params = ["default_alertstart" : self.midnightOffsetFromTimePickerView()]
-            RequestManager.put(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!).json", parameters: params,
+            RequestManager.put(url: "api/v1/users/me.json", parameters: params,
                 success: { (responseObject) -> Void in
                     CurrentUserManager.sharedManager.setDefaultAlertstart(self.midnightOffsetFromTimePickerView())
                 }) { (error) -> Void in
@@ -52,7 +52,7 @@ class EditDefaultNotificationsViewController: EditNotificationsViewController {
         if self.timePickerEditingMode == .deadline {
             self.updateDeadlineLabel(self.midnightOffsetFromTimePickerView())
             let params = ["default_deadline" : self.midnightOffsetFromTimePickerView()]
-            RequestManager.put(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!).json", parameters: params,
+            RequestManager.put(url: "api/v1/users/me.json", parameters: params,
                 success: { (responseObject) -> Void in
                     CurrentUserManager.sharedManager.setDefaultDeadline(self.midnightOffsetFromTimePickerView())
                 }) { (error) -> Void in

--- a/BeeSwift/EditGoalNotificationsViewController.swift
+++ b/BeeSwift/EditGoalNotificationsViewController.swift
@@ -60,7 +60,7 @@ class EditGoalNotificationsViewController : EditNotificationsViewController {
         var userInfo = timer.userInfo! as! Dictionary<String, NSNumber>
         let leadtime = userInfo["leadtime"]
         let params = [ "leadtime" : leadtime, "use_defaults" : false ]
-        RequestManager.put(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.goal!.slug).json", parameters: params,
+        RequestManager.put(url: "api/v1/users/me/goals/\(self.goal!.slug).json", parameters: params,
             success: { (responseObject) -> Void in
                 self.goal!.leadtime = leadtime!
                 self.goal!.use_defaults = NSNumber(value: false as Bool)
@@ -74,7 +74,7 @@ class EditGoalNotificationsViewController : EditNotificationsViewController {
         if self.timePickerEditingMode == .alertstart {
             self.updateAlertstartLabel(self.midnightOffsetFromTimePickerView())
             let params = ["alertstart" : self.midnightOffsetFromTimePickerView(), "use_defaults" : false]
-            RequestManager.put(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.goal!.slug).json", parameters: params,
+            RequestManager.put(url: "api/v1/users/me/goals/\(self.goal!.slug).json", parameters: params,
                 success: { (responseObject) -> Void in
                     self.goal!.alertstart = self.midnightOffsetFromTimePickerView()
                     self.goal!.use_defaults = NSNumber(value: false as Bool)
@@ -86,7 +86,7 @@ class EditGoalNotificationsViewController : EditNotificationsViewController {
         if self.timePickerEditingMode == .deadline {
             self.updateDeadlineLabel(self.midnightOffsetFromTimePickerView())
             let params = ["deadline" : self.midnightOffsetFromTimePickerView(), "use_defaults" : false]
-            RequestManager.put(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.goal!.slug).json", parameters: params,
+            RequestManager.put(url: "api/v1/users/me/goals/\(self.goal!.slug).json", parameters: params,
                 success: { (responseObject) -> Void in
                     self.goal?.deadline = self.midnightOffsetFromTimePickerView()
                     self.goal!.use_defaults = NSNumber(value: false as Bool)
@@ -107,7 +107,7 @@ class EditGoalNotificationsViewController : EditNotificationsViewController {
             let alertController = UIAlertController(title: "Confirm", message: "This will wipe out your current settings for this goal. Are you sure?", preferredStyle: .alert)
             alertController.addAction(UIAlertAction(title: "Yes", style: .default, handler: { (action) -> Void in
                 let params = ["use_defaults" : true]
-                RequestManager.put(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.goal!.slug).json", parameters: params,
+                RequestManager.put(url: "api/v1/users/me/goals/\(self.goal!.slug).json", parameters: params,
                     success: { (responseObject) -> Void in
                         self.goal?.use_defaults = NSNumber(value: true as Bool)
                         CurrentUserManager.sharedManager.syncNotificationDefaults({ () -> Void in
@@ -133,7 +133,7 @@ class EditGoalNotificationsViewController : EditNotificationsViewController {
         }
         else {
             let params = ["use_defaults" : false]
-            RequestManager.put(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.goal!.slug).json", parameters: params,
+            RequestManager.put(url: "api/v1/users/me/goals/\(self.goal!.slug).json", parameters: params,
                 success: { (responseObject) -> Void in
                     self.goal?.use_defaults = NSNumber(value: false as Bool)
                 }) { (error) -> Void in

--- a/BeeSwift/GoalViewController.swift
+++ b/BeeSwift/GoalViewController.swift
@@ -421,12 +421,12 @@ class GoalViewController: UIViewController, UITableViewDelegate, UITableViewData
     }
     
     @objc func safariButtonPressed() {
-        let url = "\(RequestManager.baseURLString)/api/v1/users/\(CurrentUserManager.sharedManager.username!).json?access_token=\(CurrentUserManager.sharedManager.accessToken!)&redirect_to_url=\(RequestManager.baseURLString)/\(CurrentUserManager.sharedManager.username!)/\(self.goal!.slug)"
+        let url = "\(RequestManager.baseURLString)/api/v1/users/me.json?access_token=\(CurrentUserManager.sharedManager.accessToken!)&redirect_to_url=\(RequestManager.baseURLString)/me/\(self.goal!.slug)"
         UIApplication.shared.openURL(URL(string: url)!)
     }
     
     @objc func refreshButtonPressed() {
-        RequestManager.get(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.goal.slug)/refresh_graph.json", parameters: nil, success: { (responseObject) in
+        RequestManager.get(url: "api/v1/users/me/goals/\(self.goal.slug)/refresh_graph.json", parameters: nil, success: { (responseObject) in
             self.pollUntilGraphUpdates()
         }) { (error) in
             let alert = UIAlertController(title: "Error", message: "Could not refresh graph", preferredStyle: .alert)
@@ -537,7 +537,7 @@ class GoalViewController: UIViewController, UITableViewDelegate, UITableViewData
         self.scrollView.scrollRectToVisible(CGRect(x: 0, y: 0, width: 0, height: 0), animated: true)
         let params = ["urtext": self.urtextFromTextFields(), "requestid": UUID().uuidString]
         
-        RequestManager.post(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.goal.slug)/datapoints.json", parameters: params, success: { (responseObject) in
+        RequestManager.post(url: "api/v1/users/me/goals/\(self.goal.slug)/datapoints.json", parameters: params, success: { (responseObject) in
             self.commentTextField.text = ""
             self.refreshGoal()
             self.pollUntilGraphUpdates()
@@ -559,7 +559,7 @@ class GoalViewController: UIViewController, UITableViewDelegate, UITableViewData
     }
     
     @objc func refreshGoal() {
-        RequestManager.get(url: "/api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.goal.slug)?access_token=\(CurrentUserManager.sharedManager.accessToken!)&datapoints_count=5", parameters: nil, success: { (responseObject) in
+        RequestManager.get(url: "/api/v1/users/me/goals/\(self.goal.slug)?access_token=\(CurrentUserManager.sharedManager.accessToken!)&datapoints_count=5", parameters: nil, success: { (responseObject) in
             self.goal = JSONGoal(json: JSON(responseObject!))
             self.datapointsTableView.reloadData()
             self.refreshCountdown()

--- a/BeeSwift/JSONGoal.swift
+++ b/BeeSwift/JSONGoal.swift
@@ -618,7 +618,7 @@ class JSONGoal {
         
         let params = ["sort" : "daystamp", "count" : 7] as [String : Any]
         
-        RequestManager.get(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.slug)/datapoints.json", parameters: params, success: { (response) in
+        RequestManager.get(url: "api/v1/users/me/goals/\(self.slug)/datapoints.json", parameters: params, success: { (response) in
             let responseJSON = JSON(response)
             var datapoints = responseJSON.array!
             datapoints = datapoints.filter { (datapoint) -> Bool in
@@ -654,7 +654,7 @@ class JSONGoal {
                         if datapointValue == val { success?() }
                         else {
                             let datapointID = d["id"].string
-                            RequestManager.put(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.slug)/datapoints/\(datapointID!).json", parameters: params, success: { (responseObject) in
+                            RequestManager.put(url: "api/v1/users/me/goals/\(self.slug)/datapoints/\(datapointID!).json", parameters: params, success: { (responseObject) in
                                 success?()
                             }, errorHandler: { (error) in
                                 errorCompletion?()
@@ -662,7 +662,7 @@ class JSONGoal {
                         }
                     } else {
                         let datapointID = d["id"].string
-                        RequestManager.delete(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.slug)/datapoints/\(datapointID!)", parameters: nil, success: { (response) in
+                        RequestManager.delete(url: "api/v1/users/me/goals/\(self.slug)/datapoints/\(datapointID!)", parameters: nil, success: { (response) in
                             //
                         }) { (error) in
                             //
@@ -812,7 +812,7 @@ class JSONGoal {
     }
     
     func postDatapoint(params : [String : String], success : ((Any?) -> Void)?, failure : ((Error?) -> Void)?) {
-        RequestManager.post(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.slug)/datapoints.json", parameters: params, success: success, errorHandler: failure)
+        RequestManager.post(url: "api/v1/users/me/goals/\(self.slug)/datapoints.json", parameters: params, success: success, errorHandler: failure)
     }
 }
 

--- a/BeeSwift/RemoveHKMetricViewController.swift
+++ b/BeeSwift/RemoveHKMetricViewController.swift
@@ -12,10 +12,10 @@ import SwiftyJSON
 class RemoveHKMetricViewController: UIViewController {
     
     var goal : JSONGoal!
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         if #available(iOS 13.0, *) {
             self.view.backgroundColor = .systemBackground
         } else {
@@ -60,7 +60,7 @@ class RemoveHKMetricViewController: UIViewController {
         removeButton.setTitle("Disconnect", for: .normal)
         removeButton.addTarget(self, action: #selector(self.removeButtonPressed), for: .touchUpInside)
     }
-    
+
     override func didReceiveMemoryWarning() {
         super.didReceiveMemoryWarning()
         // Dispose of any resources that can be recreated.
@@ -73,7 +73,7 @@ class RemoveHKMetricViewController: UIViewController {
         let hud = MBProgressHUD.showAdded(to: self.view, animated: true)
         hud?.mode = .indeterminate
         
-        RequestManager.put(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.goal!.slug).json", parameters: params, success: { (responseObject) -> Void in
+        RequestManager.put(url: "api/v1/users/me/goals/\(self.goal!.slug).json", parameters: params, success: { (responseObject) -> Void in
             
             self.goal = JSONGoal(json: JSON(responseObject!))
 

--- a/BeeSwift/TimerViewController.swift
+++ b/BeeSwift/TimerViewController.swift
@@ -177,7 +177,7 @@ class TimerViewController: UIViewController {
         let hud = MBProgressHUD.showAdded(to: self.view, animated: true)
         hud?.mode = .indeterminate
         let params = ["urtext": self.urtext(), "requestid": UUID().uuidString]
-        RequestManager.post(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.slug!)/datapoints.json", parameters: params, success: { (responseObject) in
+        RequestManager.post(url: "api/v1/users/me/goals/\(self.slug!)/datapoints.json", parameters: params, success: { (responseObject) in
             hud?.mode = .text
             hud?.labelText = "Added!"
             DispatchQueue.main.asyncAfter(deadline: .now() + 2, execute: {


### PR DESCRIPTION
according to the [API documentation](http://api.beeminder.com/#client-oauth),
the access token uniquely identifies the user and thus the placeholder can be used
instead of the username

replaced username with me in urls using access token