### PR TITLE
Support rendering in hhmm format

### DIFF
--- a/BeeSwift/GoalViewController.swift
+++ b/BeeSwift/GoalViewController.swift
@@ -615,10 +615,19 @@ class GoalViewController: UIViewController, UITableViewDelegate, UITableViewData
         let daystamp = Int(datapoint["daystamp"].string ?? "") ?? 0
         let day = daystamp != 0 ? String(format: "%02d", daystamp % 100) : "??" // Day is two least significant digits of daystamp
 
-        let value = datapoint["value"].numberValue
+        let value = datapoint["value"].double!
         let comment = datapoint["comment"].string ?? ""
 
-        return "\(day) \(value) \(comment)"
+        var formattedValue: String
+        if goal.hhmmformat {
+            let hours = Int(value)
+            let minutes = Int(value.truncatingRemainder(dividingBy: 1) * 60)
+            formattedValue = String(hours) + ":" + String(format: "%02d", minutes)
+        } else {
+            formattedValue = String(value)
+        }
+
+        return "\(day) \(formattedValue) \(comment)"
     }
     
     // MARK: - SFSafariViewControllerDelegate

--- a/BeeSwift/JSONGoal.swift
+++ b/BeeSwift/JSONGoal.swift
@@ -41,6 +41,7 @@ class JSONGoal {
     var use_defaults: NSNumber?
     var queued: Bool?
     var todayta: Bool = false
+    var hhmmformat: Bool = false
     var recent_data: Array<Any>?
     
     init(json: JSON) {
@@ -91,6 +92,7 @@ class JSONGoal {
         
         self.healthKitMetric = json["healthkitmetric"].string
         self.todayta = json["todayta"].bool!
+        self.hhmmformat = json["hhmmformat"].bool!
         
         var datapoints : Array<JSON> = json["recent_data"].arrayValue
         datapoints.reverse()


### PR DESCRIPTION
For goals which are in hhmm format we now display entries in that format on the data table on the goal page. This makes time in bed/sleep goals easier to read.

Test Plan:
Viewed fraction goals with hhmmformat enabled and disabled in the app