### PR TITLE
Do not allow description to hide todayta indicator

### DIFF
--- a/BeeSwift/GoalCollectionViewCell.swift
+++ b/BeeSwift/GoalCollectionViewCell.swift
@@ -69,6 +69,7 @@ class GoalCollectionViewCell: UICollectionViewCell {
             make.centerY.equalTo(self.slugLabel)
             make.right.equalTo(-self.margin)
         }
+        self.todaytaLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
         self.todaytaLabel.textAlignment = .right
 
         self.thumbnailImageView.snp.makeConstraints { (make) -> Void in


### PR DESCRIPTION
Previously with a very long description, the autolayout system could decide to hide the todayta tick to show more of the description. Here we make the view holding the tick impossible to shrink so it always appears.

Fixes #305

Test Plan:
Made a goal description very long, observed before this fix the todayta is hidden, and after the change it is shown.