### PR TITLE
Convert HealthKit integration code to async

### DIFF
--- a/BeeSwift.xcodeproj/project.pbxproj
+++ b/BeeSwift.xcodeproj/project.pbxproj
@@ -28,7 +28,6 @@
 		A142492A1FD0788F007736B3 /* UIDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11488BD1EE9B0CE003316E1 /* UIDevice.swift */; };
 		A142492D1FD079B4007736B3 /* SignedRequestManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A142492C1FD079B4007736B3 /* SignedRequestManager.swift */; };
 		A142492E1FD0A56A007736B3 /* HealthKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A158DDB51E46EEA10031BD4F /* HealthKit.framework */; };
-		A142492F1FD0A590007736B3 /* HealthStoreManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11BA9A31FCE54E3004BB425 /* HealthStoreManager.swift */; };
 		A14249301FD0A5A4007736B3 /* HealthKitConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1E618FF1E86980900D8ED93 /* HealthKitConfig.swift */; };
 		A1453B351AED9184006F48DA /* UIColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1453B341AED9184006F48DA /* UIColorExtension.swift */; };
 		A1453B391AEDA71D006F48DA /* BSLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1453B381AEDA71D006F48DA /* BSLabel.swift */; };
@@ -84,8 +83,6 @@
 		E4B0A33128C194C900055EA7 /* AddDataIntents.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = E540953B260FB6A100C30784 /* AddDataIntents.intentdefinition */; };
 		E4B0A33228C194CA00055EA7 /* AddDataIntents.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = E540953B260FB6A100C30784 /* AddDataIntents.intentdefinition */; };
 		E52094FE2741D72300CB766F /* GoalHealthKitConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = E52094FD2741D72300CB766F /* GoalHealthKitConnection.swift */; };
-		E52094FF2741D73800CB766F /* GoalHealthKitConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = E52094FD2741D72300CB766F /* GoalHealthKitConnection.swift */; };
-		E52095002741D73900CB766F /* GoalHealthKitConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = E52094FD2741D72300CB766F /* GoalHealthKitConnection.swift */; };
 		E55760F526549D310076B95A /* AddDataIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = E55760F426549D310076B95A /* AddDataIntentHandler.swift */; };
 		E557610026549DD10076B95A /* AddDataIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = E55760F426549D310076B95A /* AddDataIntentHandler.swift */; };
 		E55FAB19261240F800A0CF88 /* CurrentUserManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1453B3C1AEDFA52006F48DA /* CurrentUserManager.swift */; };
@@ -100,7 +97,6 @@
 		E5C9EFE62612E02700DBBEAE /* AddDataIntents.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = E540953B260FB6A100C30784 /* AddDataIntents.intentdefinition */; settings = {ATTRIBUTES = (no_codegen, ); }; };
 		E5CF516A2612431600546184 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1C11B471B06F5D100D22871 /* Constants.swift */; };
 		E5CF51702612432400546184 /* RequestManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BCE9841AFFFB3A007322CC /* RequestManager.swift */; };
-		E5CF51762612432E00546184 /* HealthStoreManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11BA9A31FCE54E3004BB425 /* HealthStoreManager.swift */; };
 		E5CF517C2612434300546184 /* BSButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = A149B3711AEF54D100F19A09 /* BSButton.swift */; };
 		E5CF51822612434700546184 /* BSLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1453B381AEDA71D006F48DA /* BSLabel.swift */; };
 		E5CF51832612434A00546184 /* BSTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1781AB21DE50F59000B96C5 /* BSTextField.swift */; };
@@ -1074,10 +1070,8 @@
 				A1D8532A1EB0EA2B00FC75DE /* BSButton.swift in Sources */,
 				A14249301FD0A5A4007736B3 /* HealthKitConfig.swift in Sources */,
 				A1D8532D1EB0EA8100FC75DE /* UIColorExtension.swift in Sources */,
-				A142492F1FD0A590007736B3 /* HealthStoreManager.swift in Sources */,
 				A142492A1FD0788F007736B3 /* UIDevice.swift in Sources */,
 				A1D8532C1EB0EA5700FC75DE /* UIFontExtension.swift in Sources */,
-				E52094FF2741D73800CB766F /* GoalHealthKitConnection.swift in Sources */,
 				A1D853261EB0332D00FC75DE /* Constants.swift in Sources */,
 				A14249211FD07514007736B3 /* CurrentUserManager.swift in Sources */,
 				A13C9CFB2345C18D002912C4 /* JSONGoal.swift in Sources */,
@@ -1167,11 +1161,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E5CF51762612432E00546184 /* HealthStoreManager.swift in Sources */,
 				E5CF51832612434A00546184 /* BSTextField.swift in Sources */,
 				E55FAB19261240F800A0CF88 /* CurrentUserManager.swift in Sources */,
 				E5CF51952612435800546184 /* HealthKitConfig.swift in Sources */,
-				E52095002741D73900CB766F /* GoalHealthKitConnection.swift in Sources */,
 				E5F7C55026113C330095684F /* AddDataIntents.intentdefinition in Sources */,
 				E5CF51AD2612437400546184 /* JSONGoal.swift in Sources */,
 				E5CF51822612434700546184 /* BSLabel.swift in Sources */,

--- a/BeeSwift/AppDelegate.swift
+++ b/BeeSwift/AppDelegate.swift
@@ -26,11 +26,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         IQKeyboardManager.shared().isEnableAutoToolbar = false
 
         if HKHealthStore.isHealthDataAvailable() {
-            // We must register queries for all our healthkit metrics before this method completes in order to successfully be delivered background updates
-            // This means we cannot wait for a round trip to the server to fetch latest goals, so use a potentially stale list from last time we did a successful
-            // update.
+            // We must register queries for all our healthkit metrics before this method completes
+            // in order to successfully be delivered background updates. This means we cannot wait
+            // for a round trip to the server to fetch latest goals, so use a potentially stale
+            // list from last time we did a successful update.
             if let goals = CurrentUserManager.sharedManager.staleGoals() {
-                HealthStoreManager.sharedManager.setupHealthKitGoals(goals: goals)
+                HealthStoreManager.sharedManager.registerObserverQueries(goals: goals)
             }
         }
         

--- a/BeeSwift/GalleryViewController.swift
+++ b/BeeSwift/GalleryViewController.swift
@@ -380,9 +380,12 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
     }
     
     func setupHealthKit() {
-        // TODO: We could potentially merge these together?
-        HealthStoreManager.sharedManager.requestAuthorization(goals: self.goals) { (success, error) in
-            HealthStoreManager.sharedManager.setupHealthKitGoals(goals: self.goals)
+        Task {
+            do {
+                try await HealthStoreManager.sharedManager.setupHealthKitGoals(goals: self.goals)
+            } catch {
+                // We should display an error UI
+            }
         }
     }
     

--- a/BeeSwift/GoalHealthKitConnection.swift
+++ b/BeeSwift/GoalHealthKitConnection.swift
@@ -102,7 +102,7 @@ class GoalHealthKitConnection {
     }
     
     private func runCategoryTypeQuery(dayOffset : Int) async throws {
-        logger.notice("Starting: runCategoryTypeQuery for \(self.goal.healthKitMetric ?? "nil", privacy: .public)")
+        logger.notice("Starting: runCategoryTypeQuery for \(self.goal.healthKitMetric ?? "nil", privacy: .public) offset \(dayOffset)")
 
         guard let sampleType = self.hkSampleType() else { return }
         let predicate = self.predicateForDayOffset(dayOffset: dayOffset)
@@ -124,7 +124,10 @@ class GoalHealthKitConnection {
         })
 
         let datapointValue = self.hkDatapointValueForSamples(samples: samples, units: nil)
-        if datapointValue == 0 { return }
+        if datapointValue == 0 {
+            logger.notice("Skipping: runCategoryTypeQuery for \(self.goal.healthKitMetric ?? "nil", privacy: .public) as value is 0")
+            return
+        }
 
         try await self.updateBeeminderWithValue(datapointValue: datapointValue, daystamp: daystamp)
 
@@ -325,7 +328,7 @@ class GoalHealthKitConnection {
     }
     
     private func runStatsQuery(dayOffset : Int) async throws {
-        logger.notice("Started: runStatsQuery for \(self.goal.healthKitMetric ?? "nil", privacy: .public)")
+        logger.notice("Started: runStatsQuery for \(self.goal.healthKitMetric ?? "nil", privacy: .public) offset \(dayOffset)")
 
         guard let sampleType = self.hkSampleType() else { return }
         let predicate = self.predicateForDayOffset(dayOffset: dayOffset)

--- a/BeeSwift/GoalViewController.swift
+++ b/BeeSwift/GoalViewController.swift
@@ -348,15 +348,19 @@ class GoalViewController: UIViewController, UITableViewDelegate, UITableViewData
     private func syncHealthDataButtonPressed(numDays: Int) {
         let hud = MBProgressHUD.showAdded(to: self.view, animated: true)
         hud?.mode = .indeterminate
-        HealthStoreManager.sharedManager.syncHealthKitData(goal: self.goal, days: numDays, success: {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1, execute: {
-                hud?.mode = .customView
-                hud?.customView = UIImageView(image: UIImage(named: "checkmark"))
-                hud?.hide(true, afterDelay: 2)
-            })
-        }) {
-            DispatchQueue.main.async {
-                MBProgressHUD.hideAllHUDs(for: self.view, animated: true)
+        Task {
+            do {
+                try await HealthStoreManager.sharedManager.syncHealthKitData(goal: self.goal, days: numDays)
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1, execute: {
+                    hud?.mode = .customView
+                    hud?.customView = UIImageView(image: UIImage(named: "checkmark"))
+                    hud?.hide(true, afterDelay: 2)
+                })
+            } catch {
+                // TODO: Log this error?
+                DispatchQueue.main.async {
+                    MBProgressHUD.hideAllHUDs(for: self.view, animated: true)
+                }
             }
         }
     }


### PR DESCRIPTION
This makes a number of changes to the HealthKit integration code. Most notably:
* All code directly working with HealthKit now uses async/await instead of callbacks. This makes control flow easier to follow, and fixes a number of bugs where success/failure callbacks were being called multiple times.
* Centralizes permission requesting inside HealthStoreManager
* Removes callback code from the path used by AppDelegate to increase the likelihood we successfully process background delivered events.

Test Plan:
Have launched app, and checked manual sync buttons work for a variety of goals.

Will be running a build with these changes on my device for a few days without merging to test background sync behavior.