### PR TITLE
Add HealthKit entitlement

### DIFF
--- a/BeeSwift/BeeSwift.entitlements
+++ b/BeeSwift/BeeSwift.entitlements
@@ -10,6 +10,10 @@
 	</array>
 	<key>com.apple.developer.healthkit</key>
 	<true/>
+	<key>com.apple.developer.healthkit.access</key>
+	<array/>
+	<key>com.apple.developer.healthkit.background-delivery</key>
+	<true/>
 	<key>com.apple.developer.siri</key>
 	<true/>
 	<key>com.apple.security.application-groups</key>


### PR DESCRIPTION
In iOS15+ we need an entitlement to allow background healthkit delivery. This adds the appriate entitlement

Test Plan:
None