### PR TITLE
Remove all iOS version compatibility checks

### DIFF
--- a/BeeSwift/AppDelegate.swift
+++ b/BeeSwift/AppDelegate.swift
@@ -149,16 +149,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         UNUserNotificationCenter.current().removeAllPendingNotificationRequests()
     }
     func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
-        if #available(iOS 12.0, *) {
-            if let intent = userActivity.interaction?.intent as? AddDataIntent {
-                guard let goalSlug = intent.goal else { return false }
-                NotificationCenter.default.post(name: Notification.Name(rawValue: "openGoal"), object: nil, userInfo: ["slug": goalSlug])
-                
-                // Early return to avoid also checking userInfo
-                return true
-            }
-        }
-        if let goalSlug = userActivity.userInfo?["slug"] {
+        if let intent = userActivity.interaction?.intent as? AddDataIntent {
+            guard let goalSlug = intent.goal else { return false }
+            NotificationCenter.default.post(name: Notification.Name(rawValue: "openGoal"), object: nil, userInfo: ["slug": goalSlug])
+        } else if let goalSlug = userActivity.userInfo?["slug"] {
             NotificationCenter.default.post(name: Notification.Name(rawValue: "openGoal"), object: nil, userInfo: ["slug": goalSlug])
         }
         return true

--- a/BeeSwift/ChooseGoalSortViewController.swift
+++ b/BeeSwift/ChooseGoalSortViewController.swift
@@ -20,13 +20,8 @@ class ChooseGoalSortViewController: UIViewController {
         self.tableView.snp.makeConstraints { (make) -> Void in
             make.left.equalTo(0)
             make.right.equalTo(0)
-            if #available(iOS 11.0, *) {
-                make.top.equalTo(self.view.safeAreaLayoutGuide.snp.topMargin)
-                make.bottom.equalTo(self.view.safeAreaLayoutGuide.snp.bottomMargin)
-            } else {
-                make.bottom.equalTo(self.bottomLayoutGuide.snp.top)
-                make.top.equalTo(self.topLayoutGuide.snp.bottom)
-            }
+            make.top.equalTo(self.view.safeAreaLayoutGuide.snp.topMargin)
+            make.bottom.equalTo(self.view.safeAreaLayoutGuide.snp.bottomMargin)
         }
         self.tableView.delegate = self
         self.tableView.dataSource = self

--- a/BeeSwift/ChooseHKMetricViewController.swift
+++ b/BeeSwift/ChooseHKMetricViewController.swift
@@ -17,11 +17,7 @@ class ChooseHKMetricViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        if #available(iOS 13.0, *) {
-            self.view.backgroundColor = .systemBackground
-        } else {
-            self.view.backgroundColor = .white
-        }
+        self.view.backgroundColor = .systemBackground
         self.title = "Choose HK Metric"
         
         let instructionsLabel = BSLabel()

--- a/BeeSwift/ConfigureNotificationsViewController.swift
+++ b/BeeSwift/ConfigureNotificationsViewController.swift
@@ -19,11 +19,7 @@ class ConfigureNotificationsViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         self.title = "Notifications"
-        if #available(iOS 13.0, *) {
-            self.view.backgroundColor = .systemBackground
-        } else {
-            self.view.backgroundColor = .white
-        }
+        self.view.backgroundColor = .systemBackground
         
         self.view.addSubview(self.settingsButton)
         self.settingsButton.isHidden = true
@@ -41,13 +37,9 @@ class ConfigureNotificationsViewController: UIViewController {
         self.tableView.snp.makeConstraints { (make) -> Void in
             make.left.equalTo(0)
             make.right.equalTo(0)
-            if #available(iOS 11.0, *) {
-                make.top.equalTo(self.view.safeAreaLayoutGuide.snp.topMargin).offset(10)
-                make.bottom.equalTo(self.view.safeAreaLayoutGuide.snp.bottomMargin)
-            } else {
-                make.top.equalTo(self.topLayoutGuide.snp.bottom).offset(10)
-                make.bottom.equalTo(self.bottomLayoutGuide.snp.top)
-            }
+            make.top.equalTo(self.view.safeAreaLayoutGuide.snp.topMargin).offset(10)
+            make.bottom.equalTo(self.view.safeAreaLayoutGuide.snp.bottomMargin)
+
         }
         self.tableView.isHidden = true
         self.tableView.delegate = self

