### PR TITLE
Update more healtkit history on observer updates

### DIFF
--- a/BeeSwift/HeathKit/GoalHealthKitConnection.swift
+++ b/BeeSwift/HeathKit/GoalHealthKitConnection.swift
@@ -12,6 +12,13 @@ import HealthKit
 import OSLog
 
 class GoalHealthKitConnection {
+    /// The number of days to update when we are informed of a change. We are only called when the device is unlocked, so we must look
+    /// at the previous day in case data was added after the last time the device was locked. There may also be other integrations which report
+    /// data with some lag, so we look a bit further back for safety
+    /// This does mean users who have very little buffer, and are not regularly unlocking their phone, may erroneously derail. There is nothing we
+    /// can do about this.
+    static let daysToUpdateOnChangeNotification = 7
+
     private let logger = Logger(subsystem: "com.beeminder.beeminder", category: "GoalHealthKitConnection")
     private let healthStore: HKHealthStore
     private let goal : Goal
@@ -23,7 +30,6 @@ class GoalHealthKitConnection {
         self.goal = goal
         self.metric = metric
         self.healthStore = healthStore
-
     }
 
     /// Perform an initial sync and register for changes to the relevant metric so the goal can be kept up to date
@@ -49,7 +55,7 @@ class GoalHealthKitConnection {
 
             Task {
                 do {
-                    try await self.updateWithRecentData(days: 1)
+                    try await self.updateWithRecentData(days: GoalHealthKitConnection.daysToUpdateOnChangeNotification)
                     completionHandler()
                 } catch {
                     self.logger.error("Error fetching data in response to observer query \(query) error: \(error)")


### PR DESCRIPTION
Previously we were only updating a single day when data points change. This was a regresison on past behavior for aggregated data points, which tended to update the last 7 days regularly. This caused issues e.g. for data logged after the last time a device was unlocked for the day. Become more resilient by syncing more historic data.

Test Plan:
None