### PR TITLE
Update Semaphore Xcode version

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -3,7 +3,7 @@ name: Semaphore iOS Swift example with Fastlane
 agent:
   machine:
     type: a1-standard-4
-    os_image: macos-xcode11
+    os_image: macos-xcode13
 blocks:
   - name: Fastlane Test
     task:
@@ -29,5 +29,5 @@ blocks:
         - name: Test
           commands:
             - bundle exec pod install
-            - bundle exec xcversion select 11.3.1
+            - bundle exec xcversion select 13.3
             - bundle exec fastlane test

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -25,6 +25,7 @@ blocks:
           - bundle install --path vendor/bundle
           - cache store
           - cp /Users/semaphore/BeeSwift/BeeSwift/Config.swift.sample /Users/semaphore/BeeSwift/BeeSwift/Config.swift
+          - cp /Users/semaphore/BeeSwift/BeeSwift/Config.swift.sample /Users/semaphore/BeeSwift/BeeKit/Config.swift
       jobs:
         - name: Test
           commands:


### PR DESCRIPTION
Semaphore no longer supports Xcode 11 based images. Take a step towards
working tests by bumping to Xcode 13.

Test Plan:
Look at the actions on this PR