### PR TITLE
Bugfix/30 graphs remain hidden after user updates payment method

### DIFF
--- a/BeeSwift.xcodeproj/project.pbxproj
+++ b/BeeSwift.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		1B8454411999895F722BAE80 /* Pods_BeeSwiftToday.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A2D58FC1D496CC59C60A22C /* Pods_BeeSwiftToday.framework */; };
 		6E72E1F82DDC41E7CD79BEE4 /* Pods_BeeSwiftTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 20121F7A17F740656ADD55D0 /* Pods_BeeSwiftTests.framework */; };
 		9B8CA57D24B120CA009C86C2 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9B8CA57C24B120CA009C86C2 /* LaunchScreen.storyboard */; };
+		9B95A44C24DF8E8D007DD992 /* JSONUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B95A44B24DF8E8D007DD992 /* JSONUser.swift */; };
+		9B95A44D24DF92FA007DD992 /* JSONUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B95A44B24DF8E8D007DD992 /* JSONUser.swift */; };
 		A10D4E931B07948500A72D29 /* DatapointsTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10D4E921B07948500A72D29 /* DatapointsTableView.swift */; };
 		A10DC2DF207BFCBA00FB7B3A /* RemoveHKMetricViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10DC2DE207BFCBA00FB7B3A /* RemoveHKMetricViewController.swift */; };
 		A11488BE1EE9B0CE003316E1 /* UIDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11488BD1EE9B0CE003316E1 /* UIDevice.swift */; };
@@ -133,6 +135,7 @@
 		689E3517CFFCDE8407A728A7 /* Pods-BeeSwiftTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BeeSwiftTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-BeeSwiftTests/Pods-BeeSwiftTests.debug.xcconfig"; sourceTree = "<group>"; };
 		8A2D58FC1D496CC59C60A22C /* Pods_BeeSwiftToday.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BeeSwiftToday.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9B8CA57C24B120CA009C86C2 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
+		9B95A44B24DF8E8D007DD992 /* JSONUser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONUser.swift; sourceTree = "<group>"; };
 		A10D4E921B07948500A72D29 /* DatapointsTableView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatapointsTableView.swift; sourceTree = "<group>"; };
 		A10DC2DE207BFCBA00FB7B3A /* RemoveHKMetricViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoveHKMetricViewController.swift; sourceTree = "<group>"; };
 		A11488BD1EE9B0CE003316E1 /* UIDevice.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIDevice.swift; sourceTree = "<group>"; };
@@ -360,6 +363,7 @@
 				A1BD0D171AEB30A5001EDE8B /* GoalViewController.swift */,
 				A1E618E11E78158700D8ED93 /* HealthKitConfigViewController.swift */,
 				A1F8F07A232C05410060B83E /* JSONGoal.swift */,
+				9B95A44B24DF8E8D007DD992 /* JSONUser.swift */,
 				A1453B3E1AEDFCC8006F48DA /* SignInViewController.swift */,
 				A149B36F1AEF528C00F19A09 /* SettingsViewController.swift */,
 				A1A8BDE51FEAE8DD007D61D6 /* ConfigureNotificationsViewController.swift */,
@@ -776,6 +780,7 @@
 			files = (
 				A12E69511BD3EF0200AB94C2 /* TodayViewController.swift in Sources */,
 				A1D853291EB0EA2400FC75DE /* BSLabel.swift in Sources */,
+				9B95A44D24DF92FA007DD992 /* JSONUser.swift in Sources */,
 				E55FEE6C23FF7552007C20B2 /* Config.swift in Sources */,
 				A1D8532A1EB0EA2B00FC75DE /* BSButton.swift in Sources */,
 				A14249301FD0A5A4007736B3 /* HealthKitConfig.swift in Sources */,
@@ -813,6 +818,7 @@
 				A1619EA41BEECC1500E14B3A /* EditDefaultNotificationsViewController.swift in Sources */,
 				A1E619001E86980900D8ED93 /* HealthKitConfig.swift in Sources */,
 				A149B3701AEF528C00F19A09 /* SettingsViewController.swift in Sources */,
+				9B95A44C24DF8E8D007DD992 /* JSONUser.swift in Sources */,
 				A1453B391AEDA71D006F48DA /* BSLabel.swift in Sources */,
 				A1E618E21E78158700D8ED93 /* HealthKitConfigViewController.swift in Sources */,
 				A1F8F07B232C05410060B83E /* JSONGoal.swift in Sources */,

--- a/BeeSwift/CurrentUserManager.swift
+++ b/BeeSwift/CurrentUserManager.swift
@@ -98,14 +98,28 @@ class CurrentUserManager : NSObject {
     }
     
     func signInWithEmail(_ email: String, password: String) {
-        RequestManager.post(url: "api/private/sign_in", parameters: ["user": ["login": email, "password": password], "beemios_secret": self.beemiosSecret] as Dictionary<String, Any>, success: { (responseObject) in
-            self.handleSuccessfulSignin(JSON(responseObject))
+        let parameters: [String: Any] =
+            [
+                "user":
+                    [
+                        "login": email,
+                        "password": password
+                ],
+                "beemios_secret":
+                    self.beemiosSecret
+        ]
+        
+        RequestManager.post(url: "api/private/sign_in",
+                            parameters: parameters,
+                            success: { (responseObject) in
+                                self.handleSuccessfulSignin(JSON(responseObject))
         }) { (responseError, errorMessage) in
             if responseError != nil { self.handleFailedSignin(responseError!, errorMessage: errorMessage) }
         }
     }
     
     func handleSuccessfulSignin(_ responseJSON: JSON) {
+        
         if responseJSON["deadbeat"].boolValue {
             self.setDeadbeat(true)
         }
@@ -162,13 +176,13 @@ class CurrentUserManager : NSObject {
                            success: { responseJSON in
                             
                             guard let responseJSON = responseJSON else {
-                                error?(ApiError.jsonDeserializationError)
+                                error?(ApiError.jsonDeserializationError, nil)
                                 return
                             }
 
                             let json = JSON(responseJSON)
                             guard let responseUser = JSONUser(json: json) else {
-                                error?(ApiError.jsonDeserializationError)
+                                error?(ApiError.jsonDeserializationError, nil)
                                 return
                             }
 

--- a/BeeSwift/CurrentUserManager.swift
+++ b/BeeSwift/CurrentUserManager.swift
@@ -71,7 +71,7 @@ class CurrentUserManager : NSObject {
         UserDefaults.standard.synchronize()
     }
     
-    func signedIn() -> Bool {
+    var isSignedIn: Bool {
         return self.accessToken != nil && self.username != nil
     }
     

--- a/BeeSwift/CurrentUserManager.swift
+++ b/BeeSwift/CurrentUserManager.swift
@@ -160,9 +160,17 @@ class CurrentUserManager : NSObject {
         RequestManager.get(url: "api/v1/users/me.json",
                            parameters: nil,
                            success: { responseJSON in
+                            
+                            guard let responseJSON = responseJSON else {
+                                error?(ApiError.jsonDeserializationError)
+                                return
+                            }
 
-                            let json = JSON(responseJSON!)
-                            let responseUser = JSONUser(json: json)!
+                            let json = JSON(responseJSON)
+                            guard let responseUser = JSONUser(json: json) else {
+                                error?(ApiError.jsonDeserializationError)
+                                return
+                            }
                             
                             success?(responseUser)
                            }, errorHandler: { (responseError, errorMessage) in

--- a/BeeSwift/CurrentUserManager.swift
+++ b/BeeSwift/CurrentUserManager.swift
@@ -171,6 +171,8 @@ class CurrentUserManager : NSObject {
                                 error?(ApiError.jsonDeserializationError)
                                 return
                             }
+
+                            self.setDeadbeat(responseUser.deadbeat)
                             
                             success?(responseUser)
                            }, errorHandler: { (responseError, errorMessage) in

--- a/BeeSwift/GalleryViewController.swift
+++ b/BeeSwift/GalleryViewController.swift
@@ -205,7 +205,7 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
             }
         }
         
-        if CurrentUserManager.sharedManager.signedIn() {
+        if CurrentUserManager.sharedManager.isSignedIn {
             UNUserNotificationCenter.current().requestAuthorization(options: UNAuthorizationOptions([.alert, .badge, .sound])) { (success, error) in
                 print(success)
                 if success {
@@ -218,7 +218,7 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
     }
     
     override func viewDidAppear(_ animated: Bool) {
-        if !CurrentUserManager.sharedManager.signedIn() {
+        if !CurrentUserManager.sharedManager.isSignedIn {
             let signInVC = SignInViewController()
             signInVC.modalPresentationStyle = .fullScreen
             self.present(signInVC, animated: true, completion: nil)

--- a/BeeSwift/GoalViewController.swift
+++ b/BeeSwift/GoalViewController.swift
@@ -390,7 +390,7 @@ class GoalViewController: UIViewController, UITableViewDelegate, UITableViewData
     }
     
     override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
-        if (!CurrentUserManager.sharedManager.signedIn()) { return }
+        if (!CurrentUserManager.sharedManager.isSignedIn) { return }
         if keyPath == "graph_url" {
             self.setGraphImage()
         } else if keyPath == "delta_text" || keyPath == "safebump" || keyPath == "safesum" {

--- a/BeeSwift/JSONUser.swift
+++ b/BeeSwift/JSONUser.swift
@@ -1,0 +1,105 @@
+//
+//  JSONUser.swift
+//  BeeSwift
+//
+//  Created by krugerk on 23.06.20.
+//  Copyright © 2020 krugerk. All rights reserved.
+//
+
+import Foundation
+
+import SwiftyJSON
+
+/**
+ A User object ("object" in the JSON sense) includes information about a user, like their list of goals.
+ 
+ - seealso:
+ [Beeminder API - User](https://api.beeminder.com/#user)
+ */
+struct JSONUser: Codable {
+    let username: String
+    /// DRAFT: example: "Europe\/Berlin"
+    let timezone: String
+    /// (number): Unix timestamp (in seconds) of the last update to this user or any of their goals or datapoints.
+    let updated_at: TimeInterval
+    /// goals (array): A list of slugs for each of the user's goals, or an array of goal hashes (objects) if diff_since or associations is sent.
+    let goals: [String]
+    ///  (boolean): True if the user's payment info is out of date, or an attempted payment has failed.
+    let deadbeat: Bool
+    ///  (number): The idea of Urgency Load is to construct a single number that captures how edge-skatey you are across all your goals. A lower number means fewer urgently due goals. A score of 0 means that you have >= 7 days of buffer on all of your active goals.
+    let urgency_load: Int
+    ///  (array): An array of hashes, each with one key/value pair for the id of the deleted goal.
+    ///  Optional, only returned if diff_since is sent.
+    let deleted_goals: [DeletedGoal]?
+    
+    // MARK: - these were provided in the json but not on the api doc
+    
+    let id: String
+    
+    let remaining_subs_credit: Int
+    let default_deadline: Int
+    
+    /// DRAFT: example 34200; 34200 / 60 / 60 = 9.50 = 9:30 in the morning
+    let default_alertstart: TimeInterval
+    let subs_downto: String
+    let has_authorized_fitbit: Bool
+    
+    /// DRAFT: string, probably with well-known strings
+    ///
+    /// - Core Beeminder
+    /// - Infinibee
+    /// - Bee Plus
+    /// - Beemium
+    let subscription: String
+    
+    /// DRAFT: example 1000
+    let subs_freq: Int
+    
+    /// DRAFT: the extent of the validity of the subscription?
+    let subs_lifetime: String
+    
+    /// example 1416166725
+    let created_at: TimeInterval
+    
+    init?(json: JSON) {
+        self.username = json["username"].stringValue
+        self.timezone = json["timezone"].stringValue
+        self.updated_at = json["updated_at"].doubleValue
+        
+        self.goals = json["goals"].arrayValue.map { $0.stringValue }
+        
+        self.deadbeat = json["deadbeat"].boolValue
+        self.urgency_load = json["deadbeat"].intValue
+        
+        self.deleted_goals = json["deleted_goals"].array?.compactMap {
+            DeletedGoal(id: $0["id"].stringValue, slug: $0["slug"].stringValue)
+        }
+        
+        self.id = json["id"].stringValue
+        
+        self.remaining_subs_credit = json["remaining_subs_credit"].intValue
+        self.default_deadline = json["default_deadline"].intValue
+        
+        self.default_alertstart = json["default_alertstart"].doubleValue
+        self.subs_downto = json["subs_downto"].stringValue
+        self.has_authorized_fitbit = json["has_authorized_fitbit"].boolValue
+        
+        self.subscription = json["subscription"].stringValue
+        
+        self.subs_freq = json["subs_freq"].intValue
+        
+        self.subs_lifetime = json["subs_lifetime"].stringValue
+        
+        self.created_at = json["created_at"].doubleValue
+        
+    }
+}
+
+
+/// represents a deleted goal
+///
+/// hashes, each with one key/value pair for the id of the deleted goal.
+struct DeletedGoal: Codable {
+    let id: String
+    let slug: String
+}

--- a/BeeSwift/RequestManager.swift
+++ b/BeeSwift/RequestManager.swift
@@ -85,3 +85,10 @@ class RequestManager {
     }
 
 }
+
+// MARK: - Error types when interacting with the API
+
+/// Error types describing errors when interacting with the API
+public enum ApiError: Error {
+    case jsonDeserializationError
+}


### PR DESCRIPTION
fixes #30 

Rather than just fetching goals after signing in, the user resource is also fetched. The [user resource](https://api.beeminder.com/#user) contains details on 'deadbeat', with the status being updated internally once obtained.

Without complicating matters, the fetchUser is being called each time fetchGoals is called. After all, the deadbeat status can change at any time.
