### PR TITLE
Convert RequestManager to use async/await

### DIFF
--- a/BeeSwift/AddDataIntentHandler.swift
+++ b/BeeSwift/AddDataIntentHandler.swift
@@ -48,11 +48,14 @@ class AddDataIntentHandler: NSObject, AddDataIntentHandling {
             return
         }
         let comment = intent.comment ?? ""
-                
-        RequestManager.addDatapoint(urtext: "^ \(value) \"\(comment)\"", slug: goalSlug) { (response) in
-            completion(AddDataIntentResponse.success(goal: goalSlug))
-        } errorHandler: { (error, errorMessage) in
-            completion(AddDataIntentResponse.failure(goal: goalSlug))
+
+        Task {
+            do {
+                let _ = try await RequestManager.addDatapoint(urtext: "^ \(value) \"\(comment)\"", slug: goalSlug)
+                completion(AddDataIntentResponse.success(goal: goalSlug))
+            } catch {
+                completion(AddDataIntentResponse.failure(goal: goalSlug))
+            }
         }
     }
 }

--- a/BeeSwift/AppDelegate.swift
+++ b/BeeSwift/AppDelegate.swift
@@ -81,7 +81,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     func applicationDidBecomeActive(_ application: UIApplication) {
         logger.notice("applicationDidBecomeActive")
         // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
-        CurrentUserManager.sharedManager.fetchGoals(success: nil, error: nil)
+        CurrentUserManager.sharedManager.fetchGoals(success: nil, errorHandler: nil)
     }
 
     func applicationWillTerminate(_ application: UIApplication) {
@@ -131,12 +131,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     
     func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
         logger.notice("application:didRegisterForRemoteNotificationsWithDeviceToken")
-        let token = deviceToken.reduce("", {$0 + String(format: "%02X", $1)})
+        Task {
+            let token = deviceToken.reduce("", {$0 + String(format: "%02X", $1)})
 
-        SignedRequestManager.signedPOST(url: "/api/private/device_tokens", parameters: ["device_token" : token], success: { (responseObject) -> Void in
-            //foo
-        }) { (error, errorMessage) -> Void in
-            //bar
+            do {
+                let _ = try await SignedRequestManager.signedPOST(url: "/api/private/device_tokens", parameters: ["device_token" : token])
+            } catch {
+                // TODO: Log error
+            }
         }
     }
 

--- a/BeeSwift/AppDelegate.swift
+++ b/BeeSwift/AppDelegate.swift
@@ -137,7 +137,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             do {
                 let _ = try await SignedRequestManager.signedPOST(url: "/api/private/device_tokens", parameters: ["device_token" : token])
             } catch {
-                // TODO: Log error
+                logger.error("Error sending device push token: \(error)")
             }
         }
     }

--- a/BeeSwift/ChooseHKMetricViewController.swift
+++ b/BeeSwift/ChooseHKMetricViewController.swift
@@ -108,22 +108,24 @@ class ChooseHKMetricViewController: UIViewController {
             
             var params : [String : [String : String]] = [:]
             params = ["ii_params" : ["name" : "apple", "metric" : self.goal!.healthKitMetric!]]
-            
-            RequestManager.put(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.goal!.slug).json", parameters: params, success: { (responseObject) -> Void in
-                hud?.mode = .customView
-                hud?.customView = UIImageView(image: UIImage(named: "checkmark"))
-                hud?.hide(true, afterDelay: 2)
+
+            do {
+                let _ = try await RequestManager.put(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.goal!.slug).json", parameters: params)
+                DispatchQueue.main.sync {
+                    hud?.mode = .customView
+                    hud?.customView = UIImageView(image: UIImage(named: "checkmark"))
+                    hud?.hide(true, afterDelay: 2)
+                }
                 DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
                     self.navigationController?.popViewController(animated: true)
                 }
-            }) { (responseError, errorMessage) -> Void in
+            } catch {
                 self.tableView.reloadData()
-                if let errorString = responseError?.localizedDescription {
-                    MBProgressHUD.hideAllHUDs(for: self.view, animated: true)
-                    let alert = UIAlertController(title: "Error saving metric to Beeminder", message: errorString, preferredStyle: .alert)
-                    alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
-                    self.present(alert, animated: true, completion: nil)
-                }
+                let errorString = error.localizedDescription
+                MBProgressHUD.hideAllHUDs(for: self.view, animated: true)
+                let alert = UIAlertController(title: "Error saving metric to Beeminder", message: errorString, preferredStyle: .alert)
+                alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
+                self.present(alert, animated: true, completion: nil)
             }
         }
     }

--- a/BeeSwift/ChooseHKMetricViewController.swift
+++ b/BeeSwift/ChooseHKMetricViewController.swift
@@ -111,7 +111,7 @@ class ChooseHKMetricViewController: UIViewController {
 
             do {
                 let _ = try await RequestManager.put(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.goal!.slug).json", parameters: params)
-                DispatchQueue.main.sync {
+                DispatchQueue.main.async {
                     hud?.mode = .customView
                     hud?.customView = UIImageView(image: UIImage(named: "checkmark"))
                     hud?.hide(true, afterDelay: 2)

--- a/BeeSwift/CurrentUserManager.swift
+++ b/BeeSwift/CurrentUserManager.swift
@@ -221,7 +221,7 @@ class CurrentUserManager : NSObject {
                 self.updateTodayWidget()
                 self.goalsFetchedAt = Date()
                 self.setCachedLastFetchedGoals(response)
-                DispatchQueue.main.sync {
+                DispatchQueue.main.async {
                     NotificationCenter.default.post(name: Notification.Name(rawValue: CurrentUserManager.goalsFetchedNotificationName), object: self)
 
                     // Callback success on main thread. This is not in our contract, but callers assuming this

--- a/BeeSwift/CurrentUserManager.swift
+++ b/BeeSwift/CurrentUserManager.swift
@@ -153,7 +153,7 @@ class CurrentUserManager : NSObject {
                 self.handleSuccessfulSignin(JSON(response!))
             } catch {
 
-                self.handleFailedSignin(error, errorMessage: "TODO: Get Error Message")
+                self.handleFailedSignin(error, errorMessage: error.localizedDescription)
             }
         }
     }
@@ -229,8 +229,7 @@ class CurrentUserManager : NSObject {
                     success?(jGoals)
                 }
             } catch {
-                errorHandler?(error, "TODO: Provide error message")
-                return
+                errorHandler?(error, error.localizedDescription)
             }
         }
 

--- a/BeeSwift/CurrentUserManager.swift
+++ b/BeeSwift/CurrentUserManager.swift
@@ -221,9 +221,13 @@ class CurrentUserManager : NSObject {
                 self.updateTodayWidget()
                 self.goalsFetchedAt = Date()
                 self.setCachedLastFetchedGoals(response)
-                NotificationCenter.default.post(name: Notification.Name(rawValue: CurrentUserManager.goalsFetchedNotificationName), object: self)
+                DispatchQueue.main.sync {
+                    NotificationCenter.default.post(name: Notification.Name(rawValue: CurrentUserManager.goalsFetchedNotificationName), object: self)
 
-                success?(jGoals)
+                    // Callback success on main thread. This is not in our contract, but callers assuming this
+                    // appear to have worked before
+                    success?(jGoals)
+                }
             } catch {
                 errorHandler?(error, "TODO: Provide error message")
                 return

--- a/BeeSwift/EditDatapointViewController.swift
+++ b/BeeSwift/EditDatapointViewController.swift
@@ -183,18 +183,26 @@ class EditDatapointViewController: UIViewController, UITextFieldDelegate {
         self.view.endEditing(true)
         let hud = MBProgressHUD.showAdded(to: self.view, animated: true)
         hud?.mode = .indeterminate
-        let params = [
-            "access_token": CurrentUserManager.sharedManager.accessToken!,
-            "urtext": self.urtext()
-        ]
-        RequestManager.put(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.goalSlug!)/datapoints/\(self.datapointJSON!["id"]["$oid"].string!).json", parameters: params, success: { (response) in
-            let hud = MBProgressHUD.allHUDs(for: self.view).first as? MBProgressHUD
-            hud?.mode = .customView
-            hud?.customView = UIImageView(image: UIImage(named: "checkmark"))
-            hud?.hide(true, afterDelay: 2)
-        }) { (error, errorMessage) in
-            MBProgressHUD.hideAllHUDs(for: self.view, animated: true)
-            // alert
+
+        Task {
+            do {
+                let params = [
+                    "access_token": CurrentUserManager.sharedManager.accessToken!,
+                    "urtext": self.urtext()
+                ]
+                let _ = try await RequestManager.put(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.goalSlug!)/datapoints/\(self.datapointJSON!["id"]["$oid"].string!).json", parameters: params)
+                DispatchQueue.main.sync {
+                    let hud = MBProgressHUD.allHUDs(for: self.view).first as? MBProgressHUD
+                    hud?.mode = .customView
+                    hud?.customView = UIImageView(image: UIImage(named: "checkmark"))
+                    hud?.hide(true, afterDelay: 2)
+                }
+            } catch {
+                // TODO: Log error
+                DispatchQueue.main.sync {
+                    let _ = MBProgressHUD.hideAllHUDs(for: self.view, animated: true)
+                }
+            }
         }
     }
     
@@ -204,16 +212,23 @@ class EditDatapointViewController: UIViewController, UITextFieldDelegate {
         ]
         let hud = MBProgressHUD.showAdded(to: self.view, animated: true)
         hud?.mode = .indeterminate
-        RequestManager.delete(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.goalSlug!)/datapoints/\(self.datapointJSON!["id"]["$oid"].string!).json", parameters: params, success: { (response) in
-            let hud = MBProgressHUD.allHUDs(for: self.view).first as? MBProgressHUD
-            hud?.mode = .customView
-            hud?.customView = UIImageView(image: UIImage(named: "checkmark"))
-            hud?.hide(true, afterDelay: 2)
-            DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-                self.navigationController?.popViewController(animated: true)
+
+        Task {
+            do {
+                let _ = try await RequestManager.delete(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.goalSlug!)/datapoints/\(self.datapointJSON!["id"]["$oid"].string!).json", parameters: params)
+
+                DispatchQueue.main.sync {
+                    let hud = MBProgressHUD.allHUDs(for: self.view).first as? MBProgressHUD
+                    hud?.mode = .customView
+                    hud?.customView = UIImageView(image: UIImage(named: "checkmark"))
+                    hud?.hide(true, afterDelay: 2)
+                }
+                DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                    self.navigationController?.popViewController(animated: true)
+                }
+            } catch {
+                // TODO: Log error
             }
-        }) { (error, errorMessage) in
-            //
         }
     }
     

--- a/BeeSwift/EditDatapointViewController.swift
+++ b/BeeSwift/EditDatapointViewController.swift
@@ -191,7 +191,7 @@ class EditDatapointViewController: UIViewController, UITextFieldDelegate {
                     "urtext": self.urtext()
                 ]
                 let _ = try await RequestManager.put(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.goalSlug!)/datapoints/\(self.datapointJSON!["id"]["$oid"].string!).json", parameters: params)
-                DispatchQueue.main.sync {
+                DispatchQueue.main.async {
                     let hud = MBProgressHUD.allHUDs(for: self.view).first as? MBProgressHUD
                     hud?.mode = .customView
                     hud?.customView = UIImageView(image: UIImage(named: "checkmark"))
@@ -199,7 +199,7 @@ class EditDatapointViewController: UIViewController, UITextFieldDelegate {
                 }
             } catch {
                 // TODO: Log error
-                DispatchQueue.main.sync {
+                DispatchQueue.main.async {
                     let _ = MBProgressHUD.hideAllHUDs(for: self.view, animated: true)
                 }
             }
@@ -217,7 +217,7 @@ class EditDatapointViewController: UIViewController, UITextFieldDelegate {
             do {
                 let _ = try await RequestManager.delete(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.goalSlug!)/datapoints/\(self.datapointJSON!["id"]["$oid"].string!).json", parameters: params)
 
-                DispatchQueue.main.sync {
+                DispatchQueue.main.async {
                     let hud = MBProgressHUD.allHUDs(for: self.view).first as? MBProgressHUD
                     hud?.mode = .customView
                     hud?.customView = UIImageView(image: UIImage(named: "checkmark"))

--- a/BeeSwift/EditDatapointViewController.swift
+++ b/BeeSwift/EditDatapointViewController.swift
@@ -9,8 +9,10 @@
 import UIKit
 import SwiftyJSON
 import MBProgressHUD
+import OSLog
 
 class EditDatapointViewController: UIViewController, UITextFieldDelegate {
+    private let logger = Logger(subsystem: "com.beeminder.beeminder", category: "EditDatapointViewController")
     
     var datapointJSON : JSON?
     var goalSlug : String?
@@ -198,7 +200,7 @@ class EditDatapointViewController: UIViewController, UITextFieldDelegate {
                     hud?.hide(true, afterDelay: 2)
                 }
             } catch {
-                // TODO: Log error
+                logger.error("Error updating datapoint for goal \(self.goalSlug ?? "<nil>"): \(error)")
                 DispatchQueue.main.async {
                     let _ = MBProgressHUD.hideAllHUDs(for: self.view, animated: true)
                 }
@@ -227,7 +229,8 @@ class EditDatapointViewController: UIViewController, UITextFieldDelegate {
                     self.navigationController?.popViewController(animated: true)
                 }
             } catch {
-                // TODO: Log error
+                logger.error("Error deleting datapoint for goal \(self.goalSlug ?? "<nil>"): \(error)")
+
             }
         }
     }

--- a/BeeSwift/EditDefaultNotificationsViewController.swift
+++ b/BeeSwift/EditDefaultNotificationsViewController.swift
@@ -22,14 +22,17 @@ class EditDefaultNotificationsViewController: EditNotificationsViewController {
     }
     
     override func sendLeadTimeToServer(_ timer : Timer) {
-        let userInfo = timer.userInfo! as! Dictionary<String, NSNumber>
-        guard let leadtime = userInfo["leadtime"] else { return }
-        let params = [ "default_leadtime" : leadtime ]
-        RequestManager.put(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!).json", parameters: params,
-            success: { (responseObject) -> Void in
+        Task {
+            let userInfo = timer.userInfo! as! Dictionary<String, NSNumber>
+            guard let leadtime = userInfo["leadtime"] else { return }
+            let params = [ "default_leadtime" : leadtime ]
+            do {
+                let _ = try await RequestManager.put(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!).json", parameters: params)
                 CurrentUserManager.sharedManager.setDefaultLeadTime(leadtime)
-            }) { (error, errorMessage) -> Void in
+            } catch {
+                // TODO: Logging
                 // show alert
+            }
         }
     }
     
@@ -42,21 +45,27 @@ class EditDefaultNotificationsViewController: EditNotificationsViewController {
         if self.timePickerEditingMode == .alertstart {
             self.updateAlertstartLabel(self.midnightOffsetFromTimePickerView())
             let params = ["default_alertstart" : self.midnightOffsetFromTimePickerView()]
-            RequestManager.put(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!).json", parameters: params,
-                success: { (responseObject) -> Void in
+            Task {
+                do {
+                    let _ = try await RequestManager.put(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!).json", parameters: params)
                     CurrentUserManager.sharedManager.setDefaultAlertstart(self.midnightOffsetFromTimePickerView())
-                }) { (error, errorMessage) -> Void in
+                } catch {
+                    // TODO: Log error
                     //foo
+                }
             }
         }
         if self.timePickerEditingMode == .deadline {
             self.updateDeadlineLabel(self.midnightOffsetFromTimePickerView())
             let params = ["default_deadline" : self.midnightOffsetFromTimePickerView()]
-            RequestManager.put(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!).json", parameters: params,
-                success: { (responseObject) -> Void in
+            Task {
+                do {
+                    let _ = try await RequestManager.put(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!).json", parameters: params)
                     CurrentUserManager.sharedManager.setDefaultDeadline(self.midnightOffsetFromTimePickerView())
-                }) { (error, errorMessage) -> Void in
+                } catch {
+                    // TODO: Log error
                     //foo
+                }
             }
         }
     }

--- a/BeeSwift/EditDefaultNotificationsViewController.swift
+++ b/BeeSwift/EditDefaultNotificationsViewController.swift
@@ -7,8 +7,10 @@
 //
 
 import Foundation
+import OSLog
 
 class EditDefaultNotificationsViewController: EditNotificationsViewController {
+    private let logger = Logger(subsystem: "com.beeminder.beeminder", category: "EditDefaultNotificationsViewController")
     
     override init() {
         super.init()
@@ -30,7 +32,7 @@ class EditDefaultNotificationsViewController: EditNotificationsViewController {
                 let _ = try await RequestManager.put(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!).json", parameters: params)
                 CurrentUserManager.sharedManager.setDefaultLeadTime(leadtime)
             } catch {
-                // TODO: Logging
+                logger.error("Error setting default leadtime: \(error)")
                 // show alert
             }
         }
@@ -50,7 +52,7 @@ class EditDefaultNotificationsViewController: EditNotificationsViewController {
                     let _ = try await RequestManager.put(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!).json", parameters: params)
                     CurrentUserManager.sharedManager.setDefaultAlertstart(self.midnightOffsetFromTimePickerView())
                 } catch {
-                    // TODO: Log error
+                    logger.error("Error setting default alert start: \(error)")
                     //foo
                 }
             }
@@ -63,7 +65,7 @@ class EditDefaultNotificationsViewController: EditNotificationsViewController {
                     let _ = try await RequestManager.put(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!).json", parameters: params)
                     CurrentUserManager.sharedManager.setDefaultDeadline(self.midnightOffsetFromTimePickerView())
                 } catch {
-                    // TODO: Log error
+                    logger.error("Error setting default deadline: \(error)")
                     //foo
                 }
             }

--- a/BeeSwift/EditGoalNotificationsViewController.swift
+++ b/BeeSwift/EditGoalNotificationsViewController.swift
@@ -8,8 +8,11 @@
 
 import Foundation
 import UIKit
+import OSLog
 
 class EditGoalNotificationsViewController : EditNotificationsViewController {
+    private let logger = Logger(subsystem: "com.beeminder.beeminder", category: "EditGoalNotificationsViewController")
+
     var goal : JSONGoal? {
         didSet {
 
@@ -69,7 +72,7 @@ class EditGoalNotificationsViewController : EditNotificationsViewController {
                     self.useDefaultsSwitch.isOn = false
                 }
             } catch {
-                // TODO: Log error
+                logger.error("Error sending lead time to server: \(error)")
                 // show alert
             }
         }
@@ -88,7 +91,7 @@ class EditGoalNotificationsViewController : EditNotificationsViewController {
                         self.useDefaultsSwitch.isOn = false
                     }
                 } catch {
-                    // TODO: Log failure
+                    logger.error("Error setting alert start \(error)")
                     //foo
                 }
             }
@@ -139,11 +142,11 @@ class EditGoalNotificationsViewController : EditNotificationsViewController {
                                 self.timePickerEditingMode = self.timePickerEditingMode // trigger the setter which updates the timePicker components
                             }
                         }) {
-                            // TODO: Log failure
+                            self.logger.error("Error syncing notification defaults")
                             // foo
                         }
                     } catch {
-                        // TODO: Log failure
+                        self.logger.error("Error setting goal to use defaults: \(error)")
                         // foo
                     }
                 }
@@ -160,7 +163,7 @@ class EditGoalNotificationsViewController : EditNotificationsViewController {
                     let _ = try await RequestManager.put(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.goal!.slug).json", parameters: params)
                         self.goal?.use_defaults = NSNumber(value: false as Bool)
                 } catch {
-                    // TODO: Log error
+                    logger.error("Error setting goal to NOT use defaults: \(error)")
                     // foo
                 }
             }

--- a/BeeSwift/EditGoalNotificationsViewController.swift
+++ b/BeeSwift/EditGoalNotificationsViewController.swift
@@ -63,7 +63,7 @@ class EditGoalNotificationsViewController : EditNotificationsViewController {
             let params = [ "leadtime" : leadtime, "use_defaults" : false ]
             do {
                 let _ = try await RequestManager.put(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.goal!.slug).json", parameters: params as [String : Any])
-                DispatchQueue.main.sync {
+                DispatchQueue.main.async {
                     self.goal!.leadtime = leadtime!
                     self.goal!.use_defaults = NSNumber(value: false as Bool)
                     self.useDefaultsSwitch.isOn = false
@@ -82,7 +82,7 @@ class EditGoalNotificationsViewController : EditNotificationsViewController {
                 do {
                     let params = ["alertstart" : self.midnightOffsetFromTimePickerView(), "use_defaults" : false]
                     let _ = try await RequestManager.put(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.goal!.slug).json", parameters: params)
-                    DispatchQueue.main.sync {
+                    DispatchQueue.main.async {
                         self.goal!.alertstart = self.midnightOffsetFromTimePickerView()
                         self.goal!.use_defaults = NSNumber(value: false as Bool)
                         self.useDefaultsSwitch.isOn = false
@@ -99,14 +99,14 @@ class EditGoalNotificationsViewController : EditNotificationsViewController {
                 do {
                     let params = ["deadline" : self.midnightOffsetFromTimePickerView(), "use_defaults" : false]
                     let _ = try await RequestManager.put(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.goal!.slug).json", parameters: params)
-                    DispatchQueue.main.sync {
+                    DispatchQueue.main.async {
                         self.goal?.deadline = self.midnightOffsetFromTimePickerView()
                         self.goal!.use_defaults = NSNumber(value: false as Bool)
                         self.useDefaultsSwitch.isOn = false
                     }
                 } catch {
                     let errorString = error.localizedDescription
-                    DispatchQueue.main.sync {
+                    DispatchQueue.main.async {
                         MBProgressHUD.hideAllHUDs(for: self.view, animated: true)
                         let alert = UIAlertController(title: "Error saving to Beeminder", message: errorString, preferredStyle: .alert)
                         alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
@@ -128,7 +128,7 @@ class EditGoalNotificationsViewController : EditNotificationsViewController {
                         let _ = try await RequestManager.put(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.goal!.slug).json", parameters: params)
                         self.goal?.use_defaults = NSNumber(value: true as Bool)
                         CurrentUserManager.sharedManager.syncNotificationDefaults({
-                            DispatchQueue.main.sync {
+                            DispatchQueue.main.async {
                                 self.leadTimeStepper.value = CurrentUserManager.sharedManager.defaultLeadTime().doubleValue
                                 self.updateLeadTimeLabel()
                                 self.alertstart = CurrentUserManager.sharedManager.defaultAlertstart()

--- a/BeeSwift/GoalViewController.swift
+++ b/BeeSwift/GoalViewController.swift
@@ -579,7 +579,7 @@ class GoalViewController: UIViewController, UITableViewDelegate, UITableViewData
                     }
                 }
             } catch {
-                // TODO: Log failure
+                logger.error("Error refreshing details for goal \(self.goal.slug): \(error)")
                 // foo
             }
         }

--- a/BeeSwift/GoalViewController.swift
+++ b/BeeSwift/GoalViewController.swift
@@ -420,7 +420,7 @@ class GoalViewController: UIViewController, UITableViewDelegate, UITableViewData
                 let _ = try await RequestManager.get(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.goal.slug)/refresh_graph.json", parameters: nil)
                 self.pollUntilGraphUpdates()
             } catch {
-                DispatchQueue.main.sync {
+                DispatchQueue.main.async {
                     let alert = UIAlertController(title: "Error", message: "Could not refresh graph", preferredStyle: .alert)
                     alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
                     self.present(alert, animated: true, completion: nil)
@@ -533,7 +533,7 @@ class GoalViewController: UIViewController, UITableViewDelegate, UITableViewData
         Task {
             do {
                 let _ = try await RequestManager.addDatapoint(urtext: self.urtextFromTextFields(), slug: self.goal.slug)
-                DispatchQueue.main.sync {
+                DispatchQueue.main.async {
                     self.commentTextField.text = ""
                     self.refreshGoal()
                     self.pollUntilGraphUpdates()
@@ -541,7 +541,7 @@ class GoalViewController: UIViewController, UITableViewDelegate, UITableViewData
                     CurrentUserManager.sharedManager.fetchGoals(success: nil, errorHandler: nil)
                 }
             } catch {
-                DispatchQueue.main.sync {
+                DispatchQueue.main.async {
                     self.submitButton.isUserInteractionEnabled = true
                     MBProgressHUD.hideAllHUDs(for: self.view, animated: true)
                     let alertController = UIAlertController(title: "Error", message: "Failed to add datapoint", preferredStyle: .alert)
@@ -564,7 +564,7 @@ class GoalViewController: UIViewController, UITableViewDelegate, UITableViewData
         Task {
             do {
                 let responseObject = try await RequestManager.get(url: "/api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.goal.slug)?access_token=\(CurrentUserManager.sharedManager.accessToken!)&datapoints_count=5", parameters: nil)
-                DispatchQueue.main.sync {
+                DispatchQueue.main.async {
                     self.goal = JSONGoal(json: JSON(responseObject!))
                     self.datapointsTableView.reloadData()
                     self.refreshCountdown()

--- a/BeeSwift/GoalViewController.swift
+++ b/BeeSwift/GoalViewController.swift
@@ -414,13 +414,18 @@ class GoalViewController: UIViewController, UITableViewDelegate, UITableViewData
     @objc func refreshButtonPressed() {
         self.scrollView.refreshControl?.endRefreshing()
         MBProgressHUD.showAdded(to: self.view, animated: true)?.mode = .indeterminate
-        
-        RequestManager.get(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.goal.slug)/refresh_graph.json", parameters: nil, success: { (responseObject) in
-            self.pollUntilGraphUpdates()
-        }) { (error, errorMessage) in
-            let alert = UIAlertController(title: "Error", message: "Could not refresh graph", preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
-            self.present(alert, animated: true, completion: nil)
+
+        Task {
+            do {
+                let _ = try await RequestManager.get(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.goal.slug)/refresh_graph.json", parameters: nil)
+                self.pollUntilGraphUpdates()
+            } catch {
+                DispatchQueue.main.sync {
+                    let alert = UIAlertController(title: "Error", message: "Could not refresh graph", preferredStyle: .alert)
+                    alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
+                    self.present(alert, animated: true, completion: nil)
+                }
+            }
         }
     }
     
@@ -525,18 +530,25 @@ class GoalViewController: UIViewController, UITableViewDelegate, UITableViewData
         self.submitButton.isUserInteractionEnabled = false
         self.scrollView.scrollRectToVisible(CGRect(x: 0, y: 0, width: 0, height: 0), animated: true)
 
-        RequestManager.addDatapoint(urtext: self.urtextFromTextFields(), slug: self.goal.slug) { (responseObject) in
-            self.commentTextField.text = ""
-            self.refreshGoal()
-            self.pollUntilGraphUpdates()
-            self.submitButton.isUserInteractionEnabled = true
-            CurrentUserManager.sharedManager.fetchGoals(success: nil, error: nil)
-        } errorHandler: { (error, errorMessage) in
-            self.submitButton.isUserInteractionEnabled = true
-            MBProgressHUD.hideAllHUDs(for: self.view, animated: true)
-            let alertController = UIAlertController(title: "Error", message: "Failed to add datapoint", preferredStyle: .alert)
-            alertController.addAction(UIAlertAction(title: "OK", style: .cancel))
-            self.present(alertController, animated: true)
+        Task {
+            do {
+                let _ = try await RequestManager.addDatapoint(urtext: self.urtextFromTextFields(), slug: self.goal.slug)
+                DispatchQueue.main.sync {
+                    self.commentTextField.text = ""
+                    self.refreshGoal()
+                    self.pollUntilGraphUpdates()
+                    self.submitButton.isUserInteractionEnabled = true
+                    CurrentUserManager.sharedManager.fetchGoals(success: nil, errorHandler: nil)
+                }
+            } catch {
+                DispatchQueue.main.sync {
+                    self.submitButton.isUserInteractionEnabled = true
+                    MBProgressHUD.hideAllHUDs(for: self.view, animated: true)
+                    let alertController = UIAlertController(title: "Error", message: "Failed to add datapoint", preferredStyle: .alert)
+                    alertController.addAction(UIAlertAction(title: "OK", style: .cancel))
+                    self.present(alertController, animated: true)
+                }
+            }
         }
     }
     
@@ -549,21 +561,27 @@ class GoalViewController: UIViewController, UITableViewDelegate, UITableViewData
     }
     
     @objc func refreshGoal() {
-        RequestManager.get(url: "/api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.goal.slug)?access_token=\(CurrentUserManager.sharedManager.accessToken!)&datapoints_count=5", parameters: nil, success: { (responseObject) in
-            self.goal = JSONGoal(json: JSON(responseObject!))
-            self.datapointsTableView.reloadData()
-            self.refreshCountdown()
-            self.setValueTextField()
-            self.valueTextFieldValueChanged()
-            self.deltasLabel.attributedText = self.goal!.attributedDeltaText
-            if (!self.goal.queued!) {
-                self.setGraphImage()
-                MBProgressHUD.hideAllHUDs(for: self.view, animated: true)
-                self.pollTimer?.invalidate()
-                self.pollTimer = nil
+        Task {
+            do {
+                let responseObject = try await RequestManager.get(url: "/api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.goal.slug)?access_token=\(CurrentUserManager.sharedManager.accessToken!)&datapoints_count=5", parameters: nil)
+                DispatchQueue.main.sync {
+                    self.goal = JSONGoal(json: JSON(responseObject!))
+                    self.datapointsTableView.reloadData()
+                    self.refreshCountdown()
+                    self.setValueTextField()
+                    self.valueTextFieldValueChanged()
+                    self.deltasLabel.attributedText = self.goal!.attributedDeltaText
+                    if (!self.goal.queued!) {
+                        self.setGraphImage()
+                        MBProgressHUD.hideAllHUDs(for: self.view, animated: true)
+                        self.pollTimer?.invalidate()
+                        self.pollTimer = nil
+                    }
+                }
+            } catch {
+                // TODO: Log failure
+                // foo
             }
-        }) { (error, errorMessage) in
-            // foo
         }
     }
     

--- a/BeeSwift/JSONGoal.swift
+++ b/BeeSwift/JSONGoal.swift
@@ -9,11 +9,14 @@
 import Foundation
 import SwiftyJSON
 import HealthKit
+import OSLog
 import UserNotifications
 
 typealias DataPoint = (daystamp: String, value: Double, comment: String)
 
 class JSONGoal {
+    private let logger = Logger(subsystem: "com.beeminder.beeminder", category: "JSONGoal")
+
     var autodata: String = ""
     var delta_text: String = ""
     var graph_url: String?
@@ -349,7 +352,7 @@ class JSONGoal {
             do {
                 let _ = try await RequestManager.delete(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.slug)/datapoints/\(datapointID!)", parameters: nil)
             } catch {
-                // TODO: Log error
+                logger.error("Error deleting datapoint: \(error)")
             }
         }
     }
@@ -360,7 +363,7 @@ class JSONGoal {
                 let response = try await RequestManager.post(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.slug)/datapoints.json", parameters: params)
                 success?(response)
             } catch {
-                failure?(error, "TODO: Error Message")
+                failure?(error, error.localizedDescription)
             }
         }
     }

--- a/BeeSwift/RemoveHKMetricViewController.swift
+++ b/BeeSwift/RemoveHKMetricViewController.swift
@@ -8,8 +8,10 @@
 
 import UIKit
 import SwiftyJSON
+import OSLog
 
 class RemoveHKMetricViewController: UIViewController {
+    private let logger = Logger(subsystem: "com.beeminder.beeminder", category: "RemoveHKMetricViewController")
     
     var goal : JSONGoal!
     
@@ -87,7 +89,7 @@ class RemoveHKMetricViewController: UIViewController {
                     self.navigationController?.popViewController(animated: true)
                 })
             } catch {
-                // TODO: Log error
+                logger.error("Error disconnecting metric from apple heath: \(error)")
                 // bar
             }
         }

--- a/BeeSwift/RemoveHKMetricViewController.swift
+++ b/BeeSwift/RemoveHKMetricViewController.swift
@@ -75,7 +75,7 @@ class RemoveHKMetricViewController: UIViewController {
 
                 self.goal = JSONGoal(json: JSON(responseObject!))
 
-                DispatchQueue.main.sync {
+                DispatchQueue.main.async {
                     hud?.mode = .customView
                     hud?.customView = UIImageView(image: UIImage(named: "checkmark"))
 

--- a/BeeSwift/RequestManager.swift
+++ b/BeeSwift/RequestManager.swift
@@ -31,7 +31,10 @@ class RequestManager {
     private static let logger = Logger(subsystem: "com.beeminder.beeminder", category: "RequestManager")
     
     class func rawRequest(url: String, method: HTTPMethod, parameters: [String: Any]?) async throws -> Any? {
-        let response = await AF.request("\(RequestManager.baseURLString)/\(url)", method: method, parameters: parameters, encoding: URLEncoding.default, headers: HTTPHeaders.default).validate().serializingData().response
+        let response = await AF.request("\(RequestManager.baseURLString)/\(url)", method: method, parameters: parameters, encoding: URLEncoding.default, headers: HTTPHeaders.default)
+            .validate()
+            .serializingData(emptyRequestMethods: [HTTPMethod.post])
+            .response
 
         switch response.result {
         case .success(let data):

--- a/BeeSwift/RequestManager.swift
+++ b/BeeSwift/RequestManager.swift
@@ -14,71 +14,73 @@ import BeeKit
 class RequestManager {
     static let baseURLString = Config.init().baseURLString
     
-    class func rawRequest(url: String, method: HTTPMethod, parameters: [String: Any]?, success: ((Any?) -> Void)?, errorHandler: ((Error?, String?) -> Void)?) {
-        AF.request("\(RequestManager.baseURLString)/\(url)", method: method, parameters: parameters, encoding: URLEncoding.default, headers: HTTPHeaders.default).validate().response { response in
-            switch response.result {
-            case .success(let data):
-                let asJSON = data.flatMap{d in try? JSONSerialization.jsonObject(with: d)}
-                success?(asJSON)
-            case .failure(let error):
-                switch error {
-                case .responseValidationFailed(let reason):
-                    print(reason)
-                    switch reason {
-                    case .dataFileNil, .dataFileReadFailed:
-                        print("Downloaded file could not be read")
-                    case .missingContentType(let acceptableContentTypes):
-                        print("Content Type Missing: \(acceptableContentTypes)")
-                    case .unacceptableContentType(let acceptableContentTypes, let responseContentType):
-                        print("Response content type: \(responseContentType) was unacceptable: \(acceptableContentTypes)")
-                    case .unacceptableStatusCode(let code):
-                        if code == 401 {
-                            CurrentUserManager.sharedManager.signOut()
-                        }
-                        print("Response status code was unacceptable: \(code)")
-                    case .customValidationFailed(let error):
-                        print("Custom validation failed: \(error)")
-                    @unknown default:
-                        print(reason)
-                        break
+    class func rawRequest(url: String, method: HTTPMethod, parameters: [String: Any]?) async throws -> Any? {
+        let response = await AF.request("\(RequestManager.baseURLString)/\(url)", method: method, parameters: parameters, encoding: URLEncoding.default, headers: HTTPHeaders.default).serializingData().response
+
+        switch response.result {
+        case .success(let data):
+            let asJSON = try? JSONSerialization.jsonObject(with: data)
+            return asJSON
+
+        case .failure(let error):
+            // TODO: Extract any server error message and throw
+            switch error {
+            case .responseValidationFailed(let reason):
+                print(reason)
+                switch reason {
+                case .dataFileNil, .dataFileReadFailed:
+                    print("Downloaded file could not be read")
+                case .missingContentType(let acceptableContentTypes):
+                    print("Content Type Missing: \(acceptableContentTypes)")
+                case .unacceptableContentType(let acceptableContentTypes, let responseContentType):
+                    print("Response content type: \(responseContentType) was unacceptable: \(acceptableContentTypes)")
+                case .unacceptableStatusCode(let code):
+                    if code == 401 {
+                        CurrentUserManager.sharedManager.signOut()
                     }
-                case .invalidURL(let url):
-                    print(url)
-                    break
-                case .parameterEncodingFailed(let reason):
+                    print("Response status code was unacceptable: \(code)")
+                case .customValidationFailed(let error):
+                    print("Custom validation failed: \(error)")
+                @unknown default:
                     print(reason)
                     break
-                case .multipartEncodingFailed(let reason):
-                    print(reason)
-                    break
-                case .responseSerializationFailed(let reason):
-                    print(reason)
-                    break
-                default:
-                    print(error)
                 }
-                errorHandler?(response.error, JSON(data: response.data!)["error_message"].string)
+            case .invalidURL(let url):
+                print(url)
+                break
+            case .parameterEncodingFailed(let reason):
+                print(reason)
+                break
+            case .multipartEncodingFailed(let reason):
+                print(reason)
+                break
+            case .responseSerializationFailed(let reason):
+                print(reason)
+                break
+            default:
                 print(error)
-                return
             }
+
+            // TODO: Extract `JSON(data: response.data!)["error_message"].string` and include if relevant
+            throw error;
         }
     }
     
-    class func get(url: String, parameters: [String: Any]?, success: ((Any?) -> Void)?, errorHandler: ((Error?, String?) -> Void)?) {
-        RequestManager.rawRequest(url: url, method: .get, parameters: RequestManager.authedParams(parameters), success: success, errorHandler: errorHandler)
+    class func get(url: String, parameters: [String: Any]?) async throws -> Any? {
+        return try await RequestManager.rawRequest(url: url, method: .get, parameters: RequestManager.authedParams(parameters))
     }
     
     
-    class func put(url: String, parameters: [String: Any]?, success: ((Any?) -> Void)?, errorHandler: ((Error?, String?) -> Void)?) {
-        RequestManager.rawRequest(url: url, method: .patch, parameters: RequestManager.authedParams(parameters), success: success, errorHandler: errorHandler)
+    class func put(url: String, parameters: [String: Any]?) async throws -> Any? {
+        return try await RequestManager.rawRequest(url: url, method: .patch, parameters: RequestManager.authedParams(parameters))
     }
     
-    class func post(url: String, parameters: [String: Any]?, success: ((Any?) -> Void)?, errorHandler: ((Error?, String?) -> Void)?) {
-        RequestManager.rawRequest(url: url, method: .post, parameters: RequestManager.authedParams(parameters), success: success, errorHandler: errorHandler)
+    class func post(url: String, parameters: [String: Any]?) async throws -> Any? {
+        return try await RequestManager.rawRequest(url: url, method: .post, parameters: RequestManager.authedParams(parameters))
     }
     
-    class func delete(url: String, parameters: [String: Any]?, success: ((Any?) -> Void)?, errorHandler: ((Error?, String?) -> Void)?) {
-        RequestManager.rawRequest(url: url, method: .delete, parameters: RequestManager.authedParams(parameters), success: success, errorHandler: errorHandler)
+    class func delete(url: String, parameters: [String: Any]?) async throws -> Any? {
+        return try await RequestManager.rawRequest(url: url, method: .delete, parameters: RequestManager.authedParams(parameters))
     }
     
     
@@ -92,9 +94,9 @@ class RequestManager {
         return params
     }
 
-    class func addDatapoint(urtext: String, slug: String, success: ((Any?) -> Void)?, errorHandler: ((Error?, String?) -> Void)?) {
+    class func addDatapoint(urtext: String, slug: String) async throws -> Any? {
         let params = ["urtext": urtext, "requestid": UUID().uuidString]
         
-        RequestManager.post(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(slug)/datapoints.json", parameters: params, success: success, errorHandler: errorHandler)
+        return try await RequestManager.post(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(slug)/datapoints.json", parameters: params)
     }
 }

--- a/BeeSwift/SignedRequestManager.swift
+++ b/BeeSwift/SignedRequestManager.swift
@@ -12,13 +12,14 @@ import BeeKit
 
 class SignedRequestManager: RequestManager {
     
-    class func signedGET(url: String, parameters: [String: Any]?, success: ((Any?) -> Void)?, errorHandler: ((Error?, String?) -> Void)?) {
-        RequestManager.rawRequest(url: url, method: .get, parameters: SignedRequestManager.signedParameters(RequestManager.authedParams(parameters)), success: success, errorHandler: errorHandler)
+    class func signedGET(url: String, parameters: [String: Any]?) async throws -> Any? {
+        let params = SignedRequestManager.signedParameters(RequestManager.authedParams(parameters))
+        return try await RequestManager.rawRequest(url: url, method: .get, parameters: params)
     }
     
-    class func signedPOST(url: String, parameters: [String: Any]?, success: ((Any?) -> Void)?, errorHandler: ((Error?, String?) -> Void)?) {
+    class func signedPOST(url: String, parameters: [String: Any]?) async throws -> Any? {
         let params = SignedRequestManager.signedParameters(RequestManager.authedParams(parameters))
-        RequestManager.rawRequest(url: url, method: .post, parameters: params, success: success, errorHandler: errorHandler)
+        return try await RequestManager.rawRequest(url: url, method: .post, parameters: params)
     }
     
     fileprivate class func signedParameters(_ params: [String: Any]?) -> [String: Any]? {

--- a/BeeSwift/TimerViewController.swift
+++ b/BeeSwift/TimerViewController.swift
@@ -173,7 +173,7 @@ class TimerViewController: UIViewController {
             do {
                 let params = ["urtext": self.urtext(), "requestid": UUID().uuidString]
                 let _ = try await RequestManager.post(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.slug!)/datapoints.json", parameters: params)
-                DispatchQueue.main.sync {
+                DispatchQueue.main.async {
                     hud?.mode = .text
                     hud?.labelText = "Added!"
                     DispatchQueue.main.asyncAfter(deadline: .now() + 2, execute: {
@@ -186,7 +186,7 @@ class TimerViewController: UIViewController {
                     self.resetButtonPressed()
                 }
             } catch {
-                DispatchQueue.main.sync {
+                DispatchQueue.main.async {
                     MBProgressHUD.hideAllHUDs(for: self.view, animated: true)
                     let alertController = UIAlertController(title: "Error", message: "Failed to add datapoint", preferredStyle: .alert)
                     alertController.addAction(UIAlertAction(title: "OK", style: .cancel))

--- a/BeeSwift/VersionManager.swift
+++ b/BeeSwift/VersionManager.swift
@@ -60,13 +60,7 @@ class VersionManager : NSObject {
     }
     
     private func checkIfUpdateRequired() async throws -> Bool {
-        let responseJSON = try await withCheckedThrowingContinuation { continuation in
-            RequestManager.get(url: "api/private/app_versions.json",
-                               parameters: nil,
-                               success: { responseJSON in continuation.resume(returning: responseJSON) },
-                               errorHandler: { (responseError, responseMessage) in continuation.resume(throwing: responseError!) }
-                               )
-        }
+        let responseJSON = try await RequestManager.get(url: "api/private/app_versions.json", parameters: nil)
 
         guard let response = JSON(responseJSON!).dictionary else {
             throw VersionError.invalidServerResponse

--- a/BeeSwiftToday/TodayTableViewCell.swift
+++ b/BeeSwiftToday/TodayTableViewCell.swift
@@ -153,11 +153,20 @@ class TodayTableViewCell: UITableViewCell {
         
         let params = ["access_token": token, "urtext": "\(formatter.string(from: Date(timeIntervalSinceNow: offset*24*3600))) \(Int(self.valueStepper.value)) \"Added via iOS widget\"", "requestid": UUID().uuidString]
         guard let slug = self.goalDictionary["slug"] as? String else { return }
-        
-        RequestManager.post(url: "api/v1/users/me/goals/\(slug)/datapoints.json", parameters: params, success: { (responseJSON) in
-            self.pollUntilGraphUpdates()
-        }) { (responseError, errorMessage) in
-            self.addDataButton.setTitle("oops!", for: .normal)
+
+        Task {
+            do {
+                let _ = try await RequestManager.post(url: "api/v1/users/me/goals/\(slug)/datapoints.json", parameters: params)
+            } catch {
+                DispatchQueue.main.async {
+                    self.addDataButton.setTitle("oops!", for: .normal)
+                }
+                return
+            }
+
+            DispatchQueue.main.async {
+                self.pollUntilGraphUpdates()
+            }
         }
     }
     
@@ -167,29 +176,34 @@ class TodayTableViewCell: UITableViewCell {
     }
     
     @objc func refreshGoal() {
-        guard let slug = self.goalDictionary["slug"] as? String else { return }
-        let defaults = UserDefaults(suiteName: Constants.appGroupIdentifier)
-        guard let token = defaults?.object(forKey: "accessToken") as? String else { return }
-        
-        let parameters = ["access_token": token]
-        RequestManager.get(url: "api/v1/users/me/goals/\(slug)", parameters: parameters, success: { (responseObject) in
-            let goalJSON = JSON(responseObject!)
-            if (!goalJSON["queued"].bool!) {
-                self.pollTimer?.invalidate()
-                self.pollTimer = nil
-                let hud = MBProgressHUD.allHUDs(for: self).first as? MBProgressHUD
-                hud?.mode = .customView
-                hud?.customView = UIImageView(image: UIImage(named: "checkmark"))
-                hud?.hide(true, afterDelay: 2)
-                self.valueStepper.value = 0
-                self.valueLabel.text = "0"
-                self.addDataButton.isUserInteractionEnabled = true
-                self.limitLabel.text = "\(slug): \(goalJSON["limsum"])"
-                let urlString = "\(goalJSON["thumb_url"])"
-                self.setGraphImage(urlStr: urlString)
+        Task {
+            guard let slug = self.goalDictionary["slug"] as? String else { return }
+            let defaults = UserDefaults(suiteName: Constants.appGroupIdentifier)
+            guard let token = defaults?.object(forKey: "accessToken") as? String else { return }
+
+            let parameters = ["access_token": token]
+            do {
+                let responseObject = try await RequestManager.get(url: "api/v1/users/me/goals/\(slug)", parameters: parameters)
+                let goalJSON = JSON(responseObject!)
+                if (!goalJSON["queued"].bool!) {
+                    DispatchQueue.main.async {
+                        self.pollTimer?.invalidate()
+                        self.pollTimer = nil
+                        let hud = MBProgressHUD.allHUDs(for: self).first as? MBProgressHUD
+                        hud?.mode = .customView
+                        hud?.customView = UIImageView(image: UIImage(named: "checkmark"))
+                        hud?.hide(true, afterDelay: 2)
+                        self.valueStepper.value = 0
+                        self.valueLabel.text = "0"
+                        self.addDataButton.isUserInteractionEnabled = true
+                        self.limitLabel.text = "\(slug): \(goalJSON["limsum"])"
+                        let urlString = "\(goalJSON["thumb_url"])"
+                        self.setGraphImage(urlStr: urlString)
+                    }
+                }
+            } catch {
+                // TODO: Log the error?
             }
-        }) { (responseError, errorMessage) in
-            //
         }
     }
     


### PR DESCRIPTION
This converts `RequestManager` to use `async`/`await` patterns instead of completion callbacks. In the process also add more systematic logging on failures.

Test Plan
* Roughly check happy path on device
* Before releasing 6.3 should do a more thorough test, including error paths