### PR TITLE
Add checkbox indicating goals with data today to gallery

### DIFF
--- a/BeeSwift/GoalCollectionViewCell.swift
+++ b/BeeSwift/GoalCollectionViewCell.swift
@@ -11,6 +11,7 @@ import Foundation
 class GoalCollectionViewCell: UICollectionViewCell {
     let slugLabel :BSLabel = BSLabel()
     let titleLabel :BSLabel = BSLabel()
+    let todaytaLabel :BSLabel = BSLabel()
     let thumbnailImageView :UIImageView = UIImageView()
     let safesumLabel :BSLabel = BSLabel()
     let margin = 8
@@ -22,6 +23,7 @@ class GoalCollectionViewCell: UICollectionViewCell {
             self.titleLabel.text = goal?.title
             self.slugLabel.text = goal?.slug
             self.titleLabel.isHidden = goal?.title == goal?.slug
+            self.todaytaLabel.text = goal?.todayta == true ? "✓" : ""
             self.safesumLabel.text = goal?.capitalSafesum()
             self.safesumLabel.textColor = goal?.countdownColor ?? UIColor.beeminder.gray
         }
@@ -32,6 +34,7 @@ class GoalCollectionViewCell: UICollectionViewCell {
         
         self.contentView.addSubview(self.slugLabel)
         self.contentView.addSubview(self.titleLabel)
+        self.contentView.addSubview(self.todaytaLabel)
         self.contentView.addSubview(self.thumbnailImageView)
         self.contentView.addSubview(self.safesumLabel)
         if #available(iOS 13.0, *) {
@@ -54,9 +57,19 @@ class GoalCollectionViewCell: UICollectionViewCell {
         self.titleLabel.snp.makeConstraints { (make) -> Void in
             make.centerY.equalTo(self.slugLabel)
             make.left.equalTo(self.slugLabel.snp.right).offset(10)
-            make.right.lessThanOrEqualTo(-self.margin)
+            make.right.lessThanOrEqualTo(self.todaytaLabel.snp.left).offset(-10)
         }
-        self.titleLabel.textAlignment = .right
+        self.titleLabel.textAlignment = .left
+        
+        self.todaytaLabel.font = UIFont.beeminder.defaultFont
+        if #available(iOS 13.0, *) {
+            self.todaytaLabel.textColor = .label
+        }
+        self.todaytaLabel.snp.makeConstraints { (make) -> Void in
+            make.centerY.equalTo(self.slugLabel)
+            make.right.equalTo(-self.margin)
+        }
+        self.todaytaLabel.textAlignment = .right
 
         self.thumbnailImageView.snp.makeConstraints { (make) -> Void in
             make.left.equalTo(0).offset(self.margin)

--- a/BeeSwift/JSONGoal.swift
+++ b/BeeSwift/JSONGoal.swift
@@ -40,6 +40,7 @@ class JSONGoal {
     var lasttouch: NSNumber?
     var use_defaults: NSNumber?
     var queued: Bool?
+    var todayta: Bool = false
     var recent_data: Array<Any>?
     
     init(json: JSON) {
@@ -95,6 +96,7 @@ class JSONGoal {
         if json["thumb_url"].string != nil { self.thumb_url = json["thumb_url"].string! }
         
         self.healthKitMetric = json["healthkitmetric"].string
+        self.todayta = json["todayta"].bool!
         
         var datapoints : Array<JSON> = json["recent_data"].arrayValue
         datapoints.reverse()


### PR DESCRIPTION
Fixes #288

This uses the `todayta` attribute from the API to add a checkmark.
Nothing special is done for auto-data goals, so for these the
icon may not be meaningful. (This matches android behavior.)

<img width="406" alt="todayta-dark-mode" src="https://user-images.githubusercontent.com/116179/188288097-f7c5ccb0-dd41-4eb9-864a-e55ba6fa5d68.png">
<img width="408" alt="todayta-light-mode" src="https://user-images.githubusercontent.com/116179/188288098-10a456d1-948f-45c8-8d98-3e1735823b44.png">


Test Plan:
Deployed a debug build to my phone and observed it appears appropriately
for manual goals.