### PR TITLE
Introduce a ServiceLocator

### DIFF
--- a/BeeSwift.xcodeproj/project.pbxproj
+++ b/BeeSwift.xcodeproj/project.pbxproj
@@ -79,6 +79,17 @@
 		E42CB453291727B200A35AB9 /* HealthKitError.swift in Sources */ = {isa = PBXBuildFile; fileRef = E42CB451291727B200A35AB9 /* HealthKitError.swift */; };
 		E42CB454291727B200A35AB9 /* HealthKitError.swift in Sources */ = {isa = PBXBuildFile; fileRef = E42CB451291727B200A35AB9 /* HealthKitError.swift */; };
 		E43D9AFB2929C37D00FC1578 /* DatapointValueAccessory.swift in Sources */ = {isa = PBXBuildFile; fileRef = E43D9AFA2929C37D00FC1578 /* DatapointValueAccessory.swift */; };
+		E44CE7732993317B00394E87 /* ServiceLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E44CE7722993317B00394E87 /* ServiceLocator.swift */; };
+		E44CE774299332D900394E87 /* ServiceLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E44CE7722993317B00394E87 /* ServiceLocator.swift */; };
+		E44CE775299332DA00394E87 /* ServiceLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E44CE7722993317B00394E87 /* ServiceLocator.swift */; };
+		E44CE776299332FA00394E87 /* VersionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C161932423CE9F0045C90D /* VersionManager.swift */; };
+		E44CE777299332FB00394E87 /* VersionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C161932423CE9F0045C90D /* VersionManager.swift */; };
+		E44CE7782993330000394E87 /* SignedRequestManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A142492C1FD079B4007736B3 /* SignedRequestManager.swift */; };
+		E44CE7792993330100394E87 /* SignedRequestManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A142492C1FD079B4007736B3 /* SignedRequestManager.swift */; };
+		E44CE77A2993330E00394E87 /* HealthStoreManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11BA9A31FCE54E3004BB425 /* HealthStoreManager.swift */; };
+		E44CE77B2993330E00394E87 /* HealthStoreManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11BA9A31FCE54E3004BB425 /* HealthStoreManager.swift */; };
+		E44CE77C2993349C00394E87 /* Crypto.swift in Sources */ = {isa = PBXBuildFile; fileRef = A12BA9531AFFF21800AFEF32 /* Crypto.swift */; };
+		E44CE77D2993349D00394E87 /* Crypto.swift in Sources */ = {isa = PBXBuildFile; fileRef = A12BA9531AFFF21800AFEF32 /* Crypto.swift */; };
 		E457BE5D28C192B50012F5D0 /* IntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = E457BE5C28C192B50012F5D0 /* IntentHandler.swift */; };
 		E46FF15B2984C522009F8C7A /* DateUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = E46FF15A2984C522009F8C7A /* DateUtils.swift */; };
 		E46FF15C2984C590009F8C7A /* DateUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = E46FF15A2984C522009F8C7A /* DateUtils.swift */; };
@@ -94,12 +105,11 @@
 		E48E271D2970ED47008013C0 /* StandHoursHealthKitMetric.swift in Sources */ = {isa = PBXBuildFile; fileRef = E48E271B2970EC85008013C0 /* StandHoursHealthKitMetric.swift */; };
 		E48E271E2970ED48008013C0 /* StandHoursHealthKitMetric.swift in Sources */ = {isa = PBXBuildFile; fileRef = E48E271B2970EC85008013C0 /* StandHoursHealthKitMetric.swift */; };
 		E48E27202973261F008013C0 /* BackgroundUpdates.swift in Sources */ = {isa = PBXBuildFile; fileRef = E48E271F2973261F008013C0 /* BackgroundUpdates.swift */; };
+		E4B083392932F90400A71564 /* ConfigureHKMetricViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4B083382932F90400A71564 /* ConfigureHKMetricViewController.swift */; };
 		E4B0833B2934620500A71564 /* DatapointTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4B0833A2934620500A71564 /* DatapointTableViewController.swift */; };
 		E4B0833D293810EB00A71564 /* DataPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4B0833C293810EB00A71564 /* DataPoint.swift */; };
 		E4B0833E293810F600A71564 /* DataPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4B0833C293810EB00A71564 /* DataPoint.swift */; };
 		E4B0833F293810F600A71564 /* DataPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4B0833C293810EB00A71564 /* DataPoint.swift */; };
-		E4B0833B2934620500A71564 /* DatapointTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4B0833A2934620500A71564 /* DatapointTableViewController.swift */; };
-		E4B083392932F90400A71564 /* ConfigureHKMetricViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4B083382932F90400A71564 /* ConfigureHKMetricViewController.swift */; };
 		E4B0A32E28C194C800055EA7 /* AddDataIntents.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = E540953B260FB6A100C30784 /* AddDataIntents.intentdefinition */; };
 		E4B0A32F28C194C800055EA7 /* AddDataIntents.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = E540953B260FB6A100C30784 /* AddDataIntents.intentdefinition */; };
 		E4B0A33028C194C900055EA7 /* AddDataIntents.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = E540953B260FB6A100C30784 /* AddDataIntents.intentdefinition */; };
@@ -319,6 +329,8 @@
 		E029CC25A4BEE8E42BD37670 /* Pods-BeeSwift.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BeeSwift.release.xcconfig"; path = "Pods/Target Support Files/Pods-BeeSwift/Pods-BeeSwift.release.xcconfig"; sourceTree = "<group>"; };
 		E42CB451291727B200A35AB9 /* HealthKitError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthKitError.swift; sourceTree = "<group>"; };
 		E43D9AFA2929C37D00FC1578 /* DatapointValueAccessory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatapointValueAccessory.swift; sourceTree = "<group>"; };
+		E44CE7722993317B00394E87 /* ServiceLocator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceLocator.swift; sourceTree = "<group>"; };
+		E44CE77E2993351100394E87 /* CryptoKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CryptoKit.framework; path = System/Library/Frameworks/CryptoKit.framework; sourceTree = SDKROOT; };
 		E457BE5C28C192B50012F5D0 /* IntentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntentHandler.swift; sourceTree = "<group>"; };
 		E46FF15A2984C522009F8C7A /* DateUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateUtils.swift; sourceTree = "<group>"; };
 		E48E2711296B7548008013C0 /* TotalSleepMinutes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TotalSleepMinutes.swift; sourceTree = "<group>"; };
@@ -326,9 +338,9 @@
 		E48E2715296B9F4B008013C0 /* TimeAsleepHealthKitMetric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeAsleepHealthKitMetric.swift; sourceTree = "<group>"; };
 		E48E271B2970EC85008013C0 /* StandHoursHealthKitMetric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StandHoursHealthKitMetric.swift; sourceTree = "<group>"; };
 		E48E271F2973261F008013C0 /* BackgroundUpdates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundUpdates.swift; sourceTree = "<group>"; };
+		E4B083382932F90400A71564 /* ConfigureHKMetricViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigureHKMetricViewController.swift; sourceTree = "<group>"; };
 		E4B0833A2934620500A71564 /* DatapointTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatapointTableViewController.swift; sourceTree = "<group>"; };
 		E4B0833C293810EB00A71564 /* DataPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataPoint.swift; sourceTree = "<group>"; };
-		E4B083382932F90400A71564 /* ConfigureHKMetricViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigureHKMetricViewController.swift; sourceTree = "<group>"; };
 		E4E6427B2910C3AB004F3EA9 /* HealthKitMetric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthKitMetric.swift; sourceTree = "<group>"; };
 		E4E6427F2910C3FB004F3EA9 /* QuantityHealthKitMetric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuantityHealthKitMetric.swift; sourceTree = "<group>"; };
 		E4E642832910C442004F3EA9 /* CategoryHealthKitMetric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryHealthKitMetric.swift; sourceTree = "<group>"; };
@@ -558,6 +570,7 @@
 				E4B0833C293810EB00A71564 /* DataPoint.swift */,
 				E4B0833A2934620500A71564 /* DatapointTableViewController.swift */,
 				E46FF15A2984C522009F8C7A /* DateUtils.swift */,
+				E44CE7722993317B00394E87 /* ServiceLocator.swift */,
 			);
 			path = BeeSwift;
 			sourceTree = "<group>";
@@ -606,6 +619,7 @@
 		C039E8389CFF5C0D8CF85D8D /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				E44CE77E2993351100394E87 /* CryptoKit.framework */,
 				A158DDB51E46EEA10031BD4F /* HealthKit.framework */,
 				A1B672411B0989ED00584782 /* CoreGraphics.framework */,
 				A1B6723F1B0989E800584782 /* UIKit.framework */,
@@ -1145,6 +1159,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E44CE775299332DA00394E87 /* ServiceLocator.swift in Sources */,
 				E4B0A32F28C194C800055EA7 /* AddDataIntents.intentdefinition in Sources */,
 				A12E69511BD3EF0200AB94C2 /* TodayViewController.swift in Sources */,
 				E4E642892910D055004F3EA9 /* MindfulSessionHealthKitMetric.swift in Sources */,
@@ -1156,7 +1171,10 @@
 				E4E6426A290E22E6004F3EA9 /* HealthKitConfig.swift in Sources */,
 				A1D8532D1EB0EA8100FC75DE /* UIColorExtension.swift in Sources */,
 				E4E6427D2910C3AB004F3EA9 /* HealthKitMetric.swift in Sources */,
+				E44CE776299332FA00394E87 /* VersionManager.swift in Sources */,
 				E4E642912910D327004F3EA9 /* TimeInBedHealthKitMetric.swift in Sources */,
+				E44CE7792993330100394E87 /* SignedRequestManager.swift in Sources */,
+				E44CE77C2993349C00394E87 /* Crypto.swift in Sources */,
 				A142492A1FD0788F007736B3 /* UIDevice.swift in Sources */,
 				A1D8532C1EB0EA5700FC75DE /* UIFontExtension.swift in Sources */,
 				A1D853261EB0332D00FC75DE /* Constants.swift in Sources */,
@@ -1167,6 +1185,7 @@
 				E4B0833E293810F600A71564 /* DataPoint.swift in Sources */,
 				A13C9CFB2345C18D002912C4 /* Goal.swift in Sources */,
 				A142491F1FD073EC007736B3 /* RequestManager.swift in Sources */,
+				E44CE77A2993330E00394E87 /* HealthStoreManager.swift in Sources */,
 				E48E2719296BA0A6008013C0 /* TotalSleepMinutes.swift in Sources */,
 				A1D8532B1EB0EA2D00FC75DE /* BSTextField.swift in Sources */,
 				A1D853281EB0DE0700FC75DE /* TodayTableViewCell.swift in Sources */,
@@ -1193,6 +1212,7 @@
 				A1BE73AC1E8B47E700DEC4DB /* HealthKitMetricTableViewCell.swift in Sources */,
 				A1C11B481B06F5D100D22871 /* Constants.swift in Sources */,
 				E4B0833D293810EB00A71564 /* DataPoint.swift in Sources */,
+				E44CE7732993317B00394E87 /* ServiceLocator.swift in Sources */,
 				E55760F526549D310076B95A /* AddDataIntentHandler.swift in Sources */,
 				A11488BE1EE9B0CE003316E1 /* UIDevice.swift in Sources */,
 				E5C9EFE62612E02700DBBEAE /* AddDataIntents.intentdefinition in Sources */,
@@ -1270,6 +1290,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E44CE774299332D900394E87 /* ServiceLocator.swift in Sources */,
 				E5CF51832612434A00546184 /* BSTextField.swift in Sources */,
 				E55FAB19261240F800A0CF88 /* CurrentUserManager.swift in Sources */,
 				E4E6428A2910D055004F3EA9 /* MindfulSessionHealthKitMetric.swift in Sources */,
@@ -1281,7 +1302,10 @@
 				E4E6426B290E22E9004F3EA9 /* HealthKitConfig.swift in Sources */,
 				E5CF51822612434700546184 /* BSLabel.swift in Sources */,
 				E4E6427E2910C3AB004F3EA9 /* HealthKitMetric.swift in Sources */,
+				E44CE777299332FB00394E87 /* VersionManager.swift in Sources */,
 				E4E642922910D327004F3EA9 /* TimeInBedHealthKitMetric.swift in Sources */,
+				E44CE7782993330000394E87 /* SignedRequestManager.swift in Sources */,
+				E44CE77D2993349D00394E87 /* Crypto.swift in Sources */,
 				E557610026549DD10076B95A /* AddDataIntentHandler.swift in Sources */,
 				E5CF51702612432400546184 /* RequestManager.swift in Sources */,
 				E5CF519B2612435B00546184 /* UIDevice.swift in Sources */,
@@ -1292,6 +1316,7 @@
 				E4B0833F293810F600A71564 /* DataPoint.swift in Sources */,
 				E5CF517C2612434300546184 /* BSButton.swift in Sources */,
 				E5CF51892612434E00546184 /* UIColorExtension.swift in Sources */,
+				E44CE77B2993330E00394E87 /* HealthStoreManager.swift in Sources */,
 				E48E271A296BA0A7008013C0 /* TotalSleepMinutes.swift in Sources */,
 				E457BE5D28C192B50012F5D0 /* IntentHandler.swift in Sources */,
 				E5CF518F2612435000546184 /* UIFontExtension.swift in Sources */,

--- a/BeeSwift/AddDataIntentHandler.swift
+++ b/BeeSwift/AddDataIntentHandler.swift
@@ -51,7 +51,7 @@ class AddDataIntentHandler: NSObject, AddDataIntentHandling {
 
         Task {
             do {
-                let _ = try await RequestManager.addDatapoint(urtext: "^ \(value) \"\(comment)\"", slug: goalSlug)
+                let _ = try await ServiceLocator.requestManager.addDatapoint(urtext: "^ \(value) \"\(comment)\"", slug: goalSlug)
                 completion(AddDataIntentResponse.success(goal: goalSlug))
             } catch {
                 completion(AddDataIntentResponse.failure(goal: goalSlug))

--- a/BeeSwift/BackgroundUpdates.swift
+++ b/BeeSwift/BackgroundUpdates.swift
@@ -36,10 +36,10 @@ class BackgroundUpdates {
 
         Task { @MainActor in
             do {
-                let goals = try await CurrentUserManager.sharedManager.fetchGoals()
-                HealthStoreManager.sharedManager.silentlyInstallObservers(goals: goals)
+                let goals = try await ServiceLocator.currentUserManager.fetchGoals()
+                ServiceLocator.healthStoreManager.silentlyInstallObservers(goals: goals)
 
-                try await HealthStoreManager.sharedManager.updateAllGoalsWithRecentData(days: 3)
+                try await ServiceLocator.healthStoreManager.updateAllGoalsWithRecentData(days: 3)
             } catch {
                 logger.error("Error refreshing goals: \(error)")
             }

--- a/BeeSwift/ChooseHKMetricViewController.swift
+++ b/BeeSwift/ChooseHKMetricViewController.swift
@@ -123,7 +123,7 @@ extension ChooseHKMetricViewController : UITableViewDelegate, UITableViewDataSou
             let metric = self.sortedMetricsByCategory[section]![indexPath.row]
 
             do {
-                try await HealthStoreManager.sharedManager.requestAuthorization(metric: metric)
+                try await ServiceLocator.healthStoreManager.requestAuthorization(metric: metric)
             } catch {
                 logger.error("Error requesting permission for metric: \(error)")
                 self.tableView.isUserInteractionEnabled = true

--- a/BeeSwift/ConfigureHKMetricViewController.swift
+++ b/BeeSwift/ConfigureHKMetricViewController.swift
@@ -98,7 +98,7 @@ class ConfigureHKMetricViewController : UIViewController {
 
         self.datapointTableController.hhmmformat = self.goal.hhmmformat
         Task { @MainActor in
-            let datapoints = try await self.metric.recentDataPoints(days: 5, deadline: self.goal.deadline.intValue, healthStore: HealthStoreManager.sharedManager.healthStore)
+            let datapoints = try await self.metric.recentDataPoints(days: 5, deadline: self.goal.deadline.intValue, healthStore: ServiceLocator.healthStoreManager.healthStore)
             self.datapointTableController.datapoints = datapoints
 
             if datapoints.isEmpty {
@@ -113,7 +113,7 @@ class ConfigureHKMetricViewController : UIViewController {
                 }
             }
 
-            let units = try await self.metric.units(healthStore: HealthStoreManager.sharedManager.healthStore)
+            let units = try await self.metric.units(healthStore: ServiceLocator.healthStoreManager.healthStore)
             unitsLabel.attributedText = {
                 let text = NSMutableAttributedString()
                 text.append(NSMutableAttributedString(string: "This metric reports results as ", attributes: [NSAttributedString.Key.font: UIFont.beeminder.defaultFont]))
@@ -140,7 +140,7 @@ class ConfigureHKMetricViewController : UIViewController {
             self.goal.autodata = "apple"
 
             do {
-                try await HealthStoreManager.sharedManager.ensureUpdatesRegularly(goal: self.goal)
+                try await ServiceLocator.healthStoreManager.ensureUpdatesRegularly(goal: self.goal)
             } catch {
                 logger.error("Error setting up goal \(error)")
                 hud?.hide(true)
@@ -155,7 +155,7 @@ class ConfigureHKMetricViewController : UIViewController {
             params = ["ii_params" : ["name" : "apple", "metric" : self.goal.healthKitMetric!]]
 
             do {
-                let _ = try await RequestManager.put(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.goal.slug).json", parameters: params)
+                let _ = try await ServiceLocator.requestManager.put(url: "api/v1/users/\(ServiceLocator.currentUserManager.username!)/goals/\(self.goal.slug).json", parameters: params)
                 hud?.mode = .customView
                 hud?.customView = UIImageView(image: UIImage(named: "checkmark"))
                 hud?.hide(true, afterDelay: 2)

--- a/BeeSwift/ConfigureNotificationsViewController.swift
+++ b/BeeSwift/ConfigureNotificationsViewController.swift
@@ -88,7 +88,7 @@ class ConfigureNotificationsViewController: UIViewController {
     func fetchGoals() {
         Task { @MainActor in
             do {
-                let goals = try await CurrentUserManager.sharedManager.fetchGoals()
+                let goals = try await ServiceLocator.currentUserManager.fetchGoals()
                 self.goals = goals
                 self.sortGoals()
             } catch {

--- a/BeeSwift/Crypto.swift
+++ b/BeeSwift/Crypto.swift
@@ -1,3 +1,6 @@
+import Foundation
+import CommonCrypto
+
 enum HMACAlgorithm {
     case MD5, SHA1, SHA224, SHA256, SHA384, SHA512
     

--- a/BeeSwift/EditDatapointViewController.swift
+++ b/BeeSwift/EditDatapointViewController.swift
@@ -185,10 +185,10 @@ class EditDatapointViewController: UIViewController, UITextFieldDelegate {
 
             do {
                 let params = [
-                    "access_token": CurrentUserManager.sharedManager.accessToken!,
+                    "access_token": ServiceLocator.currentUserManager.accessToken!,
                     "urtext": self.urtext()
                 ]
-                let _ = try await RequestManager.put(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.goalSlug)/datapoints/\(self.datapoint.id).json", parameters: params)
+                let _ = try await ServiceLocator.requestManager.put(url: "api/v1/users/\(ServiceLocator.currentUserManager.username!)/goals/\(self.goalSlug)/datapoints/\(self.datapoint.id).json", parameters: params)
                 let hud = MBProgressHUD.allHUDs(for: self.view).first as? MBProgressHUD
                 hud?.mode = .customView
                 hud?.customView = UIImageView(image: UIImage(named: "checkmark"))
@@ -203,13 +203,13 @@ class EditDatapointViewController: UIViewController, UITextFieldDelegate {
     func deleteDatapoint() {
         Task { @MainActor in
             let params = [
-                "access_token": CurrentUserManager.sharedManager.accessToken!
+                "access_token": ServiceLocator.currentUserManager.accessToken!
             ]
             let hud = MBProgressHUD.showAdded(to: self.view, animated: true)
             hud?.mode = .indeterminate
 
             do {
-                let _ = try await RequestManager.delete(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.goalSlug)/datapoints/\(self.datapoint.id).json", parameters: params)
+                let _ = try await ServiceLocator.requestManager.delete(url: "api/v1/users/\(ServiceLocator.currentUserManager.username!)/goals/\(self.goalSlug)/datapoints/\(self.datapoint.id).json", parameters: params)
 
                 let hud = MBProgressHUD.allHUDs(for: self.view).first as? MBProgressHUD
                 hud?.mode = .customView

--- a/BeeSwift/EditDefaultNotificationsViewController.swift
+++ b/BeeSwift/EditDefaultNotificationsViewController.swift
@@ -14,9 +14,9 @@ class EditDefaultNotificationsViewController: EditNotificationsViewController {
     
     override init() {
         super.init()
-        self.leadTimeStepper.value = CurrentUserManager.sharedManager.defaultLeadTime().doubleValue
-        self.alertstart = CurrentUserManager.sharedManager.defaultAlertstart()
-        self.deadline = CurrentUserManager.sharedManager.defaultDeadline()
+        self.leadTimeStepper.value = ServiceLocator.currentUserManager.defaultLeadTime().doubleValue
+        self.alertstart = ServiceLocator.currentUserManager.defaultAlertstart()
+        self.deadline = ServiceLocator.currentUserManager.defaultDeadline()
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -29,8 +29,8 @@ class EditDefaultNotificationsViewController: EditNotificationsViewController {
             guard let leadtime = userInfo["leadtime"] else { return }
             let params = [ "default_leadtime" : leadtime ]
             do {
-                let _ = try await RequestManager.put(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!).json", parameters: params)
-                CurrentUserManager.sharedManager.setDefaultLeadTime(leadtime)
+                let _ = try await ServiceLocator.requestManager.put(url: "api/v1/users/\(ServiceLocator.currentUserManager.username!).json", parameters: params)
+                ServiceLocator.currentUserManager.setDefaultLeadTime(leadtime)
             } catch {
                 logger.error("Error setting default leadtime: \(error)")
                 // show alert
@@ -49,8 +49,8 @@ class EditDefaultNotificationsViewController: EditNotificationsViewController {
                 self.updateAlertstartLabel(self.midnightOffsetFromTimePickerView())
                 let params = ["default_alertstart" : self.midnightOffsetFromTimePickerView()]
                 do {
-                    let _ = try await RequestManager.put(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!).json", parameters: params)
-                    CurrentUserManager.sharedManager.setDefaultAlertstart(self.midnightOffsetFromTimePickerView())
+                    let _ = try await ServiceLocator.requestManager.put(url: "api/v1/users/\(ServiceLocator.currentUserManager.username!).json", parameters: params)
+                    ServiceLocator.currentUserManager.setDefaultAlertstart(self.midnightOffsetFromTimePickerView())
                 } catch {
                     logger.error("Error setting default alert start: \(error)")
                     //foo
@@ -60,8 +60,8 @@ class EditDefaultNotificationsViewController: EditNotificationsViewController {
                 self.updateDeadlineLabel(self.midnightOffsetFromTimePickerView())
                 let params = ["default_deadline" : self.midnightOffsetFromTimePickerView()]
                 do {
-                    let _ = try await RequestManager.put(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!).json", parameters: params)
-                    CurrentUserManager.sharedManager.setDefaultDeadline(self.midnightOffsetFromTimePickerView())
+                    let _ = try await ServiceLocator.requestManager.put(url: "api/v1/users/\(ServiceLocator.currentUserManager.username!).json", parameters: params)
+                    ServiceLocator.currentUserManager.setDefaultDeadline(self.midnightOffsetFromTimePickerView())
                 } catch {
                     logger.error("Error setting default deadline: \(error)")
                     //foo

--- a/BeeSwift/EditGoalNotificationsViewController.swift
+++ b/BeeSwift/EditGoalNotificationsViewController.swift
@@ -65,7 +65,7 @@ class EditGoalNotificationsViewController : EditNotificationsViewController {
             let leadtime = userInfo["leadtime"]
             let params = [ "leadtime" : leadtime, "use_defaults" : false ]
             do {
-                let _ = try await RequestManager.put(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.goal!.slug).json", parameters: params as [String : Any])
+                let _ = try await ServiceLocator.requestManager.put(url: "api/v1/users/\(ServiceLocator.currentUserManager.username!)/goals/\(self.goal!.slug).json", parameters: params as [String : Any])
                 self.goal!.leadtime = leadtime!
                 self.goal!.use_defaults = NSNumber(value: false as Bool)
                 self.useDefaultsSwitch.isOn = false
@@ -82,7 +82,7 @@ class EditGoalNotificationsViewController : EditNotificationsViewController {
                 self.updateAlertstartLabel(self.midnightOffsetFromTimePickerView())
                 do {
                     let params = ["alertstart" : self.midnightOffsetFromTimePickerView(), "use_defaults" : false]
-                    let _ = try await RequestManager.put(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.goal!.slug).json", parameters: params)
+                    let _ = try await ServiceLocator.requestManager.put(url: "api/v1/users/\(ServiceLocator.currentUserManager.username!)/goals/\(self.goal!.slug).json", parameters: params)
                     self.goal!.alertstart = self.midnightOffsetFromTimePickerView()
                     self.goal!.use_defaults = NSNumber(value: false as Bool)
                     self.useDefaultsSwitch.isOn = false
@@ -95,7 +95,7 @@ class EditGoalNotificationsViewController : EditNotificationsViewController {
                 self.updateDeadlineLabel(self.midnightOffsetFromTimePickerView())
                 do {
                     let params = ["deadline" : self.midnightOffsetFromTimePickerView(), "use_defaults" : false]
-                    let _ = try await RequestManager.put(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.goal!.slug).json", parameters: params)
+                    let _ = try await ServiceLocator.requestManager.put(url: "api/v1/users/\(ServiceLocator.currentUserManager.username!)/goals/\(self.goal!.slug).json", parameters: params)
                     self.goal?.deadline = self.midnightOffsetFromTimePickerView()
                     self.goal!.use_defaults = NSNumber(value: false as Bool)
                     self.useDefaultsSwitch.isOn = false
@@ -117,7 +117,7 @@ class EditGoalNotificationsViewController : EditNotificationsViewController {
                 Task { @MainActor in
                     do {
                         let params = ["use_defaults" : true]
-                        let _ = try await RequestManager.put(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.goal!.slug).json", parameters: params)
+                        let _ = try await ServiceLocator.requestManager.put(url: "api/v1/users/\(ServiceLocator.currentUserManager.username!)/goals/\(self.goal!.slug).json", parameters: params)
                         self.goal?.use_defaults = NSNumber(value: true as Bool)
                     } catch {
                         self.logger.error("Error setting goal to use defaults: \(error)")
@@ -126,20 +126,20 @@ class EditGoalNotificationsViewController : EditNotificationsViewController {
                     }
 
                     do {
-                        try await CurrentUserManager.sharedManager.syncNotificationDefaults()
+                        try await ServiceLocator.currentUserManager.syncNotificationDefaults()
                     } catch {
                         self.logger.error("Error syncing notification defaults")
                         // TODO: Show UI failure
                         return
                     }
 
-                    self.leadTimeStepper.value = CurrentUserManager.sharedManager.defaultLeadTime().doubleValue
+                    self.leadTimeStepper.value = ServiceLocator.currentUserManager.defaultLeadTime().doubleValue
                     self.updateLeadTimeLabel()
-                    self.alertstart = CurrentUserManager.sharedManager.defaultAlertstart()
-                    self.deadline   = CurrentUserManager.sharedManager.defaultDeadline()
-                    self.goal!.leadtime = CurrentUserManager.sharedManager.defaultLeadTime()
-                    self.goal!.alertstart = CurrentUserManager.sharedManager.defaultAlertstart()
-                    self.goal!.deadline = CurrentUserManager.sharedManager.defaultDeadline()
+                    self.alertstart = ServiceLocator.currentUserManager.defaultAlertstart()
+                    self.deadline   = ServiceLocator.currentUserManager.defaultDeadline()
+                    self.goal!.leadtime = ServiceLocator.currentUserManager.defaultLeadTime()
+                    self.goal!.alertstart = ServiceLocator.currentUserManager.defaultAlertstart()
+                    self.goal!.deadline = ServiceLocator.currentUserManager.defaultDeadline()
                     self.timePickerEditingMode = self.timePickerEditingMode // trigger the setter which updates the timePicker components
                 }
             }))
@@ -152,7 +152,7 @@ class EditGoalNotificationsViewController : EditNotificationsViewController {
             Task { @MainActor in
                 do {
                     let params = ["use_defaults" : false]
-                    let _ = try await RequestManager.put(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.goal!.slug).json", parameters: params)
+                    let _ = try await ServiceLocator.requestManager.put(url: "api/v1/users/\(ServiceLocator.currentUserManager.username!)/goals/\(self.goal!.slug).json", parameters: params)
                         self.goal?.use_defaults = NSNumber(value: false as Bool)
                 } catch {
                     logger.error("Error setting goal to NOT use defaults: \(error)")

--- a/BeeSwift/Goal.swift
+++ b/BeeSwift/Goal.swift
@@ -307,7 +307,7 @@ class Goal {
     }
 
     func refresh() async throws {
-        let responseObject = try await RequestManager.get(url: "/api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.slug)?access_token=\(CurrentUserManager.sharedManager.accessToken!)&datapoints_count=5", parameters: nil)
+        let responseObject = try await ServiceLocator.requestManager.get(url: "/api/v1/users/\(ServiceLocator.currentUserManager.username!)/goals/\(self.slug)?access_token=\(ServiceLocator.currentUserManager.accessToken!)&datapoints_count=5", parameters: nil)
         self.updateToMatch(json: JSON(responseObject!))
     }
 
@@ -356,7 +356,7 @@ class Goal {
         Task { @MainActor in
             let params = ["sort" : "daystamp", "count" : 7] as [String : Any]
             do {
-                let response = try await RequestManager.get(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.slug)/datapoints.json", parameters: params)
+                let response = try await ServiceLocator.requestManager.get(url: "api/v1/users/\(ServiceLocator.currentUserManager.username!)/goals/\(self.slug)/datapoints.json", parameters: params)
                 let responseJSON = JSON(response!)
                 success(ExistingDataPoint.fromJSONArray(array: responseJSON.arrayValue))
             } catch {
@@ -381,13 +381,13 @@ class Goal {
             let daystamp = datapoint.daystamp
             let requestId = "\(daystamp)-\(self.minuteStamp())"
             let params = [
-                "access_token": CurrentUserManager.sharedManager.accessToken!,
+                "access_token": ServiceLocator.currentUserManager.accessToken!,
                 "value": "\(datapointValue)",
                 "comment": "Auto-updated via Apple Health",
                 "requestid": requestId
             ]
             do {
-                let _ = try await RequestManager.put(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.slug)/datapoints/\(datapoint.id).json", parameters: params)
+                let _ = try await ServiceLocator.requestManager.put(url: "api/v1/users/\(ServiceLocator.currentUserManager.username!)/goals/\(self.slug)/datapoints/\(datapoint.id).json", parameters: params)
                 success?()
             } catch {
                 errorCompletion?()
@@ -398,7 +398,7 @@ class Goal {
     func deleteDatapoint(datapoint : ExistingDataPoint) {
         Task { @MainActor in
             do {
-                let _ = try await RequestManager.delete(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.slug)/datapoints/\(datapoint.id)", parameters: nil)
+                let _ = try await ServiceLocator.requestManager.delete(url: "api/v1/users/\(ServiceLocator.currentUserManager.username!)/goals/\(self.slug)/datapoints/\(datapoint.id)", parameters: nil)
             } catch {
                 logger.error("Error deleting datapoint: \(error)")
             }
@@ -408,7 +408,7 @@ class Goal {
     func postDatapoint(params : [String : String], success : ((Any?) -> Void)?, failure : ((Error?, String?) -> Void)?) {
         Task { @MainActor in
             do {
-                let response = try await RequestManager.post(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.slug)/datapoints.json", parameters: params)
+                let response = try await ServiceLocator.requestManager.post(url: "api/v1/users/\(ServiceLocator.currentUserManager.username!)/goals/\(self.slug)/datapoints.json", parameters: params)
                 success?(response)
             } catch {
                 failure?(error, error.localizedDescription)
@@ -418,7 +418,7 @@ class Goal {
 
     func fetchDatapoints(sort: String, per: Int, page: Int) async throws -> [ExistingDataPoint] {
         let params = ["sort" : sort, "per" : per, "page": page] as [String : Any]
-        let response = try await RequestManager.get(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.slug)/datapoints.json", parameters: params)
+        let response = try await ServiceLocator.requestManager.get(url: "api/v1/users/\(ServiceLocator.currentUserManager.username!)/goals/\(self.slug)/datapoints.json", parameters: params)
         let responseJSON = JSON(response!)
         return ExistingDataPoint.fromJSONArray(array: responseJSON.arrayValue)
     }
@@ -491,7 +491,7 @@ class Goal {
             }
 
             let requestId = "\(newDataPoint.daystamp)-\(minuteStamp())"
-            let params = ["access_token": CurrentUserManager.sharedManager.accessToken!, "urtext": "\(newDataPoint.daystamp.suffix(2)) \(newDataPoint.value) \"\(newDataPoint.comment)\"", "requestid": requestId]
+            let params = ["access_token": ServiceLocator.currentUserManager.accessToken!, "urtext": "\(newDataPoint.daystamp.suffix(2)) \(newDataPoint.value) \"\(newDataPoint.comment)\"", "requestid": requestId]
 
             try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
                 postDatapoint(params: params, success: { (responseObject) in

--- a/BeeSwift/GoalCollectionViewCell.swift
+++ b/BeeSwift/GoalCollectionViewCell.swift
@@ -102,7 +102,7 @@ class GoalCollectionViewCell: UICollectionViewCell {
     
     func setThumbnailImage() {
         guard let _ = self.goal else { return }
-        if CurrentUserManager.sharedManager.isDeadbeat() {
+        if ServiceLocator.currentUserManager.isDeadbeat() {
             self.thumbnailImageView.image = UIImage(named: "ThumbnailPlaceholder")
         } else {
             self.thumbnailImageView.af.setImage(withURL: URL(string: self.goal!.cacheBustingThumbUrl)!, placeholderImage: UIImage(named: "ThumbnailPlaceholder"), filter: nil, progress: nil, progressQueue: DispatchQueue.global(), imageTransition: .noTransition, runImageTransitionIfCached: false, completion: nil)

--- a/BeeSwift/HealthKitConfigViewController.swift
+++ b/BeeSwift/HealthKitConfigViewController.swift
@@ -45,7 +45,7 @@ class HealthKitConfigViewController: UIViewController {
         self.tableView.tableFooterView = UIView()
         self.tableView.backgroundColor = UIColor.clear
         self.tableView.register(HealthKitConfigTableViewCell.self, forCellReuseIdentifier: self.cellReuseIdentifier)
-        self.goals = CurrentUserManager.sharedManager.staleGoals() ?? []
+        self.goals = ServiceLocator.currentUserManager.staleGoals() ?? []
         self.sortGoals()
         
         NotificationCenter.default.addObserver(self, selector: #selector(self.handleMetricRemovedNotification(notification:)), name: NSNotification.Name(rawValue: CurrentUserManager.healthKitMetricRemovedNotificationName), object: nil)
@@ -70,7 +70,7 @@ class HealthKitConfigViewController: UIViewController {
 
             MBProgressHUD.showAdded(to: self.view, animated: true)
             do {
-                let goals = try await CurrentUserManager.sharedManager.fetchGoals()
+                let goals = try await ServiceLocator.currentUserManager.fetchGoals()
                 MBProgressHUD.hideAllHUDs(for: self.view, animated: true)
                 self.goals = goals
                 self.sortGoals()

--- a/BeeSwift/HealthStoreManager.swift
+++ b/BeeSwift/HealthStoreManager.swift
@@ -11,7 +11,6 @@ import HealthKit
 import OSLog
 
 class HealthStoreManager :NSObject {
-    static let sharedManager = HealthStoreManager()
     private let logger = Logger(subsystem: "com.beeminder.beeminder", category: "HealthStoreManager")
 
     // TODO: Public for now to use from config

--- a/BeeSwift/RemoveHKMetricViewController.swift
+++ b/BeeSwift/RemoveHKMetricViewController.swift
@@ -73,7 +73,7 @@ class RemoveHKMetricViewController: UIViewController {
 
         Task { @MainActor in
             do {
-                let responseObject = try await RequestManager.put(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.goal!.slug).json", parameters: params)
+                let responseObject = try await ServiceLocator.requestManager.put(url: "api/v1/users/\(ServiceLocator.currentUserManager.username!)/goals/\(self.goal!.slug).json", parameters: params)
 
                 self.goal = Goal(json: JSON(responseObject!))
 

--- a/BeeSwift/ServiceLocator.swift
+++ b/BeeSwift/ServiceLocator.swift
@@ -1,0 +1,17 @@
+//
+//  ServiceLocator.swift
+//  BeeSwift
+//
+//  Created by Theo Spears on 2/7/23.
+//  Copyright © 2023 APB. All rights reserved.
+//
+
+import Foundation
+
+class ServiceLocator {
+    static let requestManager = RequestManager()
+    static let signedRequestManager = SignedRequestManager(requestManager: requestManager)
+    static let currentUserManager = CurrentUserManager(requestManager: requestManager)
+    static let healthStoreManager = HealthStoreManager()
+    static let versionManager = VersionManager(requestManager: requestManager)
+}

--- a/BeeSwift/SettingsViewController.swift
+++ b/BeeSwift/SettingsViewController.swift
@@ -59,7 +59,7 @@ class SettingsViewController: UIViewController {
     
     func signOutButtonPressed() {
         Task { @MainActor in
-            await CurrentUserManager.sharedManager.signOut()
+            await ServiceLocator.currentUserManager.signOut()
             self.navigationController?.popViewController(animated: true)
         }
     }    
@@ -114,7 +114,7 @@ extension SettingsViewController : UITableViewDataSource, UITableViewDelegate {
             cell.imageName = "Notifications"
             cell.accessoryType = .disclosureIndicator
         case 2:
-            cell.title = "Time zone: \(CurrentUserManager.sharedManager.timezone())"
+            cell.title = "Time zone: \(ServiceLocator.currentUserManager.timezone())"
             cell.imageName = "Clock"
             cell.accessoryType = .none
         case 3:

--- a/BeeSwift/SignInViewController.swift
+++ b/BeeSwift/SignInViewController.swift
@@ -191,7 +191,7 @@ class SignInViewController : UIViewController, UITextFieldDelegate, SFSafariView
     }
     
     @objc func chooseSignInButtonPressed() {
-        CurrentUserManager.sharedManager.signingUp = false
+        ServiceLocator.currentUserManager.signingUp = false
         //self.divider.isHidden = false
         //self.backToSignUpButton.isHidden = false
         self.emailTextField.isHidden = false
@@ -242,7 +242,7 @@ class SignInViewController : UIViewController, UITextFieldDelegate, SFSafariView
             }
 
             MBProgressHUD.showAdded(to: self.view, animated: true)
-            await CurrentUserManager.sharedManager.signInWithEmail(email, password: password)
+            await ServiceLocator.currentUserManager.signInWithEmail(email, password: password)
         }
     }
     

--- a/BeeSwift/SignedRequestManager.swift
+++ b/BeeSwift/SignedRequestManager.swift
@@ -10,19 +10,24 @@ import Foundation
 import Alamofire
 import BeeKit
 
-class SignedRequestManager: RequestManager {
-    
-    class func signedGET(url: String, parameters: [String: Any]?) async throws -> Any? {
-        let params = SignedRequestManager.signedParameters(RequestManager.authedParams(parameters))
-        return try await RequestManager.rawRequest(url: url, method: .get, parameters: params)
+class SignedRequestManager {
+    private let requestManager: RequestManager
+
+    init(requestManager: RequestManager) {
+        self.requestManager = requestManager
+    }
+
+    func signedGET(url: String, parameters: [String: Any]?) async throws -> Any? {
+        let params = signedParameters(requestManager.authedParams(parameters))
+        return try await requestManager.rawRequest(url: url, method: .get, parameters: params)
     }
     
-    class func signedPOST(url: String, parameters: [String: Any]?) async throws -> Any? {
-        let params = SignedRequestManager.signedParameters(RequestManager.authedParams(parameters))
-        return try await RequestManager.rawRequest(url: url, method: .post, parameters: params)
+    func signedPOST(url: String, parameters: [String: Any]?) async throws -> Any? {
+        let params = signedParameters(requestManager.authedParams(parameters))
+        return try await requestManager.rawRequest(url: url, method: .post, parameters: params)
     }
     
-    fileprivate class func signedParameters(_ params: [String: Any]?) -> [String: Any]? {
+    fileprivate func signedParameters(_ params: [String: Any]?) -> [String: Any]? {
         if params == nil { return params }
         var signed = params
         var base = ""

--- a/BeeSwift/TimerViewController.swift
+++ b/BeeSwift/TimerViewController.swift
@@ -172,7 +172,7 @@ class TimerViewController: UIViewController {
         Task { @MainActor in
             do {
                 let params = ["urtext": self.urtext(), "requestid": UUID().uuidString]
-                let _ = try await RequestManager.post(url: "api/v1/users/\(CurrentUserManager.sharedManager.username!)/goals/\(self.slug!)/datapoints.json", parameters: params)
+                let _ = try await ServiceLocator.requestManager.post(url: "api/v1/users/\(ServiceLocator.currentUserManager.username!)/goals/\(self.slug!)/datapoints.json", parameters: params)
                 hud?.mode = .text
                 hud?.labelText = "Added!"
                 DispatchQueue.main.asyncAfter(deadline: .now() + 2, execute: {

--- a/BeeSwiftToday/TodayTableViewCell.swift
+++ b/BeeSwiftToday/TodayTableViewCell.swift
@@ -156,7 +156,7 @@ class TodayTableViewCell: UITableViewCell {
 
         Task { @MainActor in
             do {
-                let _ = try await RequestManager.post(url: "api/v1/users/me/goals/\(slug)/datapoints.json", parameters: params)
+                let _ = try await ServiceLocator.requestManager.post(url: "api/v1/users/me/goals/\(slug)/datapoints.json", parameters: params)
             } catch {
                 self.addDataButton.setTitle("oops!", for: .normal)
                 return
@@ -179,7 +179,7 @@ class TodayTableViewCell: UITableViewCell {
 
             let parameters = ["access_token": token]
             do {
-                let responseObject = try await RequestManager.get(url: "api/v1/users/me/goals/\(slug)", parameters: parameters)
+                let responseObject = try await ServiceLocator.requestManager.get(url: "api/v1/users/me/goals/\(slug)", parameters: parameters)
                 let goalJSON = JSON(responseObject!)
                 if (!goalJSON["queued"].bool!) {
                     self.pollTimer?.invalidate()
@@ -205,7 +205,7 @@ class TodayTableViewCell: UITableViewCell {
     /// and replacing it with the downloaded, updated image
     /// provided via the urlStr
     func setGraphImage(urlStr: String?) {
-        guard !CurrentUserManager.sharedManager.isDeadbeat(),
+        guard !ServiceLocator.currentUserManager.isDeadbeat(),
         let thumbUrlStr = urlStr, let thumbUrl = URL(string: thumbUrlStr) else {
             self.graphImageView.image = self.thumbnailPlaceholder
             return


### PR DESCRIPTION
Currently BeeSwift makes heavy use of a `sharedManager` pattern to give components access to specific functionality. This works, but makes testing difficult as we cannot provide test alternatives when writing unit tests. To make testing easier, it would be nice to instead inject dependencies.

Take a first step towards this by introducing a ServiceLocator wrapper and converting all statics (e.g. RequestManager) to instances. The ServiceLocator allows existing usages to work, but is a first step towards passing instances through to components instead.

Test Plan:
Click through the app on a device