### PR TITLE
Fix the "Working Directory lint" check

### DIFF
--- a/.github/workflows/clean-working-dir.yml
+++ b/.github/workflows/clean-working-dir.yml
@@ -10,13 +10,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: build config
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '2.6'
+        bundler-cache: true
+    - name: pod install
       run: |
-        gem install bundler:1.17.2
-        bundle config path ~/.gems
-    - name: bundle install; pod install
-      run: |
-        bundle install
         bundle exec pod install
     - name: lint working directory
       run: |

--- a/.github/workflows/clean-working-dir.yml
+++ b/.github/workflows/clean-working-dir.yml
@@ -23,5 +23,7 @@ jobs:
           echo "::debug::working dir is clean"
         else
           echo "::error ::dirty working directory - uncommitted changes"
+          git diff --color --stat
+          git diff --color
           exit 1
         fi

--- a/.github/workflows/clean-working-dir.yml
+++ b/.github/workflows/clean-working-dir.yml
@@ -24,6 +24,5 @@ jobs:
         else
           echo "::error ::dirty working directory - uncommitted changes"
           git status --color
-          git diff --color
           exit 1
         fi

--- a/.github/workflows/clean-working-dir.yml
+++ b/.github/workflows/clean-working-dir.yml
@@ -23,7 +23,7 @@ jobs:
           echo "::debug::working dir is clean"
         else
           echo "::error ::dirty working directory - uncommitted changes"
-          git diff --color --stat
+          git status --color
           git diff --color
           exit 1
         fi

--- a/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Pods/Pods.xcodeproj/project.pbxproj
@@ -1373,8 +1373,8 @@
 		BFDFE7DC352907FC980B868725387E98 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1240;
-				LastUpgradeCheck = 1240;
+				LastSwiftUpdateCheck = 1300;
+				LastUpgradeCheck = 1300;
 			};
 			buildConfigurationList = 4821239608C13582E20E6DA73FD5F1F9 /* Build configuration list for PBXProject "Pods" */;
 			compatibilityVersion = "Xcode 3.2";


### PR DESCRIPTION
The check for a clean working directory was failing for a few reasons.
* Incompatible ruby version
* Mismatched check version
* Non-ignored ruby gem packages
This diff fixes these, to stop the annoying failure messages.