### PR TITLE
Avoid no-op datapoint updates

### DIFF
--- a/BeeSwift/Goal.swift
+++ b/BeeSwift/Goal.swift
@@ -17,7 +17,7 @@ class Goal {
 
     // Ignore automatic datapoint updates where the difference is a smaller fraction than this. This
     // prevents effectively no-op updates due to float rounding
-    private let datapointValueEpsilon = 0.00001
+    private let datapointValueEpsilon = 0.00000001
 
     var autodata: String = ""
     var delta_text: String = ""


### PR DESCRIPTION
Previously we would always send new data point values to beeminder, even if the
old and new values were the same. This could lead to a large number of unnecessary
API calls, slowing things down and increasing server load. Now instead we check if
the existing value matches (with a small allowable epsilon) and only update on differences

Testing:
Ran the code on device and observed fewer (but some) updates
