### PR TITLE
Run tests through github actions on PR

### DIFF
--- a/.github/workflows/fastlane-tests.yml
+++ b/.github/workflows/fastlane-tests.yml
@@ -9,13 +9,15 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: '2.7.2'
     - name: Use sample configuration
       run: cp BeeSwift/Config.swift.sample BeeKit/Config.swift
+    - name: Setup ruby and install gems
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '2.7.2'
+        bundler-cache: true
     - name: Run tests
-      run: bundle install && bundle exec fastlane test
+      run: bundle exec fastlane test
     - name: Publish Test Report
       uses: mikepenz/action-junit-report@v3
       if: always() # always run even if the previous step fails

--- a/.github/workflows/fastlane-tests.yml
+++ b/.github/workflows/fastlane-tests.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Use sample configuration
       run: cp BeeSwift/Config.swift.sample BeeKit/Config.swift
     - name: Run tests
-      run: bundle exec fastlane test
+      run: bundle install && bundle exec fastlane test
     - name: Publish Test Report
       uses: mikepenz/action-junit-report@v3
       if: always() # always run even if the previous step fails

--- a/.github/workflows/fastlane-tests.yml
+++ b/.github/workflows/fastlane-tests.yml
@@ -12,11 +12,10 @@ jobs:
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: '2.7.2'
-    - name: script
+    - name: Use sample configuration
       run: cp BeeSwift/Config.swift.sample BeeKit/Config.swift
-    - uses: maierj/fastlane-action@v2.2.0
-      with:
-        lane: 'test'
+    - name: Run tests
+      run: fastlane test
     - name: Publish Test Report
       uses: mikepenz/action-junit-report@v3
       if: always() # always run even if the previous step fails

--- a/.github/workflows/fastlane-tests.yml
+++ b/.github/workflows/fastlane-tests.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Use sample configuration
       run: cp BeeSwift/Config.swift.sample BeeKit/Config.swift
     - name: Run tests
-      run: fastlane test
+      run: bundle exec fastlane test
     - name: Publish Test Report
       uses: mikepenz/action-junit-report@v3
       if: always() # always run even if the previous step fails

--- a/.github/workflows/fastlane-tests.yml
+++ b/.github/workflows/fastlane-tests.yml
@@ -1,0 +1,24 @@
+name: Fastlane Tests
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '2.7.2'
+    - name: script
+      run: cp BeeSwift/Config.swift.sample BeeKit/Config.swift
+    - uses: maierj/fastlane-action@v2.2.0
+      with:
+        lane: 'test'
+    - name: Publish Test Report
+      uses: mikepenz/action-junit-report@v3
+      if: always() # always run even if the previous step fails
+      with:
+        report_paths: 'fastlane/test_output/report.junit'


### PR DESCRIPTION
This project was previously configured to use semaphore for unit tests. However lack of credits meant a slow queue. Github actions now has the capability to run these tests, and is more consistent with what is used elsewhere at beeminder.

This causes github to run the test suite on PRs.

Note: The test suite is currently broken. That is not addressed by this PR.