### PR TITLE
Fix multiple settings icons being overlaid

### DIFF
--- a/BeeSwift/SettingsTableViewCell.swift
+++ b/BeeSwift/SettingsTableViewCell.swift
@@ -16,10 +16,12 @@ class SettingsTableViewCell: UITableViewCell {
     }
     var imageName : String? {
         didSet {
-            self.configure()
+            self.settingsImage.image = UIImage(named: self.imageName!)
         }
     }
+    
     let titleLabel = BSLabel()
+    let settingsImage = UIImageView()
     
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -33,22 +35,18 @@ class SettingsTableViewCell: UITableViewCell {
     
     override func prepareForReuse() {
         super.prepareForReuse()
-        self.titleLabel.text = nil
-        self.title = nil
-        self.imageName = nil
     }
     
     func configure() {
+        self.contentView.addSubview(self.titleLabel)
+        self.contentView.addSubview(self.settingsImage)
+        
         self.selectionStyle = .none
         if #available(iOS 13.0, *) {
             self.backgroundColor = .secondarySystemBackground
         } else {
             self.backgroundColor = .white
         }
-        self.accessoryType = .disclosureIndicator
-        
-        self.contentView.addSubview(self.titleLabel)
-        
         
         if #available(iOS 13.0, *) {
             self.titleLabel.textColor = .label
@@ -56,26 +54,15 @@ class SettingsTableViewCell: UITableViewCell {
             self.titleLabel.textColor = UIColor.beeminder.gray
         }
         
-        if self.imageName != nil {
-            let image = UIImage(named: self.imageName!)
-            let imageView = UIImageView(image: image)
-            
-            
-            self.contentView.addSubview(imageView)
-            imageView.snp.remakeConstraints({ (make) in
-                make.centerY.equalTo(self.contentView)
-                make.left.equalTo(10)
-                make.height.width.equalTo(26)
-            })
-            self.titleLabel.snp.remakeConstraints { (make) -> Void in
-                make.centerY.equalTo(self.contentView)
-                make.left.equalTo(imageView.snp.right).offset(10)
-            }
-        } else {
-            self.titleLabel.snp.remakeConstraints { (make) -> Void in
-                make.centerY.equalTo(self.contentView)
-                make.left.equalTo(10)
-            }
+        self.titleLabel.snp.remakeConstraints { (make) -> Void in
+            make.centerY.equalTo(self.contentView)
+            make.left.equalTo(self.settingsImage.snp.right).offset(10)
         }
+        self.settingsImage.snp.remakeConstraints({ (make) in
+            make.centerY.equalTo(self.contentView)
+            make.left.equalTo(10)
+            make.height.width.equalTo(26)
+        })
+
     }
 }

--- a/BeeSwift/SettingsViewController.swift
+++ b/BeeSwift/SettingsViewController.swift
@@ -108,6 +108,7 @@ extension SettingsViewController : UITableViewDataSource, UITableViewDelegate {
             if section == 0 {
                 cell.title = "Health app integration"
                 cell.imageName = "Health"
+                cell.accessoryType = .disclosureIndicator
                 return cell
             }
             section = section - 1
@@ -118,6 +119,7 @@ extension SettingsViewController : UITableViewDataSource, UITableViewDelegate {
             let selectedGoalSort = UserDefaults.standard.value(forKey: Constants.selectedGoalSortKey) as? String
             cell.title = "Sort goals by: \(selectedGoalSort ?? "")"
             cell.imageName = "Sort"
+            cell.accessoryType = .disclosureIndicator
         case 1:
             UNUserNotificationCenter.current().getNotificationSettings { (settings) in
                 DispatchQueue.main.async {
@@ -125,6 +127,7 @@ extension SettingsViewController : UITableViewDataSource, UITableViewDelegate {
                 }
             }
             cell.imageName = "Notifications"
+            cell.accessoryType = .disclosureIndicator
         case 2:
             cell.title = "Time zone: \(CurrentUserManager.sharedManager.timezone())"
             cell.imageName = "Clock"


### PR DESCRIPTION
Previously we were not properly removing settings icons when cells in the settings table are re-used. Here we use a shared UIImageView which has its image updated, avoiding multiple being shown.

Fixes: #306

Test Plan:
Navigate to settings, back out, and then back to settings again. Observe that icons are not mis-rendered.