### PR TITLE
Display countdown straight away

### DIFF
--- a/BeeSwift/GoalViewController.swift
+++ b/BeeSwift/GoalViewController.swift
@@ -78,6 +78,7 @@ class GoalViewController: UIViewController, UITableViewDelegate, UITableViewData
             make.centerY.centerX.equalTo(countdownView)
             make.width.equalTo(countdownView)
         }
+        self.refreshCountdown()
         
         self.scrollView.addSubview(self.goalImageScrollView)
         self.goalImageScrollView.showsHorizontalScrollIndicator = false


### PR DESCRIPTION
in goalVC, show the countdown at view load like the rest of the data.
Previously it was only being initially shown when the goal was
fetched upon loading the goalVC

fixes #164 