### PR TITLE
Remove the storage used for the today widget upon signout

### DIFF
--- a/BeeSwift/CurrentUserManager.swift
+++ b/BeeSwift/CurrentUserManager.swift
@@ -151,6 +151,10 @@ class CurrentUserManager : NSObject {
         UserDefaults.standard.removeObject(forKey: deadbeatKey)
         UserDefaults.standard.removeObject(forKey: usernameKey)
         UserDefaults.standard.synchronize()
+
+        UserDefaults.standard.removeSuite(named: "group.beeminder.beeminder")
+        CurrentUserManager.sharedManager.updateTodayWidget()
+
         NotificationCenter.default.post(name: Notification.Name(rawValue: CurrentUserManager.signedOutNotificationName), object: self)
     }
     


### PR DESCRIPTION
Clears the today widget by removing entries from the storage it uses to find the access token and top three goals.

fixes #236