### PR TITLE
Goal syncing should support arbitrary date ranges

### DIFF
--- a/BeeSwift.xcodeproj/project.pbxproj
+++ b/BeeSwift.xcodeproj/project.pbxproj
@@ -80,6 +80,9 @@
 		E42CB454291727B200A35AB9 /* HealthKitError.swift in Sources */ = {isa = PBXBuildFile; fileRef = E42CB451291727B200A35AB9 /* HealthKitError.swift */; };
 		E43D9AFB2929C37D00FC1578 /* DatapointValueAccessory.swift in Sources */ = {isa = PBXBuildFile; fileRef = E43D9AFA2929C37D00FC1578 /* DatapointValueAccessory.swift */; };
 		E457BE5D28C192B50012F5D0 /* IntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = E457BE5C28C192B50012F5D0 /* IntentHandler.swift */; };
+		E46FF15B2984C522009F8C7A /* DateUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = E46FF15A2984C522009F8C7A /* DateUtils.swift */; };
+		E46FF15C2984C590009F8C7A /* DateUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = E46FF15A2984C522009F8C7A /* DateUtils.swift */; };
+		E46FF15D2984C591009F8C7A /* DateUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = E46FF15A2984C522009F8C7A /* DateUtils.swift */; };
 		E48E2712296B7548008013C0 /* TotalSleepMinutes.swift in Sources */ = {isa = PBXBuildFile; fileRef = E48E2711296B7548008013C0 /* TotalSleepMinutes.swift */; };
 		E48E2714296B75E4008013C0 /* TotalSleepMinutesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E48E2713296B75E4008013C0 /* TotalSleepMinutesTests.swift */; };
 		E48E2716296B9F4B008013C0 /* TimeAsleepHealthKitMetric.swift in Sources */ = {isa = PBXBuildFile; fileRef = E48E2715296B9F4B008013C0 /* TimeAsleepHealthKitMetric.swift */; };
@@ -315,6 +318,7 @@
 		E42CB451291727B200A35AB9 /* HealthKitError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthKitError.swift; sourceTree = "<group>"; };
 		E43D9AFA2929C37D00FC1578 /* DatapointValueAccessory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatapointValueAccessory.swift; sourceTree = "<group>"; };
 		E457BE5C28C192B50012F5D0 /* IntentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntentHandler.swift; sourceTree = "<group>"; };
+		E46FF15A2984C522009F8C7A /* DateUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateUtils.swift; sourceTree = "<group>"; };
 		E48E2711296B7548008013C0 /* TotalSleepMinutes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TotalSleepMinutes.swift; sourceTree = "<group>"; };
 		E48E2713296B75E4008013C0 /* TotalSleepMinutesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TotalSleepMinutesTests.swift; sourceTree = "<group>"; };
 		E48E2715296B9F4B008013C0 /* TimeAsleepHealthKitMetric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeAsleepHealthKitMetric.swift; sourceTree = "<group>"; };
@@ -549,6 +553,7 @@
 				9B8CA57C24B120CA009C86C2 /* LaunchScreen.storyboard */,
 				E4B0833C293810EB00A71564 /* DataPoint.swift */,
 				E4B0833A2934620500A71564 /* DatapointTableViewController.swift */,
+				E46FF15A2984C522009F8C7A /* DateUtils.swift */,
 			);
 			path = BeeSwift;
 			sourceTree = "<group>";
@@ -1139,6 +1144,7 @@
 				E4B0A32F28C194C800055EA7 /* AddDataIntents.intentdefinition in Sources */,
 				A12E69511BD3EF0200AB94C2 /* TodayViewController.swift in Sources */,
 				E4E642892910D055004F3EA9 /* MindfulSessionHealthKitMetric.swift in Sources */,
+				E46FF15C2984C590009F8C7A /* DateUtils.swift in Sources */,
 				E48E271D2970ED47008013C0 /* StandHoursHealthKitMetric.swift in Sources */,
 				A1D853291EB0EA2400FC75DE /* BSLabel.swift in Sources */,
 				E42CB453291727B200A35AB9 /* HealthKitError.swift in Sources */,
@@ -1190,6 +1196,7 @@
 				E4E642802910C3FB004F3EA9 /* QuantityHealthKitMetric.swift in Sources */,
 				A10DC2DF207BFCBA00FB7B3A /* RemoveHKMetricViewController.swift in Sources */,
 				A1619EA41BEECC1500E14B3A /* EditDefaultNotificationsViewController.swift in Sources */,
+				E46FF15B2984C522009F8C7A /* DateUtils.swift in Sources */,
 				A1E619001E86980900D8ED93 /* HealthKitConfig.swift in Sources */,
 				A149B3701AEF528C00F19A09 /* SettingsViewController.swift in Sources */,
 				E52094FE2741D72300CB766F /* GoalHealthKitConnection.swift in Sources */,
@@ -1261,6 +1268,7 @@
 				E5CF51832612434A00546184 /* BSTextField.swift in Sources */,
 				E55FAB19261240F800A0CF88 /* CurrentUserManager.swift in Sources */,
 				E4E6428A2910D055004F3EA9 /* MindfulSessionHealthKitMetric.swift in Sources */,
+				E46FF15D2984C591009F8C7A /* DateUtils.swift in Sources */,
 				E48E271E2970ED48008013C0 /* StandHoursHealthKitMetric.swift in Sources */,
 				E5F7C55026113C330095684F /* AddDataIntents.intentdefinition in Sources */,
 				E42CB454291727B200A35AB9 /* HealthKitError.swift in Sources */,

--- a/BeeSwift/DateUtils.swift
+++ b/BeeSwift/DateUtils.swift
@@ -1,0 +1,17 @@
+//
+//  DateUtils.swift
+//  BeeSwift
+//
+//  Created by Theo Spears on 1/27/23.
+//  Copyright © 2023 APB. All rights reserved.
+//
+
+import Foundation
+
+class DateUtils {
+    static func date(daystamp: String) -> Date? {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyyMMdd"
+        return dateFormatter.date(from: daystamp)
+    }
+}


### PR DESCRIPTION
Previously when syncing healthkit datapoints to the server data, we would always fetch exactly 7 server points. This would go badly if there were multiple points for a day on the server, and didn't support adding features where we synced more history. Here we instead estimate the number of points to fetch from the server, and fetch more until we have confirmed we have enough.

Tests:
* Changed code temporarily to sync 30 points and verified it worked
* Created a large number of points for a day, and verified in the debugger they were all fetched once.