### PR TITLE
Migrate background updates to BGTaskScheduler framework

### DIFF
--- a/BeeSwift.xcodeproj/project.pbxproj
+++ b/BeeSwift.xcodeproj/project.pbxproj
@@ -90,6 +90,7 @@
 		E48E271C2970EC85008013C0 /* StandHoursHealthKitMetric.swift in Sources */ = {isa = PBXBuildFile; fileRef = E48E271B2970EC85008013C0 /* StandHoursHealthKitMetric.swift */; };
 		E48E271D2970ED47008013C0 /* StandHoursHealthKitMetric.swift in Sources */ = {isa = PBXBuildFile; fileRef = E48E271B2970EC85008013C0 /* StandHoursHealthKitMetric.swift */; };
 		E48E271E2970ED48008013C0 /* StandHoursHealthKitMetric.swift in Sources */ = {isa = PBXBuildFile; fileRef = E48E271B2970EC85008013C0 /* StandHoursHealthKitMetric.swift */; };
+		E48E27202973261F008013C0 /* BackgroundUpdates.swift in Sources */ = {isa = PBXBuildFile; fileRef = E48E271F2973261F008013C0 /* BackgroundUpdates.swift */; };
 		E4B0833B2934620500A71564 /* DatapointTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4B0833A2934620500A71564 /* DatapointTableViewController.swift */; };
 		E4B0833D293810EB00A71564 /* DataPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4B0833C293810EB00A71564 /* DataPoint.swift */; };
 		E4B0833E293810F600A71564 /* DataPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4B0833C293810EB00A71564 /* DataPoint.swift */; };
@@ -318,6 +319,7 @@
 		E48E2713296B75E4008013C0 /* TotalSleepMinutesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TotalSleepMinutesTests.swift; sourceTree = "<group>"; };
 		E48E2715296B9F4B008013C0 /* TimeAsleepHealthKitMetric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeAsleepHealthKitMetric.swift; sourceTree = "<group>"; };
 		E48E271B2970EC85008013C0 /* StandHoursHealthKitMetric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StandHoursHealthKitMetric.swift; sourceTree = "<group>"; };
+		E48E271F2973261F008013C0 /* BackgroundUpdates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundUpdates.swift; sourceTree = "<group>"; };
 		E4B0833A2934620500A71564 /* DatapointTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatapointTableViewController.swift; sourceTree = "<group>"; };
 		E4B0833C293810EB00A71564 /* DataPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataPoint.swift; sourceTree = "<group>"; };
 		E4E6427B2910C3AB004F3EA9 /* HealthKitMetric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthKitMetric.swift; sourceTree = "<group>"; };
@@ -522,6 +524,7 @@
 				A149147D1BE7A5140060600A /* Util */,
 				E540953B260FB6A100C30784 /* AddDataIntents.intentdefinition */,
 				A196CB191AE4142E00B90A3E /* AppDelegate.swift */,
+				E48E271F2973261F008013C0 /* BackgroundUpdates.swift */,
 				A1BE73A91E8B45BF00DEC4DB /* ChooseHKMetricViewController.swift */,
 				A10D4E921B07948500A72D29 /* DatapointsTableView.swift */,
 				A1619EA51BEECC6700E14B3A /* EditGoalNotificationsViewController.swift */,
@@ -1205,6 +1208,7 @@
 				A10D4E931B07948500A72D29 /* DatapointsTableView.swift in Sources */,
 				E4E642842910C442004F3EA9 /* CategoryHealthKitMetric.swift in Sources */,
 				A1BCE9851AFFFB3A007322CC /* RequestManager.swift in Sources */,
+				E48E27202973261F008013C0 /* BackgroundUpdates.swift in Sources */,
 				A149147F1BE7A5670060600A /* SettingsTableViewCell.swift in Sources */,
 				E48E271C2970EC85008013C0 /* StandHoursHealthKitMetric.swift in Sources */,
 				E43D9AFB2929C37D00FC1578 /* DatapointValueAccessory.swift in Sources */,

--- a/BeeSwift/BackgroundUpdates.swift
+++ b/BeeSwift/BackgroundUpdates.swift
@@ -1,0 +1,52 @@
+import Foundation
+import BackgroundTasks
+import OSLog
+
+class BackgroundUpdates {
+    fileprivate let logger = Logger(subsystem: "com.beeminder.beeminder", category: "BackgroundUpdates")
+    let backgroundTaskIdentifier = "com.beeminder.beeminder.goals.refresh"
+    let maximuimRefreshInterval = TimeInterval(15 * 60)
+
+    /// Install a background update handler to refresh goals, and arrange for it to be called regularly
+    func startUpdatingRegularlyInBackground() {
+        register()
+        scheduleAppRefresh()
+    }
+
+    private func register() {
+        BGTaskScheduler.shared.register(forTaskWithIdentifier: backgroundTaskIdentifier, using: nil) { task in
+             self.handleAppRefresh(task: task as! BGAppRefreshTask)
+        }
+    }
+
+    private func scheduleAppRefresh() {
+       let request = BGAppRefreshTaskRequest(identifier: backgroundTaskIdentifier)
+       request.earliestBeginDate = Date(timeIntervalSinceNow: maximuimRefreshInterval)
+
+       do {
+          try BGTaskScheduler.shared.submit(request)
+       } catch {
+           logger.error("Could not schedule app refresh: \(error)")
+       }
+    }
+
+    private func handleAppRefresh(task: BGAppRefreshTask) {
+        logger.notice("Performing background app refresh")
+        scheduleAppRefresh()
+
+        Task { @MainActor in
+            do {
+                let goals = try await CurrentUserManager.sharedManager.fetchGoals()
+                HealthStoreManager.sharedManager.silentlyInstallObservers(goals: goals)
+
+                // It should not be necessary to sync health kit goals here, as that should
+                // be handled by our observers (in particular, updating when the phone
+                // is unlocked and thus data is available). If we find that to be unreliable
+                // we could also trigger a data refresh here.
+            } catch {
+                logger.error("Error refreshing goals: \(error)")
+            }
+            task.setTaskCompleted(success: true)
+        }
+    }
+}

--- a/BeeSwift/HealthStoreManager.swift
+++ b/BeeSwift/HealthStoreManager.swift
@@ -91,6 +91,13 @@ class HealthStoreManager :NSObject {
         try await connection.updateWithRecentData(days: days)
     }
 
+    /// Immediately update all known goals based on HealthKit's data record
+    public func updateAllGoalsWithRecentData(days: Int) async throws {
+        for (_, connection) in self.connections {
+            try await connection.updateWithRecentData(days: days)
+        }
+    }
+
     /// Gets or creates an appropriate connection object for the supplied goal
     private func connectionFor(goal: Goal) -> GoalHealthKitConnection? {
         connectionsSemaphore.wait()

--- a/BeeSwift/Info.plist
+++ b/BeeSwift/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>BGTaskSchedulerPermittedIdentifiers</key>
+	<array>
+		<string>com.beeminder.beeminder.goals.refresh</string>
+	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>


### PR DESCRIPTION
In iOS13 Apple rolled out a new framework for processing background updates.
Now we only support iOS14+ we can migrate to this framework. We expect the behavior
to be the same, but will stop producing warnings at compile time.

Test Plan:
Run on my device and verify logging shows the updates are running.
