### PR TITLE
Share all UserDefaults with the app group

### DIFF
--- a/BeeSwift/CurrentUserManager.swift
+++ b/BeeSwift/CurrentUserManager.swift
@@ -32,7 +32,7 @@ class CurrentUserManager : NSObject {
     fileprivate let beemTZKey = "timezone"
     
     var allKeys: [String] {
-        return [accessTokenKey, usernameKey, deadbeatKey, defaultLeadtimeKey, defaultAlertstartKey, defaultDeadlineKey, beemTZKey]
+        [accessTokenKey, usernameKey, deadbeatKey, defaultLeadtimeKey, defaultAlertstartKey, defaultDeadlineKey, beemTZKey]
     }
     
     let userDefaults = UserDefaults(suiteName: Constants.appGroupIdentifier)!


### PR DESCRIPTION
The UserDefaults system has a number of different namespaces. BeeSwift by default has been using one which is not shared with extensions, and done some extra bookkeeping to share particular values with the today widget. This is not sufficient for Intents, and also adds complexity, so instead migrate to storing all settings in a location accessible to all apps in the app group.

To support branch switching and downgrading, at present all values are migrated and double-written to both locations. Once we are confident all users have migrated we can remove this migration code.

This is a prerequisite for #293

Test Plan:
* [ ] Log into an older version of the app, upgrade, and check we are still logged in
* [ ] Log out on new version, downgrade, and check we are logged out
* [ ] Log in on new version, downgrade, check we are still logged in
* [ ] Confirm the today widget still works
