### PR TITLE
Add additional logging to understand background update behavior

### DIFF
--- a/BeeSwift/AppDelegate.swift
+++ b/BeeSwift/AppDelegate.swift
@@ -131,10 +131,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     }
     
     @objc func updateBadgeCount() {
+        logger.notice("Updating badge count")
+
         guard let goals = ServiceLocator.goalManager.staleGoals() else { return }
-        UIApplication.shared.applicationIconBadgeNumber = goals.filter({ (goal: Goal) -> Bool in
+        let beemergencyCount = goals.filter({ (goal: Goal) -> Bool in
             return goal.relativeLane.intValue < -1
         }).count
+        logger.notice("Beemergency count is \(beemergencyCount, privacy: .public)")
+
+        UIApplication.shared.applicationIconBadgeNumber = beemergencyCount
     }
 
     private func refreshGoalsAndLogErrors() {

--- a/BeeSwift/Goal.swift
+++ b/BeeSwift/Goal.swift
@@ -493,6 +493,8 @@ class Goal {
             let requestId = "\(newDataPoint.daystamp)-\(minuteStamp())"
             let params = ["access_token": ServiceLocator.currentUserManager.accessToken!, "urtext": "\(newDataPoint.daystamp.suffix(2)) \(newDataPoint.value) \"\(newDataPoint.comment)\"", "requestid": requestId]
 
+            logger.notice("Creating new datapoint for \(self.id, privacy: .public) on \(newDataPoint.daystamp, privacy: .public): \(newDataPoint.value, privacy: .private)")
+
             try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
                 postDatapoint(params: params, success: { (responseObject) in
                     continuation.resume()
@@ -505,6 +507,8 @@ class Goal {
             matchingDatapoints.forEach { datapoint in
                 deleteDatapoint(datapoint: datapoint)
             }
+
+            logger.notice("Updating datapoint for \(self.id) on \(firstDatapoint.daystamp, privacy: .public) from \(firstDatapoint.value) to \(newDataPoint.value)")
 
             try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
                 updateDatapoint(datapoint: firstDatapoint, datapointValue: newDataPoint.value, success: {

--- a/BeeSwift/GoalViewController.swift
+++ b/BeeSwift/GoalViewController.swift
@@ -338,6 +338,7 @@ class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTabl
         hud?.mode = .indeterminate
 
         do {
+            logger.notice("Sync button for goal \(self.goal.healthKitMetric ?? "nil", privacy: .public)")
             try await ServiceLocator.healthStoreManager.updateWithRecentData(goal: self.goal, days: numDays)
             try await ensureGoalAndGraphUpToDate()
 

--- a/BeeSwift/HealthStoreManager.swift
+++ b/BeeSwift/HealthStoreManager.swift
@@ -85,6 +85,7 @@ class HealthStoreManager :NSObject {
     ///   - goal: The healthkit-connected goal to be updated
     ///   - days: How many days of history to update. Supplying 1 will update the current day.
     public func updateWithRecentData(goal: Goal, days: Int) async throws {
+        logger.notice("Updating \(goal.healthKitMetric ?? "nil", privacy: .public) goal with recent day for last \(days, privacy: .public) days")
         guard let connection = self.connectionFor(goal: goal) else {
             throw HealthKitError("Failed to find connection for goal")
         }
@@ -93,6 +94,7 @@ class HealthStoreManager :NSObject {
 
     /// Immediately update all known goals based on HealthKit's data record
     public func updateAllGoalsWithRecentData(days: Int) async throws {
+        logger.notice("Updating all goals with recent day for last \(days, privacy: .public) days")
         for (_, connection) in self.connections {
             try await connection.updateWithRecentData(days: days)
         }

--- a/BeeSwift/HeathKit/CategoryHealthKitMetric.swift
+++ b/BeeSwift/HeathKit/CategoryHealthKitMetric.swift
@@ -32,8 +32,6 @@ class CategoryHealthKitMetric : HealthKitMetric {
     }
 
     func recentDataPoints(days : Int, deadline : Int, healthStore : HKHealthStore) async throws -> [DataPoint] {
-        logger.notice("Fetching \(days) recent data points for \(self.databaseString, privacy: .public)")
-
         var results : [DataPoint] = []
         for dayOffset in ((-1*days + 1)...0) {
             results.append(try await self.getDataPoint(dayOffset: dayOffset, deadline: deadline, healthStore: healthStore))

--- a/BeeSwift/HeathKit/GoalHealthKitConnection.swift
+++ b/BeeSwift/HeathKit/GoalHealthKitConnection.swift
@@ -82,7 +82,8 @@ class GoalHealthKitConnection {
     /// Explicitly sync goal data for the number of days specified
     public func updateWithRecentData(days : Int) async throws {
         let newDataPoints = try await metric.recentDataPoints(days: days, deadline: self.goal.deadline.intValue, healthStore: healthStore)
-        let nonZeroDataPoints =  newDataPoints.filter { dataPoint in dataPoint.value != 0 }
+        let nonZeroDataPoints = newDataPoints.filter { dataPoint in dataPoint.value != 0 }
+        logger.notice("Updating \(self.metric.databaseString, privacy: .public) goal with \(nonZeroDataPoints.count, privacy: .public) datapoints. Skipped \(newDataPoints.count - nonZeroDataPoints.count, privacy: .public) empty points.")
         try await goal.updateToMatchDataPoints(healthKitDataPoints: nonZeroDataPoints)
     }
 

--- a/BeeSwift/HeathKit/QuantityHealthKitMetric.swift
+++ b/BeeSwift/HeathKit/QuantityHealthKitMetric.swift
@@ -32,8 +32,6 @@ class QuantityHealthKitMetric : HealthKitMetric {
     }
 
     func recentDataPoints(days : Int, deadline : Int, healthStore : HKHealthStore) async throws -> [DataPoint] {
-        logger.notice("Fetching \(days) recent data points for \(self.databaseString, privacy: .public)")
-
         guard let quantityType = HKObjectType.quantityType(forIdentifier: self.hkQuantityTypeIdentifier) else {
             throw HealthKitError("Unable to look up a quantityType")
         }


### PR DESCRIPTION
The beeminder app is meant to do quite a lot of work in the background, from updating goals
to also refreshing the badge count. This doesn't appear to always reliably fire, so we add
some logging to have more visibility into what is and is not happening.

Testing:
Ran on device, observed logs firing
