### PR TITLE
Run most tasks in the MainActor

### DIFF
--- a/BeeSwift/AppDelegate.swift
+++ b/BeeSwift/AppDelegate.swift
@@ -131,7 +131,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     
     func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
         logger.notice("application:didRegisterForRemoteNotificationsWithDeviceToken")
-        Task {
+        Task { @MainActor in
             let token = deviceToken.reduce("", {$0 + String(format: "%02X", $1)})
 
             do {

--- a/BeeSwift/ChooseHKMetricViewController.swift
+++ b/BeeSwift/ChooseHKMetricViewController.swift
@@ -93,11 +93,12 @@ class ChooseHKMetricViewController: UIViewController {
     }
     
     func saveMetric(databaseString : String) {
-        let hud = MBProgressHUD.allHUDs(for: self.view).first as? MBProgressHUD
+        Task { @MainActor in
+            let hud = MBProgressHUD.allHUDs(for: self.view).first as? MBProgressHUD
 
-        self.goal!.healthKitMetric = databaseString
-        self.goal!.autodata = "apple"
-        Task {
+            self.goal!.healthKitMetric = databaseString
+            self.goal!.autodata = "apple"
+            
             do {
                 try await HealthStoreManager.sharedManager.ensureUpdatesRegularly(goal: self.goal!)
             } catch {
@@ -111,11 +112,9 @@ class ChooseHKMetricViewController: UIViewController {
 
             do {
                 let _ = try await RequestManager.put(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.goal!.slug).json", parameters: params)
-                DispatchQueue.main.async {
-                    hud?.mode = .customView
-                    hud?.customView = UIImageView(image: UIImage(named: "checkmark"))
-                    hud?.hide(true, afterDelay: 2)
-                }
+                hud?.mode = .customView
+                hud?.customView = UIImageView(image: UIImage(named: "checkmark"))
+                hud?.hide(true, afterDelay: 2)
                 DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
                     self.navigationController?.popViewController(animated: true)
                 }

--- a/BeeSwift/CurrentUserManager.swift
+++ b/BeeSwift/CurrentUserManager.swift
@@ -147,7 +147,7 @@ class CurrentUserManager : NSObject {
     }
     
     func signInWithEmail(_ email: String, password: String) {
-        Task {
+        Task { @MainActor in
             do {
                let response = try await RequestManager.post(url: "api/private/sign_in", parameters: ["user": ["login": email, "password": password], "beemios_secret": self.beemiosSecret] as Dictionary<String, Any>)
                 self.handleSuccessfulSignin(JSON(response!))
@@ -172,7 +172,7 @@ class CurrentUserManager : NSObject {
     }
     
     func syncNotificationDefaults(_ success: (() -> Void)?, failure: (() -> Void)?) {
-        Task {
+        Task { @MainActor in
             do {
                 let response = try await RequestManager.get(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!).json", parameters: [:])
                 let responseJSON = JSON(response!)
@@ -215,7 +215,7 @@ class CurrentUserManager : NSObject {
     }
     
     func fetchGoals(success: ((_ goals : [JSONGoal]) -> ())?, errorHandler: ((_ error : Error?, _ errorMessage : String?) -> ())?) {
-        Task {
+        Task { @MainActor in
             guard let username = self.username else {
                 DispatchQueue.main.async {
                     CurrentUserManager.sharedManager.signOut()

--- a/BeeSwift/EditDatapointViewController.swift
+++ b/BeeSwift/EditDatapointViewController.swift
@@ -182,49 +182,43 @@ class EditDatapointViewController: UIViewController, UITextFieldDelegate {
     }
     
     @objc func updateButtonPressed() {
-        self.view.endEditing(true)
-        let hud = MBProgressHUD.showAdded(to: self.view, animated: true)
-        hud?.mode = .indeterminate
+        Task { @MainActor in
+            self.view.endEditing(true)
+            let hud = MBProgressHUD.showAdded(to: self.view, animated: true)
+            hud?.mode = .indeterminate
 
-        Task {
             do {
                 let params = [
                     "access_token": CurrentUserManager.sharedManager.accessToken!,
                     "urtext": self.urtext()
                 ]
                 let _ = try await RequestManager.put(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.goalSlug!)/datapoints/\(self.datapointJSON!["id"]["$oid"].string!).json", parameters: params)
-                DispatchQueue.main.async {
-                    let hud = MBProgressHUD.allHUDs(for: self.view).first as? MBProgressHUD
-                    hud?.mode = .customView
-                    hud?.customView = UIImageView(image: UIImage(named: "checkmark"))
-                    hud?.hide(true, afterDelay: 2)
-                }
+                let hud = MBProgressHUD.allHUDs(for: self.view).first as? MBProgressHUD
+                hud?.mode = .customView
+                hud?.customView = UIImageView(image: UIImage(named: "checkmark"))
+                hud?.hide(true, afterDelay: 2)
             } catch {
                 logger.error("Error updating datapoint for goal \(self.goalSlug ?? "<nil>"): \(error)")
-                DispatchQueue.main.async {
-                    let _ = MBProgressHUD.hideAllHUDs(for: self.view, animated: true)
-                }
+                let _ = MBProgressHUD.hideAllHUDs(for: self.view, animated: true)
             }
         }
     }
     
     func deleteDatapoint() {
-        let params = [
-            "access_token": CurrentUserManager.sharedManager.accessToken!
-        ]
-        let hud = MBProgressHUD.showAdded(to: self.view, animated: true)
-        hud?.mode = .indeterminate
+        Task { @MainActor in
+            let params = [
+                "access_token": CurrentUserManager.sharedManager.accessToken!
+            ]
+            let hud = MBProgressHUD.showAdded(to: self.view, animated: true)
+            hud?.mode = .indeterminate
 
-        Task {
             do {
                 let _ = try await RequestManager.delete(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.goalSlug!)/datapoints/\(self.datapointJSON!["id"]["$oid"].string!).json", parameters: params)
 
-                DispatchQueue.main.async {
-                    let hud = MBProgressHUD.allHUDs(for: self.view).first as? MBProgressHUD
-                    hud?.mode = .customView
-                    hud?.customView = UIImageView(image: UIImage(named: "checkmark"))
-                    hud?.hide(true, afterDelay: 2)
-                }
+                let hud = MBProgressHUD.allHUDs(for: self.view).first as? MBProgressHUD
+                hud?.mode = .customView
+                hud?.customView = UIImageView(image: UIImage(named: "checkmark"))
+                hud?.hide(true, afterDelay: 2)
                 DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
                     self.navigationController?.popViewController(animated: true)
                 }

--- a/BeeSwift/EditDefaultNotificationsViewController.swift
+++ b/BeeSwift/EditDefaultNotificationsViewController.swift
@@ -24,7 +24,7 @@ class EditDefaultNotificationsViewController: EditNotificationsViewController {
     }
     
     override func sendLeadTimeToServer(_ timer : Timer) {
-        Task {
+        Task { @MainActor in
             let userInfo = timer.userInfo! as! Dictionary<String, NSNumber>
             guard let leadtime = userInfo["leadtime"] else { return }
             let params = [ "default_leadtime" : leadtime ]
@@ -44,10 +44,10 @@ class EditDefaultNotificationsViewController: EditNotificationsViewController {
     }
     
     func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
-        if self.timePickerEditingMode == .alertstart {
-            self.updateAlertstartLabel(self.midnightOffsetFromTimePickerView())
-            let params = ["default_alertstart" : self.midnightOffsetFromTimePickerView()]
-            Task {
+        Task { @MainActor in
+            if self.timePickerEditingMode == .alertstart {
+                self.updateAlertstartLabel(self.midnightOffsetFromTimePickerView())
+                let params = ["default_alertstart" : self.midnightOffsetFromTimePickerView()]
                 do {
                     let _ = try await RequestManager.put(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!).json", parameters: params)
                     CurrentUserManager.sharedManager.setDefaultAlertstart(self.midnightOffsetFromTimePickerView())
@@ -56,11 +56,9 @@ class EditDefaultNotificationsViewController: EditNotificationsViewController {
                     //foo
                 }
             }
-        }
-        if self.timePickerEditingMode == .deadline {
-            self.updateDeadlineLabel(self.midnightOffsetFromTimePickerView())
-            let params = ["default_deadline" : self.midnightOffsetFromTimePickerView()]
-            Task {
+            if self.timePickerEditingMode == .deadline {
+                self.updateDeadlineLabel(self.midnightOffsetFromTimePickerView())
+                let params = ["default_deadline" : self.midnightOffsetFromTimePickerView()]
                 do {
                     let _ = try await RequestManager.put(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!).json", parameters: params)
                     CurrentUserManager.sharedManager.setDefaultDeadline(self.midnightOffsetFromTimePickerView())

--- a/BeeSwift/EditGoalNotificationsViewController.swift
+++ b/BeeSwift/EditGoalNotificationsViewController.swift
@@ -60,17 +60,15 @@ class EditGoalNotificationsViewController : EditNotificationsViewController {
     }
     
     override func sendLeadTimeToServer(_ timer : Timer) {
-        Task {
+        Task { @MainActor in
             let userInfo = timer.userInfo! as! Dictionary<String, NSNumber>
             let leadtime = userInfo["leadtime"]
             let params = [ "leadtime" : leadtime, "use_defaults" : false ]
             do {
                 let _ = try await RequestManager.put(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.goal!.slug).json", parameters: params as [String : Any])
-                DispatchQueue.main.async {
-                    self.goal!.leadtime = leadtime!
-                    self.goal!.use_defaults = NSNumber(value: false as Bool)
-                    self.useDefaultsSwitch.isOn = false
-                }
+                self.goal!.leadtime = leadtime!
+                self.goal!.use_defaults = NSNumber(value: false as Bool)
+                self.useDefaultsSwitch.isOn = false
             } catch {
                 logger.error("Error sending lead time to server: \(error)")
                 // show alert
@@ -79,42 +77,34 @@ class EditGoalNotificationsViewController : EditNotificationsViewController {
     }
     
     func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
-        if self.timePickerEditingMode == .alertstart {
-            self.updateAlertstartLabel(self.midnightOffsetFromTimePickerView())
-            Task {
+        Task { @MainActor in
+            if self.timePickerEditingMode == .alertstart {
+                self.updateAlertstartLabel(self.midnightOffsetFromTimePickerView())
                 do {
                     let params = ["alertstart" : self.midnightOffsetFromTimePickerView(), "use_defaults" : false]
                     let _ = try await RequestManager.put(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.goal!.slug).json", parameters: params)
-                    DispatchQueue.main.async {
-                        self.goal!.alertstart = self.midnightOffsetFromTimePickerView()
-                        self.goal!.use_defaults = NSNumber(value: false as Bool)
-                        self.useDefaultsSwitch.isOn = false
-                    }
+                    self.goal!.alertstart = self.midnightOffsetFromTimePickerView()
+                    self.goal!.use_defaults = NSNumber(value: false as Bool)
+                    self.useDefaultsSwitch.isOn = false
                 } catch {
                     logger.error("Error setting alert start \(error)")
                     //foo
                 }
             }
-        }
-        if self.timePickerEditingMode == .deadline {
-            self.updateDeadlineLabel(self.midnightOffsetFromTimePickerView())
-            Task {
+            if self.timePickerEditingMode == .deadline {
+                self.updateDeadlineLabel(self.midnightOffsetFromTimePickerView())
                 do {
                     let params = ["deadline" : self.midnightOffsetFromTimePickerView(), "use_defaults" : false]
                     let _ = try await RequestManager.put(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.goal!.slug).json", parameters: params)
-                    DispatchQueue.main.async {
-                        self.goal?.deadline = self.midnightOffsetFromTimePickerView()
-                        self.goal!.use_defaults = NSNumber(value: false as Bool)
-                        self.useDefaultsSwitch.isOn = false
-                    }
+                    self.goal?.deadline = self.midnightOffsetFromTimePickerView()
+                    self.goal!.use_defaults = NSNumber(value: false as Bool)
+                    self.useDefaultsSwitch.isOn = false
                 } catch {
                     let errorString = error.localizedDescription
-                    DispatchQueue.main.async {
-                        MBProgressHUD.hideAllHUDs(for: self.view, animated: true)
-                        let alert = UIAlertController(title: "Error saving to Beeminder", message: errorString, preferredStyle: .alert)
-                        alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
-                        self.present(alert, animated: true, completion: nil)
-                    }
+                    MBProgressHUD.hideAllHUDs(for: self.view, animated: true)
+                    let alert = UIAlertController(title: "Error saving to Beeminder", message: errorString, preferredStyle: .alert)
+                    alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
+                    self.present(alert, animated: true, completion: nil)
                 }
             }
         }
@@ -124,23 +114,20 @@ class EditGoalNotificationsViewController : EditNotificationsViewController {
         if self.useDefaultsSwitch.isOn {
             let alertController = UIAlertController(title: "Confirm", message: "This will wipe out your current settings for this goal. Are you sure?", preferredStyle: .alert)
             alertController.addAction(UIAlertAction(title: "Yes", style: .default, handler: { (action) -> Void in
-
-                Task {
+                Task { @MainActor in
                     do {
                         let params = ["use_defaults" : true]
                         let _ = try await RequestManager.put(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.goal!.slug).json", parameters: params)
                         self.goal?.use_defaults = NSNumber(value: true as Bool)
                         CurrentUserManager.sharedManager.syncNotificationDefaults({
-                            DispatchQueue.main.async {
-                                self.leadTimeStepper.value = CurrentUserManager.sharedManager.defaultLeadTime().doubleValue
-                                self.updateLeadTimeLabel()
-                                self.alertstart = CurrentUserManager.sharedManager.defaultAlertstart()
-                                self.deadline   = CurrentUserManager.sharedManager.defaultDeadline()
-                                self.goal!.leadtime = CurrentUserManager.sharedManager.defaultLeadTime()
-                                self.goal!.alertstart = CurrentUserManager.sharedManager.defaultAlertstart()
-                                self.goal!.deadline = CurrentUserManager.sharedManager.defaultDeadline()
-                                self.timePickerEditingMode = self.timePickerEditingMode // trigger the setter which updates the timePicker components
-                            }
+                            self.leadTimeStepper.value = CurrentUserManager.sharedManager.defaultLeadTime().doubleValue
+                            self.updateLeadTimeLabel()
+                            self.alertstart = CurrentUserManager.sharedManager.defaultAlertstart()
+                            self.deadline   = CurrentUserManager.sharedManager.defaultDeadline()
+                            self.goal!.leadtime = CurrentUserManager.sharedManager.defaultLeadTime()
+                            self.goal!.alertstart = CurrentUserManager.sharedManager.defaultAlertstart()
+                            self.goal!.deadline = CurrentUserManager.sharedManager.defaultDeadline()
+                            self.timePickerEditingMode = self.timePickerEditingMode // trigger the setter which updates the timePicker components
                         }) {
                             self.logger.error("Error syncing notification defaults")
                             // foo
@@ -157,7 +144,7 @@ class EditGoalNotificationsViewController : EditNotificationsViewController {
             self.present(alertController, animated: true, completion: nil)
         }
         else {
-            Task {
+            Task { @MainActor in
                 do {
                     let params = ["use_defaults" : false]
                     let _ = try await RequestManager.put(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.goal!.slug).json", parameters: params)

--- a/BeeSwift/GalleryViewController.swift
+++ b/BeeSwift/GalleryViewController.swift
@@ -177,35 +177,33 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
             }
         }
 
-        Task {
+        Task { @MainActor in
             do {
                 let updateState = try await VersionManager.sharedManager.updateState()
 
-                DispatchQueue.main.async {
-                    switch updateState {
-                    case .UpdateRequired:
-                        self.outofdateView.snp.remakeConstraints { (make) -> Void in
-                            make.left.equalTo(0)
-                            make.right.equalTo(0)
-                            make.top.equalTo(self.deadbeatView.snp.bottom)
-                            make.height.equalTo(42)
-                        }
-                        self.outofdateLabel.isHidden = false
-                        self.outofdateLabel.text = "This version of the Beeminder app is no longer supported.\n Please update to the newest version in the App Store."
-                        self.collectionView?.isHidden = true
-                    case .UpdateSuggested:
-                        self.outofdateView.snp.remakeConstraints { (make) -> Void in
-                            make.left.equalTo(0)
-                            make.right.equalTo(0)
-                            make.top.equalTo(self.deadbeatView.snp.bottom)
-                            make.height.equalTo(42)
-                        }
-                        self.outofdateLabel.isHidden = false
-                        self.outofdateLabel.text = "There is a new version of the Beeminder app in the App Store.\nPlease update when you have a moment."
-                        self.collectionView?.isHidden = false
-                    case .UpToDate:
-                        self.collectionView?.isHidden = false
+                switch updateState {
+                case .UpdateRequired:
+                    self.outofdateView.snp.remakeConstraints { (make) -> Void in
+                        make.left.equalTo(0)
+                        make.right.equalTo(0)
+                        make.top.equalTo(self.deadbeatView.snp.bottom)
+                        make.height.equalTo(42)
                     }
+                    self.outofdateLabel.isHidden = false
+                    self.outofdateLabel.text = "This version of the Beeminder app is no longer supported.\n Please update to the newest version in the App Store."
+                    self.collectionView?.isHidden = true
+                case .UpdateSuggested:
+                    self.outofdateView.snp.remakeConstraints { (make) -> Void in
+                        make.left.equalTo(0)
+                        make.right.equalTo(0)
+                        make.top.equalTo(self.deadbeatView.snp.bottom)
+                        make.height.equalTo(42)
+                    }
+                    self.outofdateLabel.isHidden = false
+                    self.outofdateLabel.text = "There is a new version of the Beeminder app in the App Store.\nPlease update when you have a moment."
+                    self.collectionView?.isHidden = false
+                case .UpToDate:
+                    self.collectionView?.isHidden = false
                 }
             } catch let error as VersionError {
                 logger.error("Error checking for current version: \(error)")
@@ -389,7 +387,7 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
     }
     
     func setupHealthKit() {
-        Task {
+        Task { @MainActor in
             do {
                 try await HealthStoreManager.sharedManager.ensureUpdatesRegularly(goals: self.goals)
             } catch {

--- a/BeeSwift/JSONGoal.swift
+++ b/BeeSwift/JSONGoal.swift
@@ -299,7 +299,7 @@ class JSONGoal {
     }
     
     func fetchRecentDatapoints(success: @escaping ((_ datapoints : [JSON]) -> ()), errorCompletion: (() -> ())?) {
-        Task {
+        Task { @MainActor in
             let params = ["sort" : "daystamp", "count" : 7] as [String : Any]
             do {
                 let response = try await RequestManager.get(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.slug)/datapoints.json", parameters: params)
@@ -322,7 +322,7 @@ class JSONGoal {
     }
     
     func updateDatapoint(datapoint : JSON, datapointValue : Double, success: (() -> ())?, errorCompletion: (() -> ())?) {
-        Task {
+        Task { @MainActor in
             let val = datapoint["value"].double
             if datapointValue == val {
                 success?()
@@ -347,7 +347,7 @@ class JSONGoal {
     }
     
     func deleteDatapoint(datapoint : JSON) {
-        Task {
+        Task { @MainActor in
             let datapointID = datapoint["id"].string
             do {
                 let _ = try await RequestManager.delete(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.slug)/datapoints/\(datapointID!)", parameters: nil)
@@ -358,7 +358,7 @@ class JSONGoal {
     }
     
     func postDatapoint(params : [String : String], success : ((Any?) -> Void)?, failure : ((Error?, String?) -> Void)?) {
-        Task {
+        Task { @MainActor in
             do {
                 let response = try await RequestManager.post(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.slug)/datapoints.json", parameters: params)
                 success?(response)

--- a/BeeSwift/RemoveHKMetricViewController.swift
+++ b/BeeSwift/RemoveHKMetricViewController.swift
@@ -71,18 +71,16 @@ class RemoveHKMetricViewController: UIViewController {
         let hud = MBProgressHUD.showAdded(to: self.view, animated: true)
         hud?.mode = .indeterminate
 
-        Task {
+        Task { @MainActor in
             do {
                 let responseObject = try await RequestManager.put(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.goal!.slug).json", parameters: params)
 
                 self.goal = JSONGoal(json: JSON(responseObject!))
 
-                DispatchQueue.main.async {
-                    hud?.mode = .customView
-                    hud?.customView = UIImageView(image: UIImage(named: "checkmark"))
+                hud?.mode = .customView
+                hud?.customView = UIImageView(image: UIImage(named: "checkmark"))
 
-                    NotificationCenter.default.post(name: Notification.Name(rawValue: CurrentUserManager.healthKitMetricRemovedNotificationName), object: self, userInfo: ["goal": self.goal as Any])
-                }
+                NotificationCenter.default.post(name: Notification.Name(rawValue: CurrentUserManager.healthKitMetricRemovedNotificationName), object: self, userInfo: ["goal": self.goal as Any])
                 
                 DispatchQueue.main.asyncAfter(deadline: .now() + 1, execute: {
                     hud?.hide(true, afterDelay: 2)

--- a/BeeSwift/TimerViewController.swift
+++ b/BeeSwift/TimerViewController.swift
@@ -169,29 +169,25 @@ class TimerViewController: UIViewController {
         let hud = MBProgressHUD.showAdded(to: self.view, animated: true)
         hud?.mode = .indeterminate
 
-        Task {
+        Task { @MainActor in
             do {
                 let params = ["urtext": self.urtext(), "requestid": UUID().uuidString]
                 let _ = try await RequestManager.post(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.slug!)/datapoints.json", parameters: params)
-                DispatchQueue.main.async {
-                    hud?.mode = .text
-                    hud?.labelText = "Added!"
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 2, execute: {
-                        MBProgressHUD.hideAllHUDs(for: self.view, animated: true)
-                    })
-                    if let goalVC = self.presentingViewController?.children.last as? GoalViewController {
-                        goalVC.refreshGoal()
-                        goalVC.pollUntilGraphUpdates()
-                    }
-                    self.resetButtonPressed()
-                }
-            } catch {
-                DispatchQueue.main.async {
+                hud?.mode = .text
+                hud?.labelText = "Added!"
+                DispatchQueue.main.asyncAfter(deadline: .now() + 2, execute: {
                     MBProgressHUD.hideAllHUDs(for: self.view, animated: true)
-                    let alertController = UIAlertController(title: "Error", message: "Failed to add datapoint", preferredStyle: .alert)
-                    alertController.addAction(UIAlertAction(title: "OK", style: .cancel))
-                    self.present(alertController, animated: true)
+                })
+                if let goalVC = self.presentingViewController?.children.last as? GoalViewController {
+                    goalVC.refreshGoal()
+                    goalVC.pollUntilGraphUpdates()
                 }
+                self.resetButtonPressed()
+            } catch {
+                MBProgressHUD.hideAllHUDs(for: self.view, animated: true)
+                let alertController = UIAlertController(title: "Error", message: "Failed to add datapoint", preferredStyle: .alert)
+                alertController.addAction(UIAlertAction(title: "OK", style: .cancel))
+                self.present(alertController, animated: true)
             }
         }
     }


### PR DESCRIPTION
We use `Task` to run async code from a sync context. By default this runs on a background thread, but we usually instead want to run in a UI thread. Previously we were dispatching back to the UI thread to do this. Here instead we mark most tasks as needing to run in the UI thread, removing the need for this.

Test Plan:
Ran on device, exercising a few code paths.