### PR TITLE
use an uninterpolated string in eval_gemfile

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -22,7 +22,8 @@ blocks:
         commands:
           - checkout
           - cache restore
-          - bundle install --path vendor/bundle
+          - bundle config set path 'vendor/bundle'
+          - bundle install
           - cache store
           - cp /Users/semaphore/BeeSwift/BeeSwift/Config.swift.sample /Users/semaphore/BeeSwift/BeeSwift/Config.swift
       jobs:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,5 +1,5 @@
 version: v1.0
-name: Semaphore iOS Swift example with Fastlane
+name: test BeeSwift
 agent:
   machine:
     type: a1-standard-4

--- a/Gemfile
+++ b/Gemfile
@@ -9,5 +9,4 @@ gem "xcode-install"
 gem "cocoapods"
 gem "rest-client"
 
-plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')
-eval_gemfile(plugins_path) if File.exist?(plugins_path)
+eval_gemfile('fastlane/Pluginfile')


### PR DESCRIPTION
Instead of using the fastlane-generated interpolated string specifiying the plugins_path,
a string is used directly. This allows dependabot to evaluate the Gemfile and thus fixes #196.