### PR TITLE
point CI build badge to beeminder.semaphoreci.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![GitHub](https://img.shields.io/github/license/beeminder/BeeSwift)](https://github.com/beeminder/BeeSwift/)
 [![GitHub tag (latest SemVer)](https://img.shields.io/github/v/tag/beeminder/BeeSwift?sort=semver)](https://github.com/beeminder/BeeSwift/tags)
-[![Semaphore CI test status](https://andrewpbrett.semaphoreci.com/badges/BeeSwift.svg)](https://andrewpbrett.semaphoreci.com)
+[![Semaphore CI test Status](https://beeminder.semaphoreci.com/badges/BeeSwift/branches/master.svg?style=shields)](https://beeminder.semaphoreci.com/projects/BeeSwift)
+
 
 # BeeSwift
 Official Beeminder for iOS app


### PR DESCRIPTION
After the renaming/migrating at semaphore, the badge showing the build/test status of the master pointed to the outdated URL. This commit updates the badge to point at the current URL and thus fixes the broken badge being displayed.