### PR TITLE
Use the complete width of the device when rendering gallery view

### DIFF
--- a/BeeSwift/GoalCollectionViewCell.swift
+++ b/BeeSwift/GoalCollectionViewCell.swift
@@ -54,7 +54,7 @@ class GoalCollectionViewCell: UICollectionViewCell {
         self.titleLabel.snp.makeConstraints { (make) -> Void in
             make.centerY.equalTo(self.slugLabel)
             make.left.equalTo(self.slugLabel.snp.right).offset(10)
-            make.width.lessThanOrEqualTo(self.contentView).multipliedBy(0.6)
+            make.right.lessThanOrEqualTo(-self.margin)
         }
         self.titleLabel.textAlignment = .right
 


### PR DESCRIPTION
Previously the gallery view was limited to 320px. This added large margins
and meant descriptions were often unnecessarily truncated. Here we change the
width calculation logic so items are always at least 320px, but will be wider
if there is space. We continue to favor showing multiple columns over making
items wider.

Test Plan:
Viewed in both portrait and landscape in the simulator on the following
devices:
* iPhone 8
* iPhone 13 Pro
* iPhone 13 Max

Screenshots from before and after in portrait and landscape (iPhone 13 Pro Simulator, note notch is not shown). The light red rectangle is a manual redaction of a private goal. The "Goals" header is not visible. This also happens on `master` for me, and I don't believe is related to this change.

Before:
![before - portrait](https://user-images.githubusercontent.com/116179/175828242-3668b487-c846-4da5-b683-0ca5dd70a601.png)
![before - landscape](https://user-images.githubusercontent.com/116179/175828243-caf88610-debd-45c3-827b-96858abe200d.png)

After:
![after - portrait](https://user-images.githubusercontent.com/116179/175828246-d1455023-941f-40bf-8977-c254ef5a1171.png)
![after - landscape](https://user-images.githubusercontent.com/116179/175828249-9e4d2251-d423-411d-8e4a-332b24b48af6.png)



