### PR TITLE
Isolate HealthKit interactions from the rest of the codebase

### DIFF
--- a/BeeSwift.xcodeproj/project.pbxproj
+++ b/BeeSwift.xcodeproj/project.pbxproj
@@ -83,9 +83,9 @@
 		E4B0A33028C194C900055EA7 /* AddDataIntents.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = E540953B260FB6A100C30784 /* AddDataIntents.intentdefinition */; };
 		E4B0A33128C194C900055EA7 /* AddDataIntents.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = E540953B260FB6A100C30784 /* AddDataIntents.intentdefinition */; };
 		E4B0A33228C194CA00055EA7 /* AddDataIntents.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = E540953B260FB6A100C30784 /* AddDataIntents.intentdefinition */; };
-		E52094FE2741D72300CB766F /* JSONGoal+Healthkit.swift in Sources */ = {isa = PBXBuildFile; fileRef = E52094FD2741D72300CB766F /* JSONGoal+Healthkit.swift */; };
-		E52094FF2741D73800CB766F /* JSONGoal+Healthkit.swift in Sources */ = {isa = PBXBuildFile; fileRef = E52094FD2741D72300CB766F /* JSONGoal+Healthkit.swift */; };
-		E52095002741D73900CB766F /* JSONGoal+Healthkit.swift in Sources */ = {isa = PBXBuildFile; fileRef = E52094FD2741D72300CB766F /* JSONGoal+Healthkit.swift */; };
+		E52094FE2741D72300CB766F /* GoalHealthKitConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = E52094FD2741D72300CB766F /* GoalHealthKitConnection.swift */; };
+		E52094FF2741D73800CB766F /* GoalHealthKitConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = E52094FD2741D72300CB766F /* GoalHealthKitConnection.swift */; };
+		E52095002741D73900CB766F /* GoalHealthKitConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = E52094FD2741D72300CB766F /* GoalHealthKitConnection.swift */; };
 		E55760F526549D310076B95A /* AddDataIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = E55760F426549D310076B95A /* AddDataIntentHandler.swift */; };
 		E557610026549DD10076B95A /* AddDataIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = E55760F426549D310076B95A /* AddDataIntentHandler.swift */; };
 		E55FAB19261240F800A0CF88 /* CurrentUserManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1453B3C1AEDFA52006F48DA /* CurrentUserManager.swift */; };
@@ -281,7 +281,7 @@
 		DB01694F5BE68BBDBB21E697 /* Pods_BeeSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BeeSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E029CC25A4BEE8E42BD37670 /* Pods-BeeSwift.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BeeSwift.release.xcconfig"; path = "Pods/Target Support Files/Pods-BeeSwift/Pods-BeeSwift.release.xcconfig"; sourceTree = "<group>"; };
 		E457BE5C28C192B50012F5D0 /* IntentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntentHandler.swift; sourceTree = "<group>"; };
-		E52094FD2741D72300CB766F /* JSONGoal+Healthkit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "JSONGoal+Healthkit.swift"; sourceTree = "<group>"; };
+		E52094FD2741D72300CB766F /* GoalHealthKitConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalHealthKitConnection.swift; sourceTree = "<group>"; };
 		E540953B260FB6A100C30784 /* AddDataIntents.intentdefinition */ = {isa = PBXFileReference; lastKnownFileType = file.intentdefinition; path = AddDataIntents.intentdefinition; sourceTree = "<group>"; };
 		E55760F426549D310076B95A /* AddDataIntentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddDataIntentHandler.swift; sourceTree = "<group>"; };
 		E55FEE6A23FF7552007C20B2 /* Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Config.swift; sourceTree = "<group>"; };
@@ -488,7 +488,7 @@
 				A1BD0D171AEB30A5001EDE8B /* GoalViewController.swift */,
 				A1E618E11E78158700D8ED93 /* HealthKitConfigViewController.swift */,
 				A1F8F07A232C05410060B83E /* JSONGoal.swift */,
-				E52094FD2741D72300CB766F /* JSONGoal+Healthkit.swift */,
+				E52094FD2741D72300CB766F /* GoalHealthKitConnection.swift */,
 				A1453B3E1AEDFCC8006F48DA /* SignInViewController.swift */,
 				A149B36F1AEF528C00F19A09 /* SettingsViewController.swift */,
 				A1A8BDE51FEAE8DD007D61D6 /* ConfigureNotificationsViewController.swift */,
@@ -1077,7 +1077,7 @@
 				A142492F1FD0A590007736B3 /* HealthStoreManager.swift in Sources */,
 				A142492A1FD0788F007736B3 /* UIDevice.swift in Sources */,
 				A1D8532C1EB0EA5700FC75DE /* UIFontExtension.swift in Sources */,
-				E52094FF2741D73800CB766F /* JSONGoal+Healthkit.swift in Sources */,
+				E52094FF2741D73800CB766F /* GoalHealthKitConnection.swift in Sources */,
 				A1D853261EB0332D00FC75DE /* Constants.swift in Sources */,
 				A14249211FD07514007736B3 /* CurrentUserManager.swift in Sources */,
 				A13C9CFB2345C18D002912C4 /* JSONGoal.swift in Sources */,
@@ -1109,7 +1109,7 @@
 				A1619EA41BEECC1500E14B3A /* EditDefaultNotificationsViewController.swift in Sources */,
 				A1E619001E86980900D8ED93 /* HealthKitConfig.swift in Sources */,
 				A149B3701AEF528C00F19A09 /* SettingsViewController.swift in Sources */,
-				E52094FE2741D72300CB766F /* JSONGoal+Healthkit.swift in Sources */,
+				E52094FE2741D72300CB766F /* GoalHealthKitConnection.swift in Sources */,
 				A1453B391AEDA71D006F48DA /* BSLabel.swift in Sources */,
 				A1E618E21E78158700D8ED93 /* HealthKitConfigViewController.swift in Sources */,
 				A1F8F07B232C05410060B83E /* JSONGoal.swift in Sources */,
@@ -1171,7 +1171,7 @@
 				E5CF51832612434A00546184 /* BSTextField.swift in Sources */,
 				E55FAB19261240F800A0CF88 /* CurrentUserManager.swift in Sources */,
 				E5CF51952612435800546184 /* HealthKitConfig.swift in Sources */,
-				E52095002741D73900CB766F /* JSONGoal+Healthkit.swift in Sources */,
+				E52095002741D73900CB766F /* GoalHealthKitConnection.swift in Sources */,
 				E5F7C55026113C330095684F /* AddDataIntents.intentdefinition in Sources */,
 				E5CF51AD2612437400546184 /* JSONGoal.swift in Sources */,
 				E5CF51822612434700546184 /* BSLabel.swift in Sources */,

--- a/BeeSwift/AppDelegate.swift
+++ b/BeeSwift/AppDelegate.swift
@@ -26,13 +26,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         IQKeyboardManager.shared().isEnableAutoToolbar = false
 
         if HKHealthStore.isHealthDataAvailable() {
-            HealthStoreManager.sharedManager.setupHealthkit()
-
             // We must register queries for all our healthkit metrics before this method completes in order to successfully be delivered background updates
             // This means we cannot wait for a round trip to the server to fetch latest goals, so use a potentially stale list from last time we did a successful
             // update.
             if let goals = CurrentUserManager.sharedManager.staleGoals() {
-                goals.forEach({ goal in goal.setupHealthKit() })
+                HealthStoreManager.sharedManager.setupHealthKitGoals(goals: goals)
             }
         }
         

--- a/BeeSwift/ChooseHKMetricViewController.swift
+++ b/BeeSwift/ChooseHKMetricViewController.swift
@@ -98,7 +98,7 @@ class ChooseHKMetricViewController: UIViewController {
     func saveMetric(databaseString : String) {
         self.goal!.healthKitMetric = databaseString
         self.goal!.autodata = "apple"
-        self.goal!.setupHealthKit()
+        HealthStoreManager.sharedManager.setupHealthKitGoal(goal: self.goal!)
         
         var params : [String : [String : String]] = [:]
         params = ["ii_params" : ["name" : "apple", "metric" : self.goal!.healthKitMetric!]]

--- a/BeeSwift/GalleryViewController.swift
+++ b/BeeSwift/GalleryViewController.swift
@@ -393,16 +393,10 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
     }
     
     func setupHealthKit() {
-        var permissions = Set<HKObjectType>.init()
-        self.goals.forEach { (goal) in
-            if goal.hkPermissionType() != nil { permissions.insert(goal.hkPermissionType()!) }
+        // TODO: We could potentially merge these together?
+        HealthStoreManager.sharedManager.requestAuthorization(goals: self.goals) { (success, error) in
+            HealthStoreManager.sharedManager.setupHealthKitGoals(goals: self.goals)
         }
-        guard permissions.count > 0 else { return }
-        guard let healthStore = HealthStoreManager.sharedManager.healthStore else { return }
-        
-        healthStore.requestAuthorization(toShare: nil, read: permissions, completion: { (success, error) in
-            self.goals.forEach { (goal) in goal.setupHealthKit() }
-        })
     }
     
     @objc func fetchGoals() {

--- a/BeeSwift/GoalViewController.swift
+++ b/BeeSwift/GoalViewController.swift
@@ -369,7 +369,7 @@ class GoalViewController: UIViewController, UITableViewDelegate, UITableViewData
     private func syncHealthDataButtonPressed(numDays: Int) {
         let hud = MBProgressHUD.showAdded(to: self.view, animated: true)
         hud?.mode = .indeterminate
-        self.goal.hkQueryForLast(days: numDays, success: {
+        HealthStoreManager.sharedManager.syncHealthKitData(goal: self.goal, days: numDays, success: {
             DispatchQueue.main.asyncAfter(deadline: .now() + 1, execute: {
                 hud?.mode = .customView
                 hud?.customView = UIImageView(image: UIImage(named: "checkmark"))

--- a/BeeSwift/HealthStoreManager.swift
+++ b/BeeSwift/HealthStoreManager.swift
@@ -10,11 +10,66 @@ import Foundation
 import HealthKit
 
 class HealthStoreManager :NSObject {
-    
     static let sharedManager = HealthStoreManager()
+
     var healthStore : HKHealthStore?
+
+    /// The Connection objects responsible for updating goals based on their healthkit metrics
+    /// Dictionary key is the goal id, as this is stable across goal renames
+    private var connections: [String: GoalHealthKitConnection] = [:]
     
-    func setupHealthkit() {
+    private func ensureHealthStoreCreated() {
         self.healthStore = HKHealthStore()
+    }
+
+    /// Gets or creates an appropriate connection object for the supplied goal
+    private func connectionFor(goal: JSONGoal) -> GoalHealthKitConnection? {
+        if goal.healthKitMetric == "" {
+            // Goal does not have a metric. Make sure any connection is removed
+            connections.removeValue(forKey: goal.id)
+            return nil
+        } else {
+            return connections[goal.id] ?? GoalHealthKitConnection(goal: goal)
+        }
+    }
+
+    func requestAuthorization(goals: [JSONGoal], completion: @escaping (Bool, Error?) -> Void) {
+        ensureHealthStoreCreated();
+        let goalConnections = goals.map { self.connectionFor(goal:$0) }.compactMap { $0 }
+
+        var permissions = Set<HKObjectType>.init()
+        goalConnections.forEach { (connection) in
+            if let permissionType = connection.hkPermissionType() {
+               permissions.insert(permissionType)
+            }
+        }
+        guard permissions.count > 0 else { return }
+
+        guard let healthStore = HealthStoreManager.sharedManager.healthStore else { return }
+        healthStore.requestAuthorization(toShare: nil, read: permissions, completion: completion)
+    }
+
+    func setupHealthKitGoals(goals: [JSONGoal]) {
+        ensureHealthStoreCreated();
+        let goalConnections = goals.map { self.connectionFor(goal:$0) }.compactMap { $0 }
+        goalConnections.forEach { (connection) in
+            connection.setupHealthKit()
+        }
+    }
+
+    func setupHealthKitGoal(goal: JSONGoal) {
+        ensureHealthStoreCreated();
+        if let connection = self.connectionFor(goal: goal) {
+            connection.setupHealthKit()
+        }
+    }
+
+    func syncHealthKitData(goal: JSONGoal, days: Int, success: (() -> ())?, errorCompletion: (() -> ())?) {
+        ensureHealthStoreCreated();
+        if let connection = self.connectionFor(goal: goal) {
+            connection.hkQueryForLast(days: days, success: success, errorCompletion: errorCompletion)
+        } else {
+            errorCompletion?()
+        }
     }
 }

--- a/BeeSwift/JSONGoal.swift
+++ b/BeeSwift/JSONGoal.swift
@@ -285,18 +285,7 @@ class JSONGoal {
     var deltaColorsWhenAboveIsGoodSide: [UIColor] {
         return deltaColorsWhenBelowIsGoodSide.reversed()
     }
-    
-    func hkQuantityTypeIdentifier() -> HKQuantityTypeIdentifier? {
-        return HealthKitConfig.shared.metrics.first { (metric) -> Bool in
-            metric.databaseString == self.healthKitMetric
-            }?.hkIdentifier
-    }
-    
-    func hkCategoryTypeIdentifier() -> HKCategoryTypeIdentifier? {
-        return HealthKitConfig.shared.metrics.first { (metric) -> Bool in
-            metric.databaseString == self.healthKitMetric
-            }?.hkCategoryTypeIdentifier
-    }
+
     
     func hideDataEntry() -> Bool {
         return self.autodata.count > 0 || self.won.boolValue


### PR DESCRIPTION
This PR takes two steps towards isolating HealthKit logic from the rest of the codebase
1. It removes logic from the JSONGoal class, and instead moves it to a HealthKitConnection class
2. It moves all health kit data model operations to behind HealthStoreManager

This reduction in surface area should make it much simpler to refactor the health kit code.

Test Plan:
* Run on device and observe sync with health kit buttons work
* Also add significant logging and observe it is run as expected

Note that this code cannot be correctly tested on simulator as it does not have data available.