### PR TITLE
Convert CurrentUserManger to use async

### DIFF
--- a/BeeSwift/EditGoalNotificationsViewController.swift
+++ b/BeeSwift/EditGoalNotificationsViewController.swift
@@ -119,23 +119,28 @@ class EditGoalNotificationsViewController : EditNotificationsViewController {
                         let params = ["use_defaults" : true]
                         let _ = try await RequestManager.put(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.goal!.slug).json", parameters: params)
                         self.goal?.use_defaults = NSNumber(value: true as Bool)
-                        CurrentUserManager.sharedManager.syncNotificationDefaults({
-                            self.leadTimeStepper.value = CurrentUserManager.sharedManager.defaultLeadTime().doubleValue
-                            self.updateLeadTimeLabel()
-                            self.alertstart = CurrentUserManager.sharedManager.defaultAlertstart()
-                            self.deadline   = CurrentUserManager.sharedManager.defaultDeadline()
-                            self.goal!.leadtime = CurrentUserManager.sharedManager.defaultLeadTime()
-                            self.goal!.alertstart = CurrentUserManager.sharedManager.defaultAlertstart()
-                            self.goal!.deadline = CurrentUserManager.sharedManager.defaultDeadline()
-                            self.timePickerEditingMode = self.timePickerEditingMode // trigger the setter which updates the timePicker components
-                        }) {
-                            self.logger.error("Error syncing notification defaults")
-                            // foo
-                        }
                     } catch {
                         self.logger.error("Error setting goal to use defaults: \(error)")
-                        // foo
+                        // TODO: Show UI failure
+                        return
                     }
+
+                    do {
+                        try await CurrentUserManager.sharedManager.syncNotificationDefaults()
+                    } catch {
+                        self.logger.error("Error syncing notification defaults")
+                        // TODO: Show UI failure
+                        return
+                    }
+
+                    self.leadTimeStepper.value = CurrentUserManager.sharedManager.defaultLeadTime().doubleValue
+                    self.updateLeadTimeLabel()
+                    self.alertstart = CurrentUserManager.sharedManager.defaultAlertstart()
+                    self.deadline   = CurrentUserManager.sharedManager.defaultDeadline()
+                    self.goal!.leadtime = CurrentUserManager.sharedManager.defaultLeadTime()
+                    self.goal!.alertstart = CurrentUserManager.sharedManager.defaultAlertstart()
+                    self.goal!.deadline = CurrentUserManager.sharedManager.defaultDeadline()
+                    self.timePickerEditingMode = self.timePickerEditingMode // trigger the setter which updates the timePicker components
                 }
             }))
             alertController.addAction(UIAlertAction(title: "No", style: .cancel, handler: { (action) -> Void in

--- a/BeeSwift/GoalViewController.swift
+++ b/BeeSwift/GoalViewController.swift
@@ -522,13 +522,20 @@ class GoalViewController: UIViewController, UITableViewDelegate, UITableViewData
                 self.refreshGoal() // TODO: How should sequencing here work?
                 self.pollUntilGraphUpdates()
                 self.submitButton.isUserInteractionEnabled = true
-                CurrentUserManager.sharedManager.fetchGoals(success: nil, errorHandler: nil)
             } catch {
                 self.submitButton.isUserInteractionEnabled = true
                 MBProgressHUD.hideAllHUDs(for: self.view, animated: true)
                 let alertController = UIAlertController(title: "Error", message: "Failed to add datapoint", preferredStyle: .alert)
                 alertController.addAction(UIAlertAction(title: "OK", style: .cancel))
                 self.present(alertController, animated: true)
+
+                return
+            }
+
+            do {
+                let _ = try await CurrentUserManager.sharedManager.fetchGoals()
+            } catch {
+                logger.error("Failed up refresh goals after posting: \(error)")
             }
         }
     }

--- a/BeeSwift/SignInViewController.swift
+++ b/BeeSwift/SignInViewController.swift
@@ -235,13 +235,15 @@ class SignInViewController : UIViewController, UITextFieldDelegate, SFSafariView
     }
     
     @objc func signInButtonPressed() {
-        guard let email = self.emailTextField.text?.trimmingCharacters(in: .whitespaces), let password = self.passwordTextField.text, !email.isEmpty, !password.isEmpty else {
-            self.present(self.missingDataOnSignIn, animated: true, completion: nil)
-            return
+        Task { @MainActor in
+            guard let email = self.emailTextField.text?.trimmingCharacters(in: .whitespaces), let password = self.passwordTextField.text, !email.isEmpty, !password.isEmpty else {
+                self.present(self.missingDataOnSignIn, animated: true, completion: nil)
+                return
+            }
+
+            MBProgressHUD.showAdded(to: self.view, animated: true)
+            await CurrentUserManager.sharedManager.signInWithEmail(email, password: password)
         }
-        
-        MBProgressHUD.showAdded(to: self.view, animated: true)
-        CurrentUserManager.sharedManager.signInWithEmail(email, password: password)
     }
     
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {


### PR DESCRIPTION
This continues the conversion of data model code to async, with the boundary between sync and async code now largely happening in UI handlers. Unfortunately we still have to be a little careful to only call into NotificationCenter from the main thread.

Test Plan:
Launched app in simulator and clicked around, including logging out and in