### PR TITLE
Upgrade github actions to macos-12

### DIFF
--- a/.github/workflows/fastlane-tests.yml
+++ b/.github/workflows/fastlane-tests.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-12
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Surprisingly macos-latest does not refer to the latest available version of macOS. Upgrade explicitly to macos-12 so the latest XCode is available.