### PR TITLE
Provide a confirmation screen when adding health metrics

### DIFF
--- a/BeeSwift.xcodeproj/project.pbxproj
+++ b/BeeSwift.xcodeproj/project.pbxproj
@@ -95,6 +95,8 @@
 		E4B0833D293810EB00A71564 /* DataPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4B0833C293810EB00A71564 /* DataPoint.swift */; };
 		E4B0833E293810F600A71564 /* DataPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4B0833C293810EB00A71564 /* DataPoint.swift */; };
 		E4B0833F293810F600A71564 /* DataPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4B0833C293810EB00A71564 /* DataPoint.swift */; };
+		E4B0833B2934620500A71564 /* DatapointTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4B0833A2934620500A71564 /* DatapointTableViewController.swift */; };
+		E4B083392932F90400A71564 /* ConfigureHKMetricViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4B083382932F90400A71564 /* ConfigureHKMetricViewController.swift */; };
 		E4B0A32E28C194C800055EA7 /* AddDataIntents.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = E540953B260FB6A100C30784 /* AddDataIntents.intentdefinition */; };
 		E4B0A32F28C194C800055EA7 /* AddDataIntents.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = E540953B260FB6A100C30784 /* AddDataIntents.intentdefinition */; };
 		E4B0A33028C194C900055EA7 /* AddDataIntents.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = E540953B260FB6A100C30784 /* AddDataIntents.intentdefinition */; };
@@ -322,6 +324,7 @@
 		E48E271F2973261F008013C0 /* BackgroundUpdates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundUpdates.swift; sourceTree = "<group>"; };
 		E4B0833A2934620500A71564 /* DatapointTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatapointTableViewController.swift; sourceTree = "<group>"; };
 		E4B0833C293810EB00A71564 /* DataPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataPoint.swift; sourceTree = "<group>"; };
+		E4B083382932F90400A71564 /* ConfigureHKMetricViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigureHKMetricViewController.swift; sourceTree = "<group>"; };
 		E4E6427B2910C3AB004F3EA9 /* HealthKitMetric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthKitMetric.swift; sourceTree = "<group>"; };
 		E4E6427F2910C3FB004F3EA9 /* QuantityHealthKitMetric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuantityHealthKitMetric.swift; sourceTree = "<group>"; };
 		E4E642832910C442004F3EA9 /* CategoryHealthKitMetric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryHealthKitMetric.swift; sourceTree = "<group>"; };
@@ -526,6 +529,7 @@
 				A196CB191AE4142E00B90A3E /* AppDelegate.swift */,
 				E48E271F2973261F008013C0 /* BackgroundUpdates.swift */,
 				A1BE73A91E8B45BF00DEC4DB /* ChooseHKMetricViewController.swift */,
+				E4B083382932F90400A71564 /* ConfigureHKMetricViewController.swift */,
 				A10D4E921B07948500A72D29 /* DatapointsTableView.swift */,
 				A1619EA51BEECC6700E14B3A /* EditGoalNotificationsViewController.swift */,
 				A1F9D1E9211B9B7600E2BC93 /* EditDatapointViewController.swift */,
@@ -1175,6 +1179,7 @@
 				A1453B3D1AEDFA52006F48DA /* CurrentUserManager.swift in Sources */,
 				A1E618E41E7934C700D8ED93 /* HealthKitConfigTableViewCell.swift in Sources */,
 				A1781AB31DE50F59000B96C5 /* BSTextField.swift in Sources */,
+				E4B083392932F90400A71564 /* ConfigureHKMetricViewController.swift in Sources */,
 				A1BD0D1C1AEB34E0001EDE8B /* GalleryNavigationController.swift in Sources */,
 				A196CB1F1AE4142F00B90A3E /* GalleryViewController.swift in Sources */,
 				A1BE73AA1E8B45BF00DEC4DB /* ChooseHKMetricViewController.swift in Sources */,

--- a/BeeSwift/ChooseHKMetricViewController.swift
+++ b/BeeSwift/ChooseHKMetricViewController.swift
@@ -66,6 +66,11 @@ class ChooseHKMetricViewController: UIViewController {
         super.didReceiveMemoryWarning()
         // Dispose of any resources that can be recreated.
     }
+
+    override func viewWillAppear(_ animated: Bool) {
+        // Re-enable the table on returning to the view
+        self.tableView.isUserInteractionEnabled = true
+    }
 }
 
 extension ChooseHKMetricViewController : UITableViewDelegate, UITableViewDataSource {
@@ -110,6 +115,9 @@ extension ChooseHKMetricViewController : UITableViewDelegate, UITableViewDataSou
     }
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        // Prevent double taps
+        self.tableView.isUserInteractionEnabled = false
+
         Task { @MainActor in
             let section = HealthKitCategory.allCases[indexPath.section]
             let metric = self.sortedMetricsByCategory[section]![indexPath.row]
@@ -119,6 +127,7 @@ extension ChooseHKMetricViewController : UITableViewDelegate, UITableViewDataSou
                 try await HealthStoreManager.sharedManager.requestAuthorization(metric: metric)
             } catch {
                 logger.error("Error requesting permission for metric: \(error)")
+                self.tableView.isUserInteractionEnabled = true
                 return
             }
 

--- a/BeeSwift/ChooseHKMetricViewController.swift
+++ b/BeeSwift/ChooseHKMetricViewController.swift
@@ -81,6 +81,7 @@ class ChooseHKMetricViewController: UIViewController {
             let metric = self.sortedMetricsByCategory[section]![indexPath.row]
 
             do {
+                // TODO: We need to disable the button while in this state
                 try await HealthStoreManager.sharedManager.requestAuthorization(metric: metric)
             } catch {
                 logger.error("Error requesting permission for metric: \(error)")

--- a/BeeSwift/ConfigureHKMetricViewController.swift
+++ b/BeeSwift/ConfigureHKMetricViewController.swift
@@ -16,6 +16,7 @@ class ConfigureHKMetricViewController : UIViewController {
     let previewDescriptionLabel = BSLabel()
     fileprivate var datapointTableController = DatapointTableViewController()
     fileprivate let noDataFoundLabel = BSLabel()
+    let saveButton = BSButton()
 
     init(goal: Goal, metric : HealthKitMetric) {
         self.goal = goal
@@ -85,7 +86,6 @@ class ConfigureHKMetricViewController : UIViewController {
             make.right.equalTo(self.view.safeAreaLayoutGuide.snp.rightMargin).offset(-componentMargin)
         }
 
-        let saveButton = BSButton()
         self.view.addSubview(saveButton)
         saveButton.snp.makeConstraints { (make) in
             make.bottom.equalTo(self.view.safeAreaLayoutGuide.snp.bottomMargin).offset(-20)
@@ -123,7 +123,15 @@ class ConfigureHKMetricViewController : UIViewController {
         }
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        // Re-allow use of the save button as we have been shown again
+        saveButton.isUserInteractionEnabled = true
+    }
+
     @objc func saveButtonPressed() {
+        // Disable interaction to avoid double-taps
+        saveButton.isUserInteractionEnabled = false
+
         Task { @MainActor in
             let hud = MBProgressHUD.showAdded(to: self.view, animated: true)
             hud?.mode = .indeterminate
@@ -136,6 +144,10 @@ class ConfigureHKMetricViewController : UIViewController {
             } catch {
                 logger.error("Error setting up goal \(error)")
                 hud?.hide(true)
+
+                // Re-enable the save button as we did not dismiss the screen
+                saveButton.isUserInteractionEnabled = true
+                
                 return
             }
 
@@ -163,6 +175,9 @@ class ConfigureHKMetricViewController : UIViewController {
                 let alert = UIAlertController(title: "Error saving metric to Beeminder", message: errorString, preferredStyle: .alert)
                 alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
                 self.present(alert, animated: true, completion: nil)
+
+                // Re-enable the save button as we did not dismiss the screen
+                saveButton.isUserInteractionEnabled = true
             }
         }
     }

--- a/BeeSwift/ConfigureHKMetricViewController.swift
+++ b/BeeSwift/ConfigureHKMetricViewController.swift
@@ -119,9 +119,12 @@ class ConfigureHKMetricViewController : UIViewController {
                 hud?.customView = UIImageView(image: UIImage(named: "checkmark"))
                 hud?.hide(true, afterDelay: 2)
                 DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-                    // TODO: Do something better here?
-                    self.navigationController?.popViewController(animated: true)
-                    self.navigationController?.popViewController(animated: true)
+                    guard let healthKitConfigController = self.navigationController?.viewControllers.first(where: { vc in vc is HealthKitConfigViewController }) else {
+                        self.logger.error("Could not find HealthKitConfigViewController in view stack")
+                        return
+                    }
+                    self.navigationController?.popToViewController(healthKitConfigController, animated: true)
+
                 }
             } catch {
                 // TODO: This needs to be done somehow? Or dismiss?

--- a/BeeSwift/ConfigureHKMetricViewController.swift
+++ b/BeeSwift/ConfigureHKMetricViewController.swift
@@ -1,0 +1,82 @@
+// Shows a preview of a healthkit metric and allows any relevant
+// settings to be configured
+
+import Foundation
+import UIKit
+import OSLog
+
+class ConfigureHKMetricViewController : UIViewController {
+    fileprivate let logger = Logger(subsystem: "com.beeminder.beeminder", category: "ConfigureHKMetricViewController")
+
+    private let goal: Goal
+    private let metric: HealthKitMetric
+
+    init(goal: Goal, metric : HealthKitMetric) {
+        self.goal = goal
+        self.metric = metric
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        return nil
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        self.view.backgroundColor = UIColor.systemBackground
+
+        let saveButton = BSButton()
+        self.view.addSubview(saveButton)
+        saveButton.snp.makeConstraints { (make) in
+            make.bottom.equalTo(self.view.safeAreaLayoutGuide.snp.bottomMargin).offset(-20)
+            make.centerX.equalTo(self.view)
+            make.width.equalTo(self.view).multipliedBy(0.5)
+            make.height.equalTo(Constants.defaultTextFieldHeight)
+        }
+        saveButton.setTitle("Save", for: .normal)
+        saveButton.addTarget(self, action: #selector(self.saveButtonPressed), for: .touchUpInside)
+    }
+
+    @objc func saveButtonPressed() {
+        Task { @MainActor in
+            let hud = MBProgressHUD.showAdded(to: self.view, animated: true)
+            hud?.mode = .indeterminate
+
+            self.goal.healthKitMetric = metric.databaseString
+            self.goal.autodata = "apple"
+
+            do {
+                try await HealthStoreManager.sharedManager.ensureUpdatesRegularly(goal: self.goal)
+            } catch {
+                logger.error("Error setting up goal \(error)")
+                hud?.hide(true)
+                return
+            }
+
+            var params : [String : [String : String]] = [:]
+            params = ["ii_params" : ["name" : "apple", "metric" : self.goal.healthKitMetric!]]
+
+            do {
+                let _ = try await RequestManager.put(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.goal.slug).json", parameters: params)
+                hud?.mode = .customView
+                hud?.customView = UIImageView(image: UIImage(named: "checkmark"))
+                hud?.hide(true, afterDelay: 2)
+                DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                    // TODO: Do something better here?
+                    self.navigationController?.popViewController(animated: true)
+                    self.navigationController?.popViewController(animated: true)
+                }
+            } catch {
+                // TODO: This needs to be done somehow? Or dismiss?
+                // self.tableView.reloadData()
+                let errorString = error.localizedDescription
+                MBProgressHUD.hideAllHUDs(for: self.view, animated: true)
+                let alert = UIAlertController(title: "Error saving metric to Beeminder", message: errorString, preferredStyle: .alert)
+                alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
+                self.present(alert, animated: true, completion: nil)
+            }
+        }
+    }
+
+}

--- a/BeeSwift/HealthStoreManager.swift
+++ b/BeeSwift/HealthStoreManager.swift
@@ -14,7 +14,8 @@ class HealthStoreManager :NSObject {
     static let sharedManager = HealthStoreManager()
     private let logger = Logger(subsystem: "com.beeminder.beeminder", category: "HealthStoreManager")
 
-    private let healthStore = HKHealthStore()
+    // TODO: Public for now to use from config
+    let healthStore = HKHealthStore()
 
     /// The Connection objects responsible for updating goals based on their healthkit metrics
     /// Dictionary key is the goal id, as this is stable across goal renames

--- a/BeeSwift/HeathKit/CategoryHealthKitMetric.swift
+++ b/BeeSwift/HeathKit/CategoryHealthKitMetric.swift
@@ -41,6 +41,10 @@ class CategoryHealthKitMetric : HealthKitMetric {
         return results
     }
 
+    func units(healthStore : HKHealthStore) async throws -> HKUnit {
+        return HKUnit.count()
+    }
+
     private func getDataPoint(dayOffset : Int, deadline : Int, healthStore : HKHealthStore) async throws -> DataPoint {
         let bounds = try dateBoundsForDayOffset(dayOffset: dayOffset, deadline: deadline)
         let daystamp = try self.dayStampFromDayOffset(dayOffset: dayOffset, deadline: deadline)

--- a/BeeSwift/HeathKit/HealthKitMetric.swift
+++ b/BeeSwift/HeathKit/HealthKitMetric.swift
@@ -37,4 +37,6 @@ protocol HealthKitMetric {
     /// - Returns: A list of DataPoint objects containing values for the provided date range. May or may not include 0 values if there is no data. Values are not guaranteed to be in order.
     func recentDataPoints(days : Int, deadline : Int, healthStore : HKHealthStore) async throws -> [DataPoint]
 
+    /// The units this metric returns its datapoint values in
+    func units(healthStore : HKHealthStore) async throws -> HKUnit
 }

--- a/BeeSwift/HeathKit/MindfulSessionHealthKitMetric.swift
+++ b/BeeSwift/HeathKit/MindfulSessionHealthKitMetric.swift
@@ -11,4 +11,8 @@ class MindfulSessionHealthKitMetric : CategoryHealthKitMetric {
     override func valueInAppropriateUnits(rawValue: Double) -> Double {
         return rawValue / minuteInSeconds
     }
+
+    override func units(healthStore : HKHealthStore) async throws -> HKUnit {
+        return HKUnit.minute()
+    }
 }

--- a/BeeSwift/HeathKit/QuantityHealthKitMetric.swift
+++ b/BeeSwift/HeathKit/QuantityHealthKitMetric.swift
@@ -63,6 +63,15 @@ class QuantityHealthKitMetric : HealthKitMetric {
         return try await datapointsForCollection(collection: statsCollection, days: days, deadline: deadline, healthStore: healthStore)
     }
 
+    func units(healthStore : HKHealthStore) async throws -> HKUnit {
+        let quantityType = HKObjectType.quantityType(forIdentifier: hkQuantityTypeIdentifier)!
+        let units = try await healthStore.preferredUnits(for: [quantityType])
+        guard let unit = units.first?.value else {
+            throw HealthKitError("No preferred units")
+        }
+        return unit
+    }
+
     private func predicateForLast(days : Int, deadline : Int) -> NSPredicate? {
         let startTime = goalAwareStartOfDay(days: days, deadline: deadline)
         return HKQuery.predicateForSamples(withStart: startTime, end: nil)

--- a/BeeSwift/HeathKit/StandHoursHealthKitMetric.swift
+++ b/BeeSwift/HeathKit/StandHoursHealthKitMetric.swift
@@ -19,4 +19,8 @@ class StandHoursHealthKitMetric : CategoryHealthKitMetric {
         let standingSamples = categorySamples.filter{sample in sample.value == HKCategoryValueAppleStandHour.stood.rawValue}
         return Double(standingSamples.count)
     }
+
+    override func units(healthStore : HKHealthStore) async throws -> HKUnit {
+        return HKUnit.count()
+    }
 }

--- a/BeeSwift/HeathKit/TimeAsleepHealthKitMetric.swift
+++ b/BeeSwift/HeathKit/TimeAsleepHealthKitMetric.swift
@@ -14,4 +14,8 @@ class TimeAsleepHealthKitMetric : CategoryHealthKitMetric {
         let totalMinutes = totalSleepMinutes(samples: categorySamples)
         return Double(totalMinutes) / hourInMinutes
     }
+
+    override func units(healthStore : HKHealthStore) async throws -> HKUnit {
+        return HKUnit.hour()
+    }
 }

--- a/BeeSwift/HeathKit/TimeInBedHealthKitMetric.swift
+++ b/BeeSwift/HeathKit/TimeInBedHealthKitMetric.swift
@@ -16,4 +16,8 @@ class TimeInBedHealthKitMetric : CategoryHealthKitMetric {
     override func valueInAppropriateUnits(rawValue: Double) -> Double {
         return rawValue / hourInSeconds
     }
+
+    override func units(healthStore : HKHealthStore) async throws -> HKUnit {
+        return HKUnit.hour()
+    }
 }


### PR DESCRIPTION
This adds a confirmation screen to the flow for adding an apple health metric. This screen
* Allows for a preview of the data which will be added for the metric and information about the unit.
* In the future will allow additional configuration settings.

Test Plan:
Added various metrics using this, both on device and on simulator