### PR TITLE
built in timer getting cancelled

### DIFF
--- a/BeeSwift/CurrentUserManager.swift
+++ b/BeeSwift/CurrentUserManager.swift
@@ -33,6 +33,21 @@ class CurrentUserManager : NSObject {
     
     var goals : [JSONGoal] = []
     var goalsFetchedAt : Date = Date()
+
+    func timingSince(for goal: JSONGoal) -> Date? {
+        return UserDefaults.standard.object(forKey: keyTimer(for: goal)) as? Date
+    }
+    func set(timerSince: Date?, for goal: JSONGoal) {
+        let key = keyTimer(for: goal)
+        guard let timingSince = timerSince else {
+            UserDefaults.standard.removeObject(forKey: key)
+            return
+        }
+        UserDefaults.standard.set(timingSince, forKey: key)
+    }
+    private func keyTimer(for goal: JSONGoal) -> String {
+        return "key-timer-\(goal.id)"
+    }
     
     var accessToken :String? {
         return UserDefaults.standard.object(forKey: accessTokenKey) as! String?

--- a/BeeSwift/GoalViewController.swift
+++ b/BeeSwift/GoalViewController.swift
@@ -404,9 +404,7 @@ class GoalViewController: UIViewController, UITableViewDelegate, UITableViewData
     }
     
     @objc func timerButtonPressed() {
-        let controller = TimerViewController()
-        controller.slug = self.goal.slug
-        controller.goal = self.goal
+        let controller = TimerViewController(for: self.goal)
         controller.modalPresentationStyle = .fullScreen
         do {
             let hoursRegex = try NSRegularExpression(pattern: "(hr|hour)s?")

--- a/BeeSwift/TimerViewController.swift
+++ b/BeeSwift/TimerViewController.swift
@@ -195,3 +195,10 @@ class TimerViewController: UIViewController {
         
     }
 }
+
+extension TimerViewController {
+    convenience init(for goal: JSONGoal) {
+        self.init()
+        self.goal = goal
+    }
+}

--- a/BeeSwift/TimerViewController.swift
+++ b/BeeSwift/TimerViewController.swift
@@ -14,10 +14,12 @@ class TimerViewController: UIViewController {
     
     let timerLabel = BSLabel()
     let startStopButton = BSButton()
-    var goal : JSONGoal?
+    var goal : JSONGoal!
     var timingSince: Date?
     var timer: Timer?
-    var slug: String?
+    var slug: String {
+        goal.slug
+    }
     var units: String?
     var accumulatedSeconds = 0
 
@@ -177,7 +179,7 @@ class TimerViewController: UIViewController {
         let hud = MBProgressHUD.showAdded(to: self.view, animated: true)
         hud?.mode = .indeterminate
         let params = ["urtext": self.urtext(), "requestid": UUID().uuidString]
-        RequestManager.post(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.slug!)/datapoints.json", parameters: params, success: { (responseObject) in
+        RequestManager.post(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.slug)/datapoints.json", parameters: params, success: { (responseObject) in
             hud?.mode = .text
             hud?.labelText = "Added!"
             DispatchQueue.main.asyncAfter(deadline: .now() + 2, execute: {

--- a/BeeSwift/TimerViewController.swift
+++ b/BeeSwift/TimerViewController.swift
@@ -15,7 +15,12 @@ class TimerViewController: UIViewController {
     let timerLabel = BSLabel()
     let startStopButton = BSButton()
     var goal : JSONGoal!
-    var timingSince: Date?
+    var timingSince: Date? {
+        didSet {
+            guard let goal = self.goal else { return }
+            CurrentUserManager.sharedManager.set(timerSince: timingSince, for: goal)
+        }
+    }
     var timer: Timer?
     var slug: String {
         goal.slug
@@ -84,11 +89,15 @@ class TimerViewController: UIViewController {
         resetButton.addTarget(self, action: #selector(self.resetButtonPressed), for: .touchUpInside)
         resetButton.setTitle("Reset", for: .normal)
         resetButton.backgroundColor = .clear
+
+        if let goal = self.goal {
+            self.timingSince = CurrentUserManager.sharedManager.timingSince(for: goal)
+        }
     }
 
-    override func didReceiveMemoryWarning() {
-        super.didReceiveMemoryWarning()
-        // Dispose of any resources that can be recreated.
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        self.updateTimerLabel()
     }
     
     @objc func exitButtonPressed() {
@@ -115,16 +124,23 @@ class TimerViewController: UIViewController {
     }
     
     @objc func startStopButtonPressed() {
-        if self.timingSince == nil {
-            self.timingSince = Date()
-            self.startStopButton.setTitle("Stop", for: .normal)
-            self.timer = Timer.scheduledTimer(timeInterval: 1, target: self, selector: #selector(self.updateTimerLabel), userInfo: nil, repeats: true)
-        } else {
-            self.accumulatedSeconds += Int(Date().timeIntervalSince(self.timingSince!))
-            self.startStopButton.setTitle("Start", for: .normal)
-            self.timer?.invalidate()
-            self.timer = nil
-            self.timingSince = nil
+        switch (self.timingSince, self.timer) {
+
+            case (nil, nil):
+                self.timingSince = Date()
+                self.startStopButton.setTitle("Stop", for: .normal)
+                self.timer = Timer.scheduledTimer(timeInterval: 1, target: self, selector: #selector(self.updateTimerLabel), userInfo: nil, repeats: true)
+
+            case (_, nil):
+                self.startStopButton.setTitle("Stop", for: .normal)
+                self.timer = Timer.scheduledTimer(timeInterval: 1, target: self, selector: #selector(self.updateTimerLabel), userInfo: nil, repeats: true)
+
+            default:
+                self.accumulatedSeconds += Int(Date().timeIntervalSince(self.timingSince!))
+                self.startStopButton.setTitle("Start", for: .normal)
+                self.timer?.invalidate()
+                self.timer = nil
+                self.timingSince = nil
         }
     }
     
@@ -180,19 +196,19 @@ class TimerViewController: UIViewController {
         hud?.mode = .indeterminate
         let params = ["urtext": self.urtext(), "requestid": UUID().uuidString]
         RequestManager.post(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.slug)/datapoints.json", parameters: params, success: { (responseObject) in
-            hud?.mode = .text
-            hud?.labelText = "Added!"
-            DispatchQueue.main.asyncAfter(deadline: .now() + 2, execute: {
-                MBProgressHUD.hideAllHUDs(for: self.view, animated: true)
-            })
-            if let goalVC = self.presentingViewController?.childViewControllers.last as? GoalViewController {
-                goalVC.refreshGoal()
-                goalVC.pollUntilGraphUpdates()
-            }
-            self.resetButtonPressed()
+                                            hud?.mode = .text
+                                            hud?.labelText = "Added!"
+                                            DispatchQueue.main.asyncAfter(deadline: .now() + 2, execute: {
+                                                MBProgressHUD.hideAllHUDs(for: self.view, animated: true)
+                                            })
+                                            if let goalVC = self.presentingViewController?.childViewControllers.last as? GoalViewController {
+                                                goalVC.refreshGoal()
+                                                goalVC.pollUntilGraphUpdates()
+                                            }
+                                            self.resetButtonPressed()
         }) { (error, errorMessage) in
-            MBProgressHUD.hideAllHUDs(for: self.view, animated: true)
-            UIAlertView(title: "Error", message: "Failed to add datapoint", delegate: nil, cancelButtonTitle: "OK").show()
+                                            MBProgressHUD.hideAllHUDs(for: self.view, animated: true)
+                                            UIAlertView(title: "Error", message: "Failed to add datapoint", delegate: nil, cancelButtonTitle: "OK").show()
         }
         
     }


### PR DESCRIPTION
Introduce a very basic variant of timer persistence to fix #5.

For those users with 4h long tasks, once the timer is started, the date `timingSince` is persisted, linked to the goal. Once the user returns to the app and eventually the timer interface, the timer is is restored.

Some nice to haves:
 - the timer ticking need not do so while the app is not visible
 - if the timer could be restored, resume the timer as though it had never been stopped
 - UI tests (including sending the app into the background, terminating the app, starting the app, returning to the same goal's timer screen)
