### PR TITLE
Only register with HealthKit for each goal once

### DIFF
--- a/BeeSwift/GoalHealthKitConnection.swift
+++ b/BeeSwift/GoalHealthKitConnection.swift
@@ -15,6 +15,7 @@ class GoalHealthKitConnection {
     let logger = Logger(subsystem: "com.beeminder.beeminder", category: "GoalHealthKitConnection")
     let healthStore: HKHealthStore
     let goal : JSONGoal
+    var haveRegisteredObserverQuery = false
 
     init(healthStore: HKHealthStore, goal: JSONGoal) {
         self.healthStore = healthStore
@@ -34,11 +35,17 @@ class GoalHealthKitConnection {
     }
 
     func registerObserverQuery() {
+        if haveRegisteredObserverQuery {
+            return
+        }
+
         if self.hkQuantityTypeIdentifier() != nil {
             self.setupHKStatisticsCollectionQuery()
+            haveRegisteredObserverQuery = true
         }
         else if self.hkSampleType() != nil {
             self.setupHKObserverQuery()
+            haveRegisteredObserverQuery = true
         } else {
             // big trouble
             logger.error("Failed to register query for \(self.goal.healthKitMetric ?? "nil", privacy: .public) with neither hkQuantityTypeIdentifier nor hkSampleType")

--- a/BeeSwift/HealthStoreManager.swift
+++ b/BeeSwift/HealthStoreManager.swift
@@ -8,9 +8,11 @@
 
 import Foundation
 import HealthKit
+import OSLog
 
 class HealthStoreManager :NSObject {
     static let sharedManager = HealthStoreManager()
+    let logger = Logger(subsystem: "com.beeminder.beeminder", category: "HealthStoreManager")
 
     private var healthStore : HKHealthStore?
 
@@ -29,7 +31,10 @@ class HealthStoreManager :NSObject {
             connections.removeValue(forKey: goal.id)
             return nil
         } else {
-            return connections[goal.id] ?? GoalHealthKitConnection(healthStore: healthStore!, goal: goal)
+            if connections[goal.id] == nil {
+                connections[goal.id] = GoalHealthKitConnection(healthStore: healthStore!, goal: goal)
+            }
+            return connections[goal.id]
         }
     }
 


### PR DESCRIPTION
We have a tendency to repeatedly try to register each goal with HealthKit. This results in callbacks being called many times, and us and the server doing extra work. Here each GoalHealthKitConnection checks if it has registered and avoids doing so multiple times.

This could cause issues if a goal switched metric, but that state is already very broken in the app in terms of reporting.

Test Plan:
Ran in debugger and observed log output