### PR TITLE
Register HealthKit queries on startup

### DIFF
--- a/BeeSwift/AppDelegate.swift
+++ b/BeeSwift/AppDelegate.swift
@@ -27,6 +27,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
         if HKHealthStore.isHealthDataAvailable() {
             HealthStoreManager.sharedManager.setupHealthkit()
+
+            // We must register queries for all our healthkit metrics before this method completes in order to successfully be delivered background updates
+            // This means we cannot wait for a round trip to the server to fetch latest goals, so use a potentially stale list from last time we did a successful
+            // update.
+            if let goals = CurrentUserManager.sharedManager.staleGoals() {
+                goals.forEach({ goal in goal.setupHealthKit() })
+            }
         }
         
         NetworkActivityIndicatorManager.shared.isEnabled = true


### PR DESCRIPTION
When the app is started in the background due to a healthkit change it is expected to register queries as part of application start, in order to receive new data. BeeSwift previously did not do so until later in startup due to needing to wait for an up to date goals list.

Now we store the goals list each time it updates, which means on startup we can use the most recent list to register for updates. This may occasionally lead to over-registration, but that is better than not receiving background updates.

Relevant to #312

Test Plan:
Observed the app starts successfully in simulator