### PR TITLE
let github dependabot check dependencies regularly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+# Set update schedule for various package managers
+
+version: 2
+updates:
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  # Maintain dependencies for bundler
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+


### PR DESCRIPTION
configure the [dependabot](https://docs.github.com/en/github/administering-a-repository/keeping-your-dependencies-updated-automatically) for the supported package managers this project uses
 - bundler (Gemfile)
 - github-actions (.github/actions folder)

Missing and not supported by the bot is the package manager cocoapods