--- a/BeeSwift/EditDatapointViewController.swift
+++ b/BeeSwift/EditDatapointViewController.swift
@@ -24,12 +24,8 @@ class EditDatapointViewController: UIViewController, UITextFieldDelegate {
         super.viewDidLoad()
 
         self.title = "Edit Datapoint"
-        
-        if #available(iOS 13.0, *) {
-            self.view.backgroundColor = .systemBackground
-        } else {
-            self.view.backgroundColor = .white
-        }
+
+        self.view.backgroundColor = .systemBackground
         
         self.view.addSubview(self.scrollView)
         self.scrollView.snp.makeConstraints { (make) -> Void in

--- a/BeeSwift/EditNotificationsViewController.swift
+++ b/BeeSwift/EditNotificationsViewController.swift
@@ -56,11 +56,7 @@ class EditNotificationsViewController: UIViewController {
     }
     
     override func viewDidLoad() {
-        if #available(iOS 13.0, *) {
-            self.view.backgroundColor = UIColor.systemBackground
-        } else {
-            self.view.backgroundColor = UIColor.white
-        }
+        self.view.backgroundColor = UIColor.systemBackground
         
         self.view.addSubview(self.leadTimeLabel)
         self.leadTimeLabel.snp.makeConstraints { (make) -> Void in

--- a/BeeSwift/GalleryViewController.swift
+++ b/BeeSwift/GalleryViewController.swift
@@ -44,19 +44,11 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
         
         self.collectionViewLayout = UICollectionViewFlowLayout()
         self.collectionView = UICollectionView(frame: self.view.frame, collectionViewLayout: self.collectionViewLayout!)
-        if #available(iOS 13.0, *) {
-            self.collectionView?.backgroundColor = .systemBackground
-        } else {
-            self.collectionView?.backgroundColor = UIColor.white
-        }
-        
+        self.collectionView?.backgroundColor = .systemBackground
         self.collectionView?.alwaysBounceVertical = true
         self.collectionView?.register(UICollectionReusableView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionFooter, withReuseIdentifier: "footer")
-        if #available(iOS 13.0, *) {
-            self.view.backgroundColor = .systemBackground
-        } else {
-            self.view.backgroundColor = .white
-        }
+
+        self.view.backgroundColor = .systemBackground
         self.title = "Goals"
         
         let item = UIBarButtonItem(image: UIImage(named: "Settings"), style: UIBarButtonItem.Style.plain, target: self, action: #selector(self.settingsButtonPressed))
@@ -154,13 +146,8 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
         
         self.collectionView!.snp.makeConstraints { (make) -> Void in
             make.top.equalTo(self.searchBar.snp.bottom)
-            if #available(iOS 11.0, *) {
-                make.left.equalTo(self.view.safeAreaLayoutGuide.snp.leftMargin)
-                make.right.equalTo(self.view.safeAreaLayoutGuide.snp.rightMargin)
-            } else {
-                make.left.equalTo(0)
-                make.right.equalTo(0)
-            }
+            make.left.equalTo(self.view.safeAreaLayoutGuide.snp.leftMargin)
+            make.right.equalTo(self.view.safeAreaLayoutGuide.snp.rightMargin)
             make.bottom.equalTo(0)
         }
         

--- a/BeeSwift/GoalCollectionViewCell.swift
+++ b/BeeSwift/GoalCollectionViewCell.swift
@@ -37,40 +37,33 @@ class GoalCollectionViewCell: UICollectionViewCell {
         self.contentView.addSubview(self.todaytaLabel)
         self.contentView.addSubview(self.thumbnailImageView)
         self.contentView.addSubview(self.safesumLabel)
-        if #available(iOS 13.0, *) {
-            self.contentView.backgroundColor = .systemBackground
-        }
+        self.contentView.backgroundColor = .systemBackground
+
         self.slugLabel.font = UIFont.beeminder.defaultFontHeavy
+        self.slugLabel.textColor = .label
         self.slugLabel.snp.makeConstraints { (make) -> Void in
             make.left.equalTo(self.margin)
             make.top.equalTo(10)
             make.width.lessThanOrEqualTo(self.contentView).multipliedBy(0.35)
         }
-        if #available(iOS 13.0, *) {
-            self.slugLabel.textColor = .label
-        }
         
         self.titleLabel.font = UIFont.beeminder.defaultFont
-        if #available(iOS 13.0, *) {
-            self.titleLabel.textColor = .label
-        }
+        self.titleLabel.textColor = .label
+        self.titleLabel.textAlignment = .left
         self.titleLabel.snp.makeConstraints { (make) -> Void in
             make.centerY.equalTo(self.slugLabel)
             make.left.equalTo(self.slugLabel.snp.right).offset(10)
             make.right.lessThanOrEqualTo(self.todaytaLabel.snp.left).offset(-10)
         }
-        self.titleLabel.textAlignment = .left
         
         self.todaytaLabel.font = UIFont.beeminder.defaultFont
-        if #available(iOS 13.0, *) {
-            self.todaytaLabel.textColor = .label
-        }
+        self.todaytaLabel.textColor = .label
+        self.todaytaLabel.textAlignment = .right
         self.todaytaLabel.snp.makeConstraints { (make) -> Void in
             make.centerY.equalTo(self.slugLabel)
             make.right.equalTo(-self.margin)
         }
         self.todaytaLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
-        self.todaytaLabel.textAlignment = .right
 
         self.thumbnailImageView.snp.makeConstraints { (make) -> Void in
             make.left.equalTo(0).offset(self.margin)

--- a/BeeSwift/GoalHealthKitConnection.swift
+++ b/BeeSwift/GoalHealthKitConnection.swift
@@ -346,13 +346,10 @@ class GoalHealthKitConnection {
                 var datapointValue : Double?
                 guard let unit = units.first?.value else { return }
                 
-                let aggStyle : HKQuantityAggregationStyle
-                if #available(iOS 13.0, *) { aggStyle = .discreteArithmetic } else { aggStyle = .discrete }
-                
                 if quantityType.aggregationStyle == .cumulative {
                     let quantity = statistics!.sumQuantity()
                     datapointValue = quantity?.doubleValue(for: unit)
-                } else if quantityType.aggregationStyle == aggStyle {
+                } else if quantityType.aggregationStyle == .discreteArithmetic {
                     let quantity = statistics!.minimumQuantity()
                     datapointValue = quantity?.doubleValue(for: unit)
                 }

--- a/BeeSwift/GoalViewController.swift
+++ b/BeeSwift/GoalViewController.swift
@@ -37,11 +37,7 @@ class GoalViewController: UIViewController, UITableViewDelegate, UITableViewData
     fileprivate let viewGoalActivityType = "com.beeminder.viewGoal"
 
     override func viewDidLoad() {
-        if #available(iOS 13.0, *) {
-            self.view.backgroundColor = UIColor.systemBackground
-        } else {
-            self.view.backgroundColor = UIColor.white
-        }
+        self.view.backgroundColor = UIColor.systemBackground
         self.title = self.goal.slug
         
         // have to set these before the datapoints since setting the most recent datapoint updates the text field,
@@ -94,13 +90,8 @@ class GoalViewController: UIViewController, UITableViewDelegate, UITableViewData
         self.goalImageScrollView.delegate = self
         self.goalImageScrollView.snp.makeConstraints { (make) -> Void in
             make.centerX.equalTo(self.view)
-            if #available(iOS 11.0, *) {
-                make.left.greaterThanOrEqualTo(self.scrollView.safeAreaLayoutGuide.snp.leftMargin)
-                make.right.lessThanOrEqualTo(self.scrollView.safeAreaLayoutGuide.snp.rightMargin)
-            } else {
-                make.left.greaterThanOrEqualTo(0)
-                make.right.lessThanOrEqualTo(0)
-            }
+            make.left.greaterThanOrEqualTo(self.scrollView.safeAreaLayoutGuide.snp.leftMargin)
+            make.right.lessThanOrEqualTo(self.scrollView.safeAreaLayoutGuide.snp.rightMargin)
             
             make.top.equalTo(countdownView.snp.bottom)
             make.width.equalTo(self.scrollView)
@@ -150,11 +141,7 @@ class GoalViewController: UIViewController, UITableViewDelegate, UITableViewData
         self.scrollView.addSubview(dataEntryView)
         dataEntryView.snp.makeConstraints { (make) -> Void in
             make.top.equalTo(self.datapointsTableView.snp.bottom).offset(10)
-            if #available(iOS 11.0, *) {
-                make.left.equalTo(self.view.safeAreaLayoutGuide.snp.leftMargin).offset(10)
-            } else {
-                make.left.equalTo(10)
-            }
+            make.left.equalTo(self.view.safeAreaLayoutGuide.snp.leftMargin).offset(10)
             make.right.equalTo(self.datapointsTableView)
             make.bottom.equalTo(0)
             make.height.equalTo(120)
@@ -227,11 +214,7 @@ class GoalViewController: UIViewController, UITableViewDelegate, UITableViewData
         self.commentTextField.snp.makeConstraints { (make) -> Void in
             make.left.equalTo(self.valueTextField.snp.right).offset(10).priority(.high)
             make.height.equalTo(Constants.defaultTextFieldHeight)
-            if #available(iOS 11.0, *) {
-                make.right.equalTo(self.view.safeAreaLayoutGuide.snp.rightMargin).offset(-10).priority(.high)
-            } else {
-                make.right.equalTo(-10)
-            }
+            make.right.equalTo(self.view.safeAreaLayoutGuide.snp.rightMargin).offset(-10).priority(.high)
             make.top.equalTo(0)
         }
         
@@ -320,11 +303,7 @@ class GoalViewController: UIViewController, UITableViewDelegate, UITableViewData
             self.scrollView.addSubview(appleSyncView)
             appleSyncView.snp.makeConstraints({ (make) in
                 make.top.equalTo(self.datapointsTableView.snp.bottom).offset(10)
-                if #available(iOS 11.0, *) {
-                    make.left.equalTo(self.view.safeAreaLayoutGuide.snp.leftMargin).offset(10)
-                } else {
-                    make.left.equalTo(10)
-                }
+                make.left.equalTo(self.view.safeAreaLayoutGuide.snp.leftMargin).offset(10)
                 make.right.equalTo(self.datapointsTableView)
                 make.bottom.equalTo(0)
                 make.height.equalTo(120)

--- a/BeeSwift/HealthKitConfigTableViewCell.swift
+++ b/BeeSwift/HealthKitConfigTableViewCell.swift
@@ -53,11 +53,7 @@ class HealthKitConfigTableViewCell: UITableViewCell {
     }
     
     func configure() {
-        if #available(iOS 13.0, *) {
-            self.backgroundColor = UIColor.secondarySystemBackground
-        } else {
-            self.backgroundColor = UIColor.clear
-        }
+        self.backgroundColor = UIColor.secondarySystemBackground
         self.accessoryType = .none
         self.selectionStyle = .none
         

--- a/BeeSwift/HealthKitConfigViewController.swift
+++ b/BeeSwift/HealthKitConfigViewController.swift
@@ -20,11 +20,7 @@ class HealthKitConfigViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        if #available(iOS 13.0, *) {
-            self.view.backgroundColor = .systemBackground
-        } else {
-            self.view.backgroundColor = .white
-        }
+        self.view.backgroundColor = .systemBackground
         self.title = "Health app integration"
         let backItem = UIBarButtonItem(title: "Back", style: .plain, target: nil, action: nil)
         self.navigationItem.backBarButtonItem = backItem

--- a/BeeSwift/JSONGoal.swift
+++ b/BeeSwift/JSONGoal.swift
@@ -52,15 +52,9 @@ class JSONGoal {
         self.alertstart = json["alertstart"].number!
         if let lasttouchString = json["lasttouch"].string {
             let lastTouchDate: Date? = {
-                if #available(iOS 11.0, *) {
-                    let df = ISO8601DateFormatter()
-                    df.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-                    return df.date(from: lasttouchString)
-                } else {
-                    let df = DateFormatter()
-                    df.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
-                    return df.date(from: lasttouchString)
-                }
+                let df = ISO8601DateFormatter()
+                df.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+                return df.date(from: lasttouchString)
             }()
             
             if let date = lastTouchDate {

--- a/BeeSwift/RemoveHKMetricViewController.swift
+++ b/BeeSwift/RemoveHKMetricViewController.swift
@@ -15,12 +15,8 @@ class RemoveHKMetricViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        if #available(iOS 13.0, *) {
-            self.view.backgroundColor = .systemBackground
-        } else {
-            self.view.backgroundColor = .white
-        }
+
+        self.view.backgroundColor = .systemBackground
         self.title = "Remove HK Metric"
         
         let currentMetricLabel = BSLabel()

--- a/BeeSwift/SettingsTableViewCell.swift
+++ b/BeeSwift/SettingsTableViewCell.swift
@@ -42,22 +42,14 @@ class SettingsTableViewCell: UITableViewCell {
         self.contentView.addSubview(self.settingsImage)
         
         self.selectionStyle = .none
-        if #available(iOS 13.0, *) {
-            self.backgroundColor = .secondarySystemBackground
-        } else {
-            self.backgroundColor = .white
-        }
-        
-        if #available(iOS 13.0, *) {
-            self.titleLabel.textColor = .label
-        } else {
-            self.titleLabel.textColor = UIColor.beeminder.gray
-        }
-        
+        self.backgroundColor = .secondarySystemBackground
+
+        self.titleLabel.textColor = .label
         self.titleLabel.snp.remakeConstraints { (make) -> Void in
             make.centerY.equalTo(self.contentView)
             make.left.equalTo(self.settingsImage.snp.right).offset(10)
         }
+        
         self.settingsImage.snp.remakeConstraints({ (make) in
             make.centerY.equalTo(self.contentView)
             make.left.equalTo(10)

--- a/BeeSwift/SettingsViewController.swift
+++ b/BeeSwift/SettingsViewController.swift
@@ -17,36 +17,23 @@ class SettingsViewController: UIViewController {
     
     override func viewDidLoad() {
         self.title = "Settings"
-        if #available(iOS 13.0, *) {
-            self.view.backgroundColor = .systemBackground
-        } else {
-            self.view.backgroundColor = .white
-        }
+        self.view.backgroundColor = .systemBackground
         
         NotificationCenter.default.addObserver(self, selector: #selector(self.userDefaultsDidChange), name: UserDefaults.didChangeNotification, object: nil)
         
         self.view.addSubview(self.tableView)
+
         self.tableView.snp.makeConstraints { (make) -> Void in
             make.left.equalTo(0)
             make.right.equalTo(0)
-            if #available(iOS 11.0, *) {
-                make.top.equalTo(self.view.safeAreaLayoutGuide.snp.topMargin)
-                make.bottom.equalTo(self.view.snp.bottom)
-            } else {
-                make.bottom.equalTo(self.bottomLayoutGuide.snp.top)
-                make.top.equalTo(self.topLayoutGuide.snp.bottom)
-            }
+            make.top.equalTo(self.view.safeAreaLayoutGuide.snp.topMargin)
+            make.bottom.equalTo(self.view.snp.bottom)
         }
         
         self.tableView.delegate = self
         self.tableView.dataSource = self
         self.tableView.isScrollEnabled = false
         self.tableView.tableFooterView = UIView()
-        if #available(iOS 13.0, *) {
-            self.view.backgroundColor = .systemBackground
-        } else {
-            self.view.backgroundColor = .white
-        }
         self.tableView.register(SettingsTableViewCell.self, forCellReuseIdentifier: self.cellReuseIdentifier)
 
         if let info = Bundle.main.infoDictionary {
@@ -57,11 +44,7 @@ class SettingsViewController: UIViewController {
             versionLabel.text = "Version: \(appVersion) (\(appBuild))"
             self.view.addSubview(versionLabel)
             versionLabel.snp.makeConstraints { (make) in
-                if #available(iOS 11.0, *) {
-                    make.bottom.equalTo(self.view.safeAreaLayoutGuide.snp.bottomMargin).offset(-10)
-                } else {
-                    make.bottom.equalTo(self.bottomLayoutGuide.snp.top).offset(-10)
-                }
+                make.bottom.equalTo(self.view.safeAreaLayoutGuide.snp.bottomMargin).offset(-10)
                 make.width.equalTo(self.view)
             }
             versionLabel.textAlignment = .center

--- a/BeeSwift/SignInViewController.swift
+++ b/BeeSwift/SignInViewController.swift
@@ -30,18 +30,8 @@ class SignInViewController : UIViewController, UITextFieldDelegate, SFSafariView
         let button = BSButton()
         button.setTitle("Forgot password?", for: .normal)
         button.titleLabel?.font = UIFont.beeminder.defaultFontHeavy
-        if #available(iOS 13.0, *) {
-            button.setTitleColor(UIColor.label, for: .normal)
-        } else {
-            button.setTitleColor(UIColor.beeminder.gray, for: .normal)
-        }
-        
-        if #available(iOS 13.0, *) {
-            button.backgroundColor = UIColor.systemBackground
-        } else {
-            button.backgroundColor = UIColor.white
-        }
-        
+        button.setTitleColor(UIColor.label, for: .normal)
+        button.backgroundColor = UIColor.systemBackground
         button.addTarget(self, action: #selector(SignInViewController.resetPasswordTapped), for: .touchUpInside)
 
         return button
@@ -58,11 +48,7 @@ class SignInViewController : UIViewController, UITextFieldDelegate, SFSafariView
         
         NotificationCenter.default.addObserver(self, selector: #selector(self.handleFailedSignIn(_:)), name: NSNotification.Name(rawValue: CurrentUserManager.failedSignInNotificationName), object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(self.handleSignedIn(_:)), name: NSNotification.Name(rawValue: CurrentUserManager.signedInNotificationName), object: nil)
-        if #available(iOS 13.0, *) {
-            self.view.backgroundColor = UIColor.systemBackground
-        } else {
-            self.view.backgroundColor = UIColor.white
-        }
+        self.view.backgroundColor = UIColor.systemBackground
         
         
         self.beeImageView.image = UIImage(named: "website_logo_mid")

--- a/BeeSwift/TimerViewController.swift
+++ b/BeeSwift/TimerViewController.swift
@@ -37,12 +37,8 @@ class TimerViewController: UIViewController {
         let exitButton = BSButton()
         self.view.addSubview(exitButton)
         exitButton.snp.makeConstraints { (make) in
-            if #available(iOS 11.0, *) {
-                make.left.equalTo(self.view.safeAreaLayoutGuide.snp.leftMargin)
-                make.bottom.equalTo(self.view.safeAreaLayoutGuide.snp.bottomMargin)
-            } else {
-                make.left.bottom.equalTo(0)
-            }
+            make.left.equalTo(self.view.safeAreaLayoutGuide.snp.leftMargin)
+            make.bottom.equalTo(self.view.safeAreaLayoutGuide.snp.bottomMargin)
             make.right.equalTo(self.view.snp.centerX)
         }
         exitButton.backgroundColor = .clear
@@ -72,12 +68,8 @@ class TimerViewController: UIViewController {
         self.view.addSubview(resetButton)
         resetButton.snp.makeConstraints { (make) in
             make.left.equalTo(self.view.snp.centerX)
-            if #available(iOS 11.0, *) {
-                make.right.equalTo(self.view.safeAreaLayoutGuide.snp.rightMargin)
-                make.bottom.equalTo(self.view.safeAreaLayoutGuide.snp.bottomMargin)
-            } else {
-                make.right.bottom.equalTo(0)
-            }
+            make.right.equalTo(self.view.safeAreaLayoutGuide.snp.rightMargin)
+            make.bottom.equalTo(self.view.safeAreaLayoutGuide.snp.bottomMargin)
         }
         resetButton.addTarget(self, action: #selector(self.resetButtonPressed), for: .touchUpInside)
         resetButton.setTitle("Reset", for: .normal)

--- a/BeeSwiftUITests/BeeSwiftUITests.swift
+++ b/BeeSwiftUITests/BeeSwiftUITests.swift
@@ -33,11 +33,9 @@ class BeeSwiftUITests: XCTestCase {
     }
 
     func testLaunchPerformance() {
-        if #available(macOS 10.15, iOS 13.0, tvOS 13.0, *) {
-            // This measures how long it takes to launch your application.
-            measure(metrics: [XCTOSSignpostMetric.applicationLaunch]) {
-                XCUIApplication().launch()
-            }
+        // This measures how long it takes to launch your application.
+        measure(metrics: [XCTOSSignpostMetric.applicationLaunch]) {
+            XCUIApplication().launch()
         }
     }
 }


### PR DESCRIPTION
As the app now targets iOS 14 we no longer need checks in code to gate feature compatibility for this version or below. No checks targetted anything newer than this, so we were able to remove all of them.

Test Plan:
Clicked around in the simulator