### PR TITLE
Fix display of & in datapoint list

### DIFF
--- a/BeeSwift/GoalViewController.swift
+++ b/BeeSwift/GoalViewController.swift
@@ -627,11 +627,19 @@ class GoalViewController: UIViewController, UITableViewDelegate, UITableViewData
         guard let datapoint = data[indexPath.row] as? JSON else {
             return cell
         }
-        
-        let text = datapoint["canonical"].string
-        cell.datapointText = text
+        cell.datapointText = displayText(datapoint: datapoint)
         
         return cell
+    }
+
+    func displayText(datapoint: JSON) -> String {
+        let daystamp = Int(datapoint["daystamp"].string ?? "") ?? 0
+        let day = daystamp != 0 ? String(format: "%02d", daystamp % 100) : "??" // Day is two least significant digits of daystamp
+
+        let value = datapoint["value"].numberValue
+        let comment = datapoint["comment"].string ?? ""
+
+        return "\(day) \(value) \(comment)"
     }
     
     // MARK: - SFSafariViewControllerDelegate


### PR DESCRIPTION
For some reason the canonical representation of data points html-encodes `&`. To avoid this we instead reconstruct the text from the individual fields. In the future we could go further and use columns, but for now we just re-assemble the original text output.

Fixes #283

Test Plan:
Added & to a datapoint and viewed the goal in the simulator