### PR TITLE
Extract the datapoint table view into a controller

### DIFF
--- a/BeeSwift.xcodeproj/project.pbxproj
+++ b/BeeSwift.xcodeproj/project.pbxproj
@@ -83,6 +83,7 @@
 		E4B0833D293810EB00A71564 /* DataPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4B0833C293810EB00A71564 /* DataPoint.swift */; };
 		E4B0833E293810F600A71564 /* DataPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4B0833C293810EB00A71564 /* DataPoint.swift */; };
 		E4B0833F293810F600A71564 /* DataPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4B0833C293810EB00A71564 /* DataPoint.swift */; };
+		E4B0833B2934620500A71564 /* DatapointTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4B0833A2934620500A71564 /* DatapointTableViewController.swift */; };
 		E4B0A32E28C194C800055EA7 /* AddDataIntents.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = E540953B260FB6A100C30784 /* AddDataIntents.intentdefinition */; };
 		E4B0A32F28C194C800055EA7 /* AddDataIntents.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = E540953B260FB6A100C30784 /* AddDataIntents.intentdefinition */; };
 		E4B0A33028C194C900055EA7 /* AddDataIntents.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = E540953B260FB6A100C30784 /* AddDataIntents.intentdefinition */; };
@@ -304,6 +305,7 @@
 		E43D9AFA2929C37D00FC1578 /* DatapointValueAccessory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatapointValueAccessory.swift; sourceTree = "<group>"; };
 		E457BE5C28C192B50012F5D0 /* IntentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntentHandler.swift; sourceTree = "<group>"; };
 		E4B0833C293810EB00A71564 /* DataPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataPoint.swift; sourceTree = "<group>"; };
+		E4B0833A2934620500A71564 /* DatapointTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatapointTableViewController.swift; sourceTree = "<group>"; };
 		E4E6427B2910C3AB004F3EA9 /* HealthKitMetric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthKitMetric.swift; sourceTree = "<group>"; };
 		E4E6427F2910C3FB004F3EA9 /* QuantityHealthKitMetric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuantityHealthKitMetric.swift; sourceTree = "<group>"; };
 		E4E642832910C442004F3EA9 /* CategoryHealthKitMetric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryHealthKitMetric.swift; sourceTree = "<group>"; };
@@ -529,6 +531,7 @@
 				A196CB171AE4142E00B90A3E /* Supporting Files */,
 				9B8CA57C24B120CA009C86C2 /* LaunchScreen.storyboard */,
 				E4B0833C293810EB00A71564 /* DataPoint.swift */,
+				E4B0833A2934620500A71564 /* DatapointTableViewController.swift */,
 			);
 			path = BeeSwift;
 			sourceTree = "<group>";
@@ -1168,6 +1171,7 @@
 				A1453B391AEDA71D006F48DA /* BSLabel.swift in Sources */,
 				A1E618E21E78158700D8ED93 /* HealthKitConfigViewController.swift in Sources */,
 				E42CB452291727B200A35AB9 /* HealthKitError.swift in Sources */,
+				E4B0833B2934620500A71564 /* DatapointTableViewController.swift in Sources */,
 				A1F8F07B232C05410060B83E /* Goal.swift in Sources */,
 				A11BC2D91FFAD5BC00E56064 /* TimerViewController.swift in Sources */,
 				A149B3721AEF54D100F19A09 /* BSButton.swift in Sources */,

--- a/BeeSwift/DatapointTableViewController.swift
+++ b/BeeSwift/DatapointTableViewController.swift
@@ -9,12 +9,18 @@
 import Foundation
 import UIKit
 
-class DatapointTableViewController<DP : DataPoint> : UIViewController, UITableViewDelegate, UITableViewDataSource {
-    fileprivate var cellIdentifier = "datapointCell"
+protocol DatapointTableViewControllerDelegate {
+    func datapointTableViewController(_ datapointTableViewController: DatapointTableViewController, didSelectDatapoint datapoint: DataPoint)
+}
 
+class DatapointTableViewController : UIViewController, UITableViewDelegate, UITableViewDataSource {
+    fileprivate var cellIdentifier = "datapointCell"
     fileprivate var datapointsTableView = DatapointsTableView()
 
-    public var datapoints : [DP] = [] {
+
+    public var delegate : DatapointTableViewControllerDelegate?
+
+    public var datapoints : [DataPoint] = [] {
         didSet {
             // Cause the table to re-render to pick up the change to rows
             self.datapointsTableView.reloadData()
@@ -24,7 +30,6 @@ class DatapointTableViewController<DP : DataPoint> : UIViewController, UITableVi
         }
     }
 
-    // TODO: Parent needs to hook this up
     public var hhmmformat : Bool = false {
         didSet {
             self.datapointsTableView.reloadData()
@@ -65,6 +70,15 @@ class DatapointTableViewController<DP : DataPoint> : UIViewController, UITableVi
         cell.datapointText = displayText(datapoint: datapoint)
 
         return cell
+    }
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        self.view.endEditing(true)
+
+        guard indexPath.row < datapoints.count else { return }
+        let datapoint = datapoints[indexPath.row]
+
+        self.delegate?.datapointTableViewController(self, didSelectDatapoint: datapoint)
     }
 
     func displayText(datapoint: DataPoint) -> String {

--- a/BeeSwift/DatapointTableViewController.swift
+++ b/BeeSwift/DatapointTableViewController.swift
@@ -1,0 +1,87 @@
+//
+//  DatapointTableViewController.swift
+//  BeeSwift
+//
+//  Created by Theo Spears on 11/27/22.
+//  Copyright © 2022 APB. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+class DatapointTableViewController<DP : DataPoint> : UIViewController, UITableViewDelegate, UITableViewDataSource {
+    fileprivate var cellIdentifier = "datapointCell"
+
+    fileprivate var datapointsTableView = DatapointsTableView()
+
+    public var datapoints : [DP] = [] {
+        didSet {
+            // Cause the table to re-render to pick up the change to rows
+            self.datapointsTableView.reloadData()
+            // The number of rows may have changed, so we must trigger a re-layout to allow the
+            // table view more or less space
+            self.datapointsTableView.invalidateIntrinsicContentSize()
+        }
+    }
+
+    // TODO: Parent needs to hook this up
+    public var hhmmformat : Bool = false {
+        didSet {
+            self.datapointsTableView.reloadData()
+        }
+    }
+
+    override func viewDidLoad() {
+        self.view.addSubview(self.datapointsTableView)
+
+        self.datapointsTableView.dataSource = self
+        self.datapointsTableView.delegate = self
+        self.datapointsTableView.separatorStyle = .none
+        self.datapointsTableView.isScrollEnabled = false
+        self.datapointsTableView.rowHeight = 24
+        self.datapointsTableView.register(DatapointTableViewCell.self, forCellReuseIdentifier: self.cellIdentifier)
+
+        self.datapointsTableView.snp.makeConstraints { (make) -> Void in
+            make.edges.equalToSuperview()
+        }
+    }
+
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return 1
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return datapoints.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: self.cellIdentifier) as! DatapointTableViewCell
+
+        guard indexPath.row < datapoints.count else {
+            return cell
+        }
+        let datapoint = datapoints[indexPath.row]
+
+        cell.datapointText = displayText(datapoint: datapoint)
+
+        return cell
+    }
+
+    func displayText(datapoint: DataPoint) -> String {
+        let daystamp = Int(datapoint.daystamp) ?? 0
+        let day = daystamp != 0 ? String(format: "%02d", daystamp % 100) : "??" // Day is two least significant digits of daystamp
+
+        var formattedValue: String
+        if hhmmformat {
+            let value = datapoint.value.doubleValue
+            let hours = Int(value)
+            let minutes = Int(value.truncatingRemainder(dividingBy: 1) * 60)
+            formattedValue = String(hours) + ":" + String(format: "%02d", minutes)
+        } else {
+            formattedValue = datapoint.value.stringValue
+        }
+        let comment = datapoint.comment
+
+        return "\(day) \(formattedValue) \(comment)"
+    }
+}

--- a/BeeSwift/Goal.swift
+++ b/BeeSwift/Goal.swift
@@ -12,7 +12,6 @@ import HealthKit
 import OSLog
 import UserNotifications
 
-
 class Goal {
     private let logger = Logger(subsystem: "com.beeminder.beeminder", category: "Goal")
 


### PR DESCRIPTION
The goal view page includes a table of recent data points. Here we extract that table into a separate (nested) view controller which takes a set of data points as input. This will allow us to re-use this to show a preview of healthkit data points.

Test Plan:
Viewed the goal view for various goals
Confirmed hhmmformat was preserved
Confirmed tapping through to the edit screen works