### PR TITLE
Fix the AddData Intent

### DIFF
--- a/BeeSwift.xcodeproj/project.pbxproj
+++ b/BeeSwift.xcodeproj/project.pbxproj
@@ -77,6 +77,12 @@
 		A1FF19141DE8EEA900FD0527 /* NewGoalCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1FF19131DE8EEA900FD0527 /* NewGoalCollectionViewCell.swift */; };
 		D25716F2B8CCFE41DCD5CD5C /* Pods_BeeSwiftIntents.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 45017ADDD1E7A7E50917F8D4 /* Pods_BeeSwiftIntents.framework */; };
 		D2C3F7C8533EA7EC6CA52E77 /* Pods_BeeSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DB01694F5BE68BBDBB21E697 /* Pods_BeeSwift.framework */; };
+		E457BE5D28C192B50012F5D0 /* IntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = E457BE5C28C192B50012F5D0 /* IntentHandler.swift */; };
+		E4B0A32E28C194C800055EA7 /* AddDataIntents.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = E540953B260FB6A100C30784 /* AddDataIntents.intentdefinition */; };
+		E4B0A32F28C194C800055EA7 /* AddDataIntents.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = E540953B260FB6A100C30784 /* AddDataIntents.intentdefinition */; };
+		E4B0A33028C194C900055EA7 /* AddDataIntents.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = E540953B260FB6A100C30784 /* AddDataIntents.intentdefinition */; };
+		E4B0A33128C194C900055EA7 /* AddDataIntents.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = E540953B260FB6A100C30784 /* AddDataIntents.intentdefinition */; };
+		E4B0A33228C194CA00055EA7 /* AddDataIntents.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = E540953B260FB6A100C30784 /* AddDataIntents.intentdefinition */; };
 		E52094FE2741D72300CB766F /* JSONGoal+Healthkit.swift in Sources */ = {isa = PBXBuildFile; fileRef = E52094FD2741D72300CB766F /* JSONGoal+Healthkit.swift */; };
 		E52094FF2741D73800CB766F /* JSONGoal+Healthkit.swift in Sources */ = {isa = PBXBuildFile; fileRef = E52094FD2741D72300CB766F /* JSONGoal+Healthkit.swift */; };
 		E52095002741D73900CB766F /* JSONGoal+Healthkit.swift in Sources */ = {isa = PBXBuildFile; fileRef = E52094FD2741D72300CB766F /* JSONGoal+Healthkit.swift */; };
@@ -90,11 +96,6 @@
 		E57BE7042655EE1F00BA540B /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = E55FEE6A23FF7552007C20B2 /* Config.swift */; };
 		E57BE71B2655F03200BA540B /* BeeKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E57BE6E02655EBD900BA540B /* BeeKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		E5A80E6826598A370016D9A0 /* (null) in Sources */ = {isa = PBXBuildFile; };
-		E5A80E7B26598A650016D9A0 /* AddDataIntents.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = E540953B260FB6A100C30784 /* AddDataIntents.intentdefinition */; };
-		E5A80E9426598DE30016D9A0 /* AddDataIntents.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = E540953B260FB6A100C30784 /* AddDataIntents.intentdefinition */; settings = {ATTRIBUTES = (no_codegen, ); }; };
-		E5A80EA126598DE40016D9A0 /* AddDataIntents.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = E540953B260FB6A100C30784 /* AddDataIntents.intentdefinition */; settings = {ATTRIBUTES = (no_codegen, ); }; };
-		E5A80EA826598DE50016D9A0 /* AddDataIntents.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = E540953B260FB6A100C30784 /* AddDataIntents.intentdefinition */; settings = {ATTRIBUTES = (no_codegen, ); }; };
-		E5A80EAF26598DE60016D9A0 /* AddDataIntents.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = E540953B260FB6A100C30784 /* AddDataIntents.intentdefinition */; settings = {ATTRIBUTES = (no_codegen, ); }; };
 		E5C161942423CEA00045C90D /* VersionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C161932423CE9F0045C90D /* VersionManager.swift */; };
 		E5C9EFE62612E02700DBBEAE /* AddDataIntents.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = E540953B260FB6A100C30784 /* AddDataIntents.intentdefinition */; settings = {ATTRIBUTES = (no_codegen, ); }; };
 		E5CF516A2612431600546184 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1C11B471B06F5D100D22871 /* Constants.swift */; };
@@ -279,6 +280,7 @@
 		C622986C48BC5CA5BBB7E3C7 /* Pods-BeeSwiftToday.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BeeSwiftToday.debug.xcconfig"; path = "Pods/Target Support Files/Pods-BeeSwiftToday/Pods-BeeSwiftToday.debug.xcconfig"; sourceTree = "<group>"; };
 		DB01694F5BE68BBDBB21E697 /* Pods_BeeSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BeeSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E029CC25A4BEE8E42BD37670 /* Pods-BeeSwift.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BeeSwift.release.xcconfig"; path = "Pods/Target Support Files/Pods-BeeSwift/Pods-BeeSwift.release.xcconfig"; sourceTree = "<group>"; };
+		E457BE5C28C192B50012F5D0 /* IntentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntentHandler.swift; sourceTree = "<group>"; };
 		E52094FD2741D72300CB766F /* JSONGoal+Healthkit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "JSONGoal+Healthkit.swift"; sourceTree = "<group>"; };
 		E540953B260FB6A100C30784 /* AddDataIntents.intentdefinition */ = {isa = PBXFileReference; lastKnownFileType = file.intentdefinition; path = AddDataIntents.intentdefinition; sourceTree = "<group>"; };
 		E55760F426549D310076B95A /* AddDataIntentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddDataIntentHandler.swift; sourceTree = "<group>"; };
@@ -587,6 +589,7 @@
 			children = (
 				E5F7C55626113C840095684F /* BeeSwiftIntents.entitlements */,
 				E5F7C496260FC5300095684F /* Info.plist */,
+				E457BE5C28C192B50012F5D0 /* IntentHandler.swift */,
 			);
 			path = BeeSwiftIntents;
 			sourceTree = "<group>";
@@ -1067,7 +1070,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E5A80EA126598DE40016D9A0 /* AddDataIntents.intentdefinition in Sources */,
+				E4B0A32F28C194C800055EA7 /* AddDataIntents.intentdefinition in Sources */,
 				A12E69511BD3EF0200AB94C2 /* TodayViewController.swift in Sources */,
 				A1D853291EB0EA2400FC75DE /* BSLabel.swift in Sources */,
 				A1D8532A1EB0EA2B00FC75DE /* BSButton.swift in Sources */,
@@ -1138,7 +1141,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E5A80E9426598DE30016D9A0 /* AddDataIntents.intentdefinition in Sources */,
+				E4B0A32E28C194C800055EA7 /* AddDataIntents.intentdefinition in Sources */,
 				A196CB331AE4142F00B90A3E /* BeeSwiftTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1147,7 +1150,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E5A80E7B26598A650016D9A0 /* AddDataIntents.intentdefinition in Sources */,
+				E4B0A33128C194C900055EA7 /* AddDataIntents.intentdefinition in Sources */,
 				E5A80E6826598A370016D9A0 /* (null) in Sources */,
 				E57BE7042655EE1F00BA540B /* Config.swift in Sources */,
 			);
@@ -1157,7 +1160,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E5A80EAF26598DE60016D9A0 /* AddDataIntents.intentdefinition in Sources */,
+				E4B0A33228C194CA00055EA7 /* AddDataIntents.intentdefinition in Sources */,
 				E57BE6F02655EBE000BA540B /* BeeKitTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1180,6 +1183,7 @@
 				E5CF516A2612431600546184 /* Constants.swift in Sources */,
 				E5CF517C2612434300546184 /* BSButton.swift in Sources */,
 				E5CF51892612434E00546184 /* UIColorExtension.swift in Sources */,
+				E457BE5D28C192B50012F5D0 /* IntentHandler.swift in Sources */,
 				E5CF518F2612435000546184 /* UIFontExtension.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1188,7 +1192,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E5A80EA826598DE50016D9A0 /* AddDataIntents.intentdefinition in Sources */,
+				E4B0A33028C194C900055EA7 /* AddDataIntents.intentdefinition in Sources */,
 				E5FEFB4124E6FAFC00A076BB /* LaunchScreenTests.swift in Sources */,
 				E5FEFB3824E6FAC800A076BB /* BeeSwiftUITests.swift in Sources */,
 			);

--- a/BeeSwift/AddDataIntentHandler.swift
+++ b/BeeSwift/AddDataIntentHandler.swift
@@ -30,17 +30,28 @@ class AddDataIntentHandler: NSObject, AddDataIntentHandling {
     }
     
     func confirm(intent: AddDataIntent) async -> AddDataIntentResponse {
-        AddDataIntentResponse(code: .ready, userActivity: nil)
+        if intent.goal != nil && intent.value != nil {
+            return AddDataIntentResponse(code: .ready, userActivity: nil)
+        } else {
+            return AddDataIntentResponse(code: .failure, userActivity: nil)
+        }
     }
 
     func handle(intent: AddDataIntent,
               completion: @escaping (AddDataIntentResponse) -> Void) {
-        guard let datapointValue = intent.value else { return }
-        
-        RequestManager.addDatapoint(urtext: "^ \(datapointValue)", slug: intent.goal!) { (response) in
-            completion(AddDataIntentResponse.success(goal: intent.goal!))
+        guard let goal = intent.goal else {
+            completion(AddDataIntentResponse.failure(goal: ""))
+            return
+        }
+        guard let value = intent.value else {
+            completion(AddDataIntentResponse.failure(goal: goal))
+            return
+        }
+                
+        RequestManager.addDatapoint(urtext: "^ \(value)", slug: goal) { (response) in
+            completion(AddDataIntentResponse.success(goal: goal))
         } errorHandler: { (error, errorMessage) in
-            completion(AddDataIntentResponse.failure(goal: intent.goal!))
+            completion(AddDataIntentResponse.failure(goal: goal))
         }
     }
 }

--- a/BeeSwift/AddDataIntentHandler.swift
+++ b/BeeSwift/AddDataIntentHandler.swift
@@ -21,9 +21,9 @@ class AddDataIntentHandler: NSObject, AddDataIntentHandling {
     }
     
     func resolveGoal(for intent: AddDataIntent) async -> INStringResolutionResult {
-        if let goal = intent.goal {
+        if let goalSlug = intent.goal {
             // TODO: We should validate this is a valid slug
-            return INStringResolutionResult.success(with: goal)
+            return INStringResolutionResult.success(with: goalSlug)
         } else {
             return INStringResolutionResult.needsValue()
         }
@@ -39,19 +39,19 @@ class AddDataIntentHandler: NSObject, AddDataIntentHandling {
 
     func handle(intent: AddDataIntent,
               completion: @escaping (AddDataIntentResponse) -> Void) {
-        guard let goal = intent.goal else {
+        guard let goalSlug = intent.goal else {
             completion(AddDataIntentResponse.failure(goal: ""))
             return
         }
         guard let value = intent.value else {
-            completion(AddDataIntentResponse.failure(goal: goal))
+            completion(AddDataIntentResponse.failure(goal: goalSlug))
             return
         }
                 
-        RequestManager.addDatapoint(urtext: "^ \(value)", slug: goal) { (response) in
-            completion(AddDataIntentResponse.success(goal: goal))
+        RequestManager.addDatapoint(urtext: "^ \(value)", slug: goalSlug) { (response) in
+            completion(AddDataIntentResponse.success(goal: goalSlug))
         } errorHandler: { (error, errorMessage) in
-            completion(AddDataIntentResponse.failure(goal: goal))
+            completion(AddDataIntentResponse.failure(goal: goalSlug))
         }
     }
 }

--- a/BeeSwift/AddDataIntentHandler.swift
+++ b/BeeSwift/AddDataIntentHandler.swift
@@ -12,17 +12,25 @@ import BeeKit
 
 @available(iOS 14.0, *)
 class AddDataIntentHandler: NSObject, AddDataIntentHandling {
-    func resolveValue(for intent: AddDataIntent, with completion: @escaping (AddDataValueResolutionResult) -> Void) {
-        print("foo")
+    func resolveValue(for intent: AddDataIntent) async -> AddDataValueResolutionResult {
+        if let value = intent.value {
+            return AddDataValueResolutionResult.success(with: value.doubleValue)
+        } else {
+            return AddDataValueResolutionResult.needsValue()
+        }
     }
     
-    func resolveGoal(for intent: AddDataIntent, with completion: @escaping (INStringResolutionResult) -> Void) {
-        print("foo")
+    func resolveGoal(for intent: AddDataIntent) async -> INStringResolutionResult {
+        if let goal = intent.goal {
+            // TODO: We should validate this is a valid slug
+            return INStringResolutionResult.success(with: goal)
+        } else {
+            return INStringResolutionResult.needsValue()
+        }
     }
     
-    func confirm(intent: AddDataIntent,
-               completion: @escaping (AddDataIntentResponse) -> Void) {
-        completion(AddDataIntentResponse(code: .ready, userActivity: nil))
+    func confirm(intent: AddDataIntent) async -> AddDataIntentResponse {
+        AddDataIntentResponse(code: .ready, userActivity: nil)
     }
 
     func handle(intent: AddDataIntent,
@@ -34,6 +42,5 @@ class AddDataIntentHandler: NSObject, AddDataIntentHandling {
         } errorHandler: { (error, errorMessage) in
             completion(AddDataIntentResponse.failure(goal: intent.goal!))
         }
-        completion(AddDataIntentResponse(code: .continueInApp, userActivity: nil))
     }
 }

--- a/BeeSwift/AppDelegate.swift
+++ b/BeeSwift/AppDelegate.swift
@@ -153,15 +153,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
         if #available(iOS 12.0, *) {
             if let intent = userActivity.interaction?.intent as? AddDataIntent {
-                guard let goal = intent.goal else { return false }
-                NotificationCenter.default.post(name: Notification.Name(rawValue: "openGoal"), object: nil, userInfo: ["slug": goal])
+                guard let goalSlug = intent.goal else { return false }
+                NotificationCenter.default.post(name: Notification.Name(rawValue: "openGoal"), object: nil, userInfo: ["slug": goalSlug])
                 
                 // Early return to avoid also checking userInfo
                 return true
             }
         }
-        if let slug = userActivity.userInfo?["slug"] {
-            NotificationCenter.default.post(name: Notification.Name(rawValue: "openGoal"), object: nil, userInfo: ["slug": slug])
+        if let goalSlug = userActivity.userInfo?["slug"] {
+            NotificationCenter.default.post(name: Notification.Name(rawValue: "openGoal"), object: nil, userInfo: ["slug": goalSlug])
         }
         return true
     }

--- a/BeeSwift/AppDelegate.swift
+++ b/BeeSwift/AppDelegate.swift
@@ -153,21 +153,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
         if #available(iOS 12.0, *) {
             if let intent = userActivity.interaction?.intent as? AddDataIntent {
-                guard let value = intent.value, let slug = intent.goal else { return false }
-                RequestManager.addDatapoint(urtext: "^ \(value)", slug: slug) { (response) in
-                    CurrentUserManager.sharedManager.fetchGoals(success: nil, error: nil)
-                } errorHandler: { (error, errorMessage) in
-                    //
-                }
-
                 NotificationCenter.default.post(name: Notification.Name(rawValue: "openGoal"), object: nil, userInfo: ["slug": slug])
-            } else if let slug = userActivity.userInfo?["slug"] {
-                NotificationCenter.default.post(name: Notification.Name(rawValue: "openGoal"), object: nil, userInfo: ["slug": slug])
+                
+                // Early return to avoid also checking userInfo
+                return true
             }
-        } else {
-            if let slug = userActivity.userInfo?["slug"] {
-                NotificationCenter.default.post(name: Notification.Name(rawValue: "openGoal"), object: nil, userInfo: ["slug": slug])
-            }
+        }
+        if let slug = userActivity.userInfo?["slug"] {
+            NotificationCenter.default.post(name: Notification.Name(rawValue: "openGoal"), object: nil, userInfo: ["slug": slug])
         }
         return true
     }

--- a/BeeSwift/AppDelegate.swift
+++ b/BeeSwift/AppDelegate.swift
@@ -153,7 +153,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
         if #available(iOS 12.0, *) {
             if let intent = userActivity.interaction?.intent as? AddDataIntent {
-                NotificationCenter.default.post(name: Notification.Name(rawValue: "openGoal"), object: nil, userInfo: ["slug": intent.goal])
+                guard let goal = intent.goal else { return false }
+                NotificationCenter.default.post(name: Notification.Name(rawValue: "openGoal"), object: nil, userInfo: ["slug": goal])
                 
                 // Early return to avoid also checking userInfo
                 return true

--- a/BeeSwift/AppDelegate.swift
+++ b/BeeSwift/AppDelegate.swift
@@ -153,7 +153,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
         if #available(iOS 12.0, *) {
             if let intent = userActivity.interaction?.intent as? AddDataIntent {
-                NotificationCenter.default.post(name: Notification.Name(rawValue: "openGoal"), object: nil, userInfo: ["slug": slug])
+                NotificationCenter.default.post(name: Notification.Name(rawValue: "openGoal"), object: nil, userInfo: ["slug": intent.goal])
                 
                 // Early return to avoid also checking userInfo
                 return true

--- a/BeeSwiftIntents/Info.plist
+++ b/BeeSwiftIntents/Info.plist
@@ -36,7 +36,7 @@
 		<key>NSExtensionPointIdentifier</key>
 		<string>com.apple.intents-service</string>
 		<key>NSExtensionPrincipalClass</key>
-		<string>$(PRODUCT_MODULE_NAME).AddDataIntentHandler</string>
+		<string>$(PRODUCT_MODULE_NAME).IntentHandler</string>
 	</dict>
 </dict>
 </plist>

--- a/BeeSwiftIntents/IntentHandler.swift
+++ b/BeeSwiftIntents/IntentHandler.swift
@@ -1,0 +1,17 @@
+//
+//  IntentHandler.swift
+//  BeeSwiftIntents
+//
+//  Created by Theo Spears on 9/1/22.
+//  Copyright © 2022 APB. All rights reserved.
+//
+
+import Foundation
+import Intents
+
+@available(iOS 14.0, *)
+class IntentHandler : INExtension {
+    override func handler(for intent: INIntent) -> Any? {
+        return AddDataIntentHandler()
+    }
+}

--- a/BeeSwiftIntents/IntentHandler.swift
+++ b/BeeSwiftIntents/IntentHandler.swift
@@ -3,7 +3,6 @@
 //  BeeSwiftIntents
 //
 //  Created by Theo Spears on 9/1/22.
-//  Copyright © 2022 APB. All rights reserved.
 //
 
 import Foundation
@@ -12,6 +11,6 @@ import Intents
 @available(iOS 14.0, *)
 class IntentHandler : INExtension {
     override func handler(for intent: INIntent) -> Any? {
-        return AddDataIntentHandler()
+        AddDataIntentHandler()
     }
 }


### PR DESCRIPTION
Previous commits had begun to implement an intent to add data points to beeminder. This follows up on that work, adding the necessary extension routing and parameter checking to make intents support work without launching the app. This should be seen as a minimum viable implementation, there remain many possible improvements to e.g. error handling, and suggesting allowed goal names.

As datapoint submission is now handled the the extension this removes the code which submitted them as part of app startup.

Fixes #293

Test Plan:
* [X] Created a shortcut which added a data point
* [X] Ran this shortcut, observed it finished successfully and that the data point was added
* [X] Tried to run without a goal name set, or with an invalid goal name, and observed a sensible error.