### PR TITLE
Reduce wall clock time spend during background updates

### DIFF
--- a/BeeSwift/BackgroundUpdates.swift
+++ b/BeeSwift/BackgroundUpdates.swift
@@ -36,10 +36,17 @@ class BackgroundUpdates {
 
         Task { @MainActor in
             do {
+                // Update healthkit data and fetch new goals in parallel
+                // This means we are not guaranteed to update data if discover a new healthkit goal, but that is very rare
+                // and probably would lack permissions, so is not worth keeping the app awake longer for.
+
+                async let goalUpdateResult: () = ServiceLocator.healthStoreManager.updateAllGoalsWithRecentData(days: 3)
+
                 let goals = try await ServiceLocator.goalManager.fetchGoals()
                 ServiceLocator.healthStoreManager.silentlyInstallObservers(goals: goals)
 
-                try await ServiceLocator.healthStoreManager.updateAllGoalsWithRecentData(days: 3)
+                try await goalUpdateResult
+
             } catch {
                 logger.error("Error refreshing goals: \(error)")
             }

--- a/BeeSwift/HealthStoreManager.swift
+++ b/BeeSwift/HealthStoreManager.swift
@@ -95,8 +95,14 @@ class HealthStoreManager :NSObject {
     /// Immediately update all known goals based on HealthKit's data record
     public func updateAllGoalsWithRecentData(days: Int) async throws {
         logger.notice("Updating all goals with recent day for last \(days, privacy: .public) days")
-        for (_, connection) in self.connections {
-            try await connection.updateWithRecentData(days: days)
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            for (_, connection) in self.connections {
+                group.addTask {
+                    try await connection.updateWithRecentData(days: days)
+                }
+            }
+            try await group.waitForAll()
         }
     }
 

--- a/BeeSwift/HeathKit/GoalHealthKitConnection.swift
+++ b/BeeSwift/HeathKit/GoalHealthKitConnection.swift
@@ -67,10 +67,13 @@ class GoalHealthKitConnection {
             Task {
                 do {
                     try await self.updateWithRecentData(days: GoalHealthKitConnection.daysToUpdateOnChangeNotification)
-                    completionHandler()
                 } catch {
                     self.logger.error("Error fetching data in response to observer query \(query) error: \(error)")
                 }
+
+                // Report completion even on failure. It would be nice to have the iOS retry mechanism call us again
+                // on failure, but in pratice iOS waits a long time, leading to higher background usage.
+                completionHandler()
             }
         })
         healthStore.execute(query)


### PR DESCRIPTION
iOS applies some complex logic to decide how often to allow apps to run background updates. The rules are opaque, but potentially include the app's energy use. To try to maximize the chance of beeminder waking up to update goals and badges, here we change background processesing to complete as quickly as possible

For background updates, do work as quickly as possible For healthkit observers report as soon as we are done, even on failure.

Testing:
Observed in the debugger than background updates were still happening, and completing much quicker than before.