### PR TITLE
Re-use goal objects where possible

### DIFF
--- a/BeeSwift/AppDelegate.swift
+++ b/BeeSwift/AppDelegate.swift
@@ -132,7 +132,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     }
     
     @objc func updateBadgeCount() {
-        UIApplication.shared.applicationIconBadgeNumber = CurrentUserManager.sharedManager.goals.filter({ (goal: Goal) -> Bool in
+        guard let goals = CurrentUserManager.sharedManager.staleGoals() else { return }
+        UIApplication.shared.applicationIconBadgeNumber = goals.filter({ (goal: Goal) -> Bool in
             return goal.relativeLane.intValue < -1
         }).count
     }

--- a/BeeSwift/GalleryViewController.swift
+++ b/BeeSwift/GalleryViewController.swift
@@ -216,12 +216,15 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
             let signInVC = SignInViewController()
             signInVC.modalPresentationStyle = .fullScreen
             self.present(signInVC, animated: true, completion: nil)
+        } else {
+            self.goals = CurrentUserManager.sharedManager.staleGoals() ?? []
+            self.collectionView!.reloadData()
         }
         self.fetchGoals()
     }
     
     @objc func handleGoalsFetchedNotification() {
-        self.goals = CurrentUserManager.sharedManager.goals
+        self.goals = CurrentUserManager.sharedManager.staleGoals() ?? []
         self.lastUpdated = CurrentUserManager.sharedManager.goalsFetchedAt
         self.didFetchGoals()
     }

--- a/BeeSwift/HealthKitConfigViewController.swift
+++ b/BeeSwift/HealthKitConfigViewController.swift
@@ -45,7 +45,7 @@ class HealthKitConfigViewController: UIViewController {
         self.tableView.tableFooterView = UIView()
         self.tableView.backgroundColor = UIColor.clear
         self.tableView.register(HealthKitConfigTableViewCell.self, forCellReuseIdentifier: self.cellReuseIdentifier)
-        self.goals = CurrentUserManager.sharedManager.goals
+        self.goals = CurrentUserManager.sharedManager.staleGoals() ?? []
         self.sortGoals()
         
         NotificationCenter.default.addObserver(self, selector: #selector(self.handleMetricRemovedNotification(notification:)), name: NSNotification.Name(rawValue: CurrentUserManager.healthKitMetricRemovedNotificationName), object: nil)


### PR DESCRIPTION
We often pass around goal objects to other classes which keep references. Previously we would have many copies of the same goal, which could allow drift, or copies to get out of date. Now we instead maintain a single copy of each goal, which we can update in place.

Testing:
Loaded and clicked around the app.