### PR TITLE
Don't say "coming soon" for years and years

### DIFF
--- a/BeeSwift/GalleryViewController.swift
+++ b/BeeSwift/GalleryViewController.swift
@@ -168,7 +168,7 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
         self.noGoalsLabel.snp.makeConstraints { (make) in
             make.top.left.right.equalTo(self.collectionView!)
         }
-        self.noGoalsLabel.text = "No goals yet!\n\nIn-app goal creation is coming soon, but for now, head to beeminder.com to create a goal."
+        self.noGoalsLabel.text = "You have no Beeminder goals!\n\nYou'll need to create one before this app will be any use."
         self.noGoalsLabel.textAlignment = .center
         self.noGoalsLabel.numberOfLines = 0
         self.noGoalsLabel.isHidden = true


### PR DESCRIPTION
This just tweaks the message the user sees in their gallery if they have no goals yet:

1. Don't say "coming soon", cuz, lies
2. Don't refer explicitly to the website, cuz, capricious appley monsters

I was going to add a warning about #226 as well but it got too long and awkward and confusing and I guess I think a user will naturally try leaving the gallery and coming back to it so it's not worth the convoluted extra sentence to warn about that.