### PR TITLE
Fix navigation and status bar colors when built for iOS 15

### DIFF
--- a/BeeSwift/Base.lproj/Main.storyboard
+++ b/BeeSwift/Base.lproj/Main.storyboard
@@ -1,18 +1,21 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9059" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="E0t-UY-3pO">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="E0t-UY-3pO">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9049"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--Gallery Navigation Controller-->
         <scene sceneID="qqJ-th-mte">
             <objects>
                 <navigationController id="E0t-UY-3pO" customClass="GalleryNavigationController" customModule="BeeSwift" customModuleProvider="target" sceneMemberID="viewController">
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="Pjd-c5-Ja5">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" barStyle="black" translucent="NO" id="Pjd-c5-Ja5">
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
-                        <animations/>
+                        <color key="tintColor" systemColor="labelColor"/>
                     </navigationBar>
                     <connections>
                         <segue destination="61E-DD-3wo" kind="relationship" relationship="rootViewController" id="mRC-E2-iEZ"/>
@@ -31,10 +34,9 @@
                         <viewControllerLayoutGuide type="bottom" id="Srv-mm-wIg"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="3bJ-hz-njv">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="808"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <animations/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
                     <navigationItem key="navigationItem" id="iIR-mA-gmW"/>
                 </viewController>
@@ -43,4 +45,9 @@
             <point key="canvasLocation" x="-660" y="718"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="labelColor">
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/BeeSwift/GalleryNavigationController.swift
+++ b/BeeSwift/GalleryNavigationController.swift
@@ -9,14 +9,4 @@
 import Foundation
 
 class GalleryNavigationController: UINavigationController {
-    
-    override func viewDidLoad() {
-        self.navigationBar.barStyle = UIBarStyle.black
-        self.navigationBar.barTintColor = UIColor.black
-        self.navigationBar.tintColor = UIColor.white
-//
-//        let titleDict: NSDictionary = [NSForegroundColorAttributeName: UIColor.whiteColor()]
-//        self.navigationBar.titleTextAttributes = titleDict as [NSObject : AnyObject]
-    }
-    
 }


### PR DESCRIPTION
Fixes #294

Due to changes in a recent iOS version, navigation controllers now default to
having a transparent background, which meant the intended black background
was not shown.

Here we move UI configuration into the Storyboard file, and update so that
the background is always opaque, fixing the rendering.

Manual Testing:
Viewed in the simulator on the gallery and goals page, in light and dark
modes