### PR TITLE
Refactor VersionManager to be async

### DIFF
--- a/BeeSwift/VersionManager.swift
+++ b/BeeSwift/VersionManager.swift
@@ -10,55 +10,79 @@ import Foundation
 import SwiftyJSON
 
 enum VersionError: Error {
-    case invalidResponse, invalidBundleInfo
+    case invalidAppStoreResponse, invalidBundleInfo, invalidServerResponse, noMinimumVersion
+}
+
+enum UpdateState {
+    case UpToDate, UpdateSuggested, UpdateRequired
 }
 
 class VersionManager : NSObject {
     static let sharedManager = VersionManager()
-    var minRequiredVersion : String = "1.0"
-    
-    func currentVersion() -> String? {
-        return Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+
+    private var minRequiredVersion : String = "1.0"
+    private var updateState = UpdateState.UpToDate
+
+    func lastChckedUpdateState() -> UpdateState {
+        return updateState
     }
-    
-    func updateRequired() -> Bool {
-        guard let version = VersionManager.sharedManager.currentVersion() else { return false }
-        return version.compare(VersionManager.sharedManager.minRequiredVersion, options: .numeric) == .orderedAscending
-    }
-    
-    func checkIfUpdateRequired(completion: @escaping (Bool, Error?) -> Void) {        
-        RequestManager.get(url: "api/private/app_versions.json", parameters: nil, success: { (responseJSON) in
-            guard let response = JSON(responseJSON!).dictionary else { return }
-            if let minVersion = response["min_ios"]?.number?.decimalValue,
-                let currentVersion = VersionManager.sharedManager.currentVersion() {
-                VersionManager.sharedManager.minRequiredVersion = "\(minVersion)"
-                completion(currentVersion.compare("\(minVersion)", options: .numeric) == .orderedAscending, nil)
-            }
-        }) { (responseError, responseMessage) in
-            completion(false, responseError)
+
+    func updateState() async throws -> UpdateState {
+        let currentVersion = VersionManager.sharedManager.currentVersion()
+
+        async let appStoreVersion = VersionManager.sharedManager.appStoreVersion()
+        async let updateRequired = VersionManager.sharedManager.checkIfUpdateRequired()
+
+        if try await updateRequired {
+            updateState = UpdateState.UpdateRequired
+        } else if try await currentVersion < appStoreVersion {
+            updateState = UpdateState.UpdateSuggested
+        } else {
+            updateState = UpdateState.UpToDate
         }
+
+        return updateState
+    }
+
+    private func currentVersion() -> String {
+        return Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as! String
     }
     
-    func appStoreVersion(completion: @escaping (String?, Error?) -> Void) throws -> URLSessionDataTask {
+    private func checkIfUpdateRequired() async throws -> Bool {
+        let responseJSON = try await withCheckedThrowingContinuation { continuation in
+            RequestManager.get(url: "api/private/app_versions.json",
+                               parameters: nil,
+                               success: { responseJSON in continuation.resume(returning: responseJSON) },
+                               errorHandler: { (responseError, responseMessage) in continuation.resume(throwing: responseError!) }
+                               )
+        }
+
+        guard let response = JSON(responseJSON!).dictionary else {
+            throw VersionError.invalidServerResponse
+        }
+        guard let minVersion = response["min_ios"]?.number?.decimalValue else {
+            throw VersionError.noMinimumVersion
+        }
+        VersionManager.sharedManager.minRequiredVersion = "\(minVersion)"
+
+        let currentVersion = VersionManager.sharedManager.currentVersion()
+        return currentVersion.compare("\(minVersion)", options: .numeric) == .orderedAscending
+    }
+    
+    private func appStoreVersion() async throws -> String {
         guard let info = Bundle.main.infoDictionary,
             let identifier = info["CFBundleIdentifier"] as? String,
             let url = URL(string: "https://itunes.apple.com/lookup?bundleId=\(identifier)") else {
                 throw VersionError.invalidBundleInfo
         }
-        let task = URLSession.shared.dataTask(with: url) { (data, response, error) in
-            do {
-                if let error = error { throw error }
-                guard let data = data else { throw VersionError.invalidResponse }
-                let json = try JSONSerialization.jsonObject(with: data, options: [.allowFragments]) as? [String: Any]
-                guard let result = (json?["results"] as? [Any])?.first as? [String: Any], let version = result["version"] as? String else {
-                    throw VersionError.invalidResponse
-                }
-                completion(version, nil)
-            } catch {
-                completion(nil, error)
-            }
+
+        let (data, _) = try await URLSession.shared.data(from: url)
+
+        let json = try JSONSerialization.jsonObject(with: data, options: [.allowFragments]) as? [String: Any]
+        guard let result = (json?["results"] as? [Any])?.first as? [String: Any], let version = result["version"] as? String else {
+            throw VersionError.invalidAppStoreResponse
         }
-        task.resume()
-        return task
+
+        return version
     }
 }


### PR DESCRIPTION
This changes the VersionManager (which compares the current app version to the latest available and supported) to expose an async rather than a callback based interface. It also somewhat simplifies the interface, with the manager now responsible for returning an enum, rather than clients having to do version comparisons.

Test Plan:
* Ran the app in the simulator
* Patched the VersionManager to return different values and checked the UI rendered correctly