### PR TITLE
Convert GoalManager to be an actor

### DIFF
--- a/BeeSwift.xcodeproj/project.pbxproj
+++ b/BeeSwift.xcodeproj/project.pbxproj
@@ -94,6 +94,9 @@
 		E44CE78429933A6100394E87 /* GoalManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E44CE782299338C500394E87 /* GoalManager.swift */; };
 		E44CE78529933A6100394E87 /* GoalManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E44CE782299338C500394E87 /* GoalManager.swift */; };
 		E457BE5D28C192B50012F5D0 /* IntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = E457BE5C28C192B50012F5D0 /* IntentHandler.swift */; };
+		E462BA2E29A31C3B00E80EF0 /* SynchronizedBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = E462BA2D29A31C3B00E80EF0 /* SynchronizedBox.swift */; };
+		E462BA2F29A31C5000E80EF0 /* SynchronizedBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = E462BA2D29A31C3B00E80EF0 /* SynchronizedBox.swift */; };
+		E462BA3029A31C5000E80EF0 /* SynchronizedBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = E462BA2D29A31C3B00E80EF0 /* SynchronizedBox.swift */; };
 		E46FF15B2984C522009F8C7A /* DateUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = E46FF15A2984C522009F8C7A /* DateUtils.swift */; };
 		E46FF15C2984C590009F8C7A /* DateUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = E46FF15A2984C522009F8C7A /* DateUtils.swift */; };
 		E46FF15D2984C591009F8C7A /* DateUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = E46FF15A2984C522009F8C7A /* DateUtils.swift */; };
@@ -336,6 +339,7 @@
 		E44CE77E2993351100394E87 /* CryptoKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CryptoKit.framework; path = System/Library/Frameworks/CryptoKit.framework; sourceTree = SDKROOT; };
 		E44CE782299338C500394E87 /* GoalManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalManager.swift; sourceTree = "<group>"; };
 		E457BE5C28C192B50012F5D0 /* IntentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntentHandler.swift; sourceTree = "<group>"; };
+		E462BA2D29A31C3B00E80EF0 /* SynchronizedBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SynchronizedBox.swift; sourceTree = "<group>"; };
 		E46FF15A2984C522009F8C7A /* DateUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateUtils.swift; sourceTree = "<group>"; };
 		E48E2711296B7548008013C0 /* TotalSleepMinutes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TotalSleepMinutes.swift; sourceTree = "<group>"; };
 		E48E2713296B75E4008013C0 /* TotalSleepMinutesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TotalSleepMinutesTests.swift; sourceTree = "<group>"; };
@@ -502,6 +506,7 @@
 				A12BA9531AFFF21800AFEF32 /* Crypto.swift */,
 				A11488BD1EE9B0CE003316E1 /* UIDevice.swift */,
 				E5DF493624DC69A200260560 /* Config.swift.sample */,
+				E462BA2D29A31C3B00E80EF0 /* SynchronizedBox.swift */,
 			);
 			name = Util;
 			sourceTree = "<group>";
@@ -1180,6 +1185,7 @@
 				E44CE776299332FA00394E87 /* VersionManager.swift in Sources */,
 				E4E642912910D327004F3EA9 /* TimeInBedHealthKitMetric.swift in Sources */,
 				E44CE7792993330100394E87 /* SignedRequestManager.swift in Sources */,
+				E462BA2F29A31C5000E80EF0 /* SynchronizedBox.swift in Sources */,
 				E44CE77C2993349C00394E87 /* Crypto.swift in Sources */,
 				A142492A1FD0788F007736B3 /* UIDevice.swift in Sources */,
 				A1D8532C1EB0EA5700FC75DE /* UIFontExtension.swift in Sources */,
@@ -1230,6 +1236,7 @@
 				A1619EA41BEECC1500E14B3A /* EditDefaultNotificationsViewController.swift in Sources */,
 				E46FF15B2984C522009F8C7A /* DateUtils.swift in Sources */,
 				A1E619001E86980900D8ED93 /* HealthKitConfig.swift in Sources */,
+				E462BA2E29A31C3B00E80EF0 /* SynchronizedBox.swift in Sources */,
 				A149B3701AEF528C00F19A09 /* SettingsViewController.swift in Sources */,
 				E52094FE2741D72300CB766F /* GoalHealthKitConnection.swift in Sources */,
 				E4E642902910D327004F3EA9 /* TimeInBedHealthKitMetric.swift in Sources */,
@@ -1313,6 +1320,7 @@
 				E44CE777299332FB00394E87 /* VersionManager.swift in Sources */,
 				E4E642922910D327004F3EA9 /* TimeInBedHealthKitMetric.swift in Sources */,
 				E44CE7782993330000394E87 /* SignedRequestManager.swift in Sources */,
+				E462BA3029A31C5000E80EF0 /* SynchronizedBox.swift in Sources */,
 				E44CE77D2993349D00394E87 /* Crypto.swift in Sources */,
 				E557610026549DD10076B95A /* AddDataIntentHandler.swift in Sources */,
 				E5CF51702612432400546184 /* RequestManager.swift in Sources */,

--- a/BeeSwift/AppDelegate.swift
+++ b/BeeSwift/AppDelegate.swift
@@ -44,7 +44,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         
         NetworkActivityIndicatorManager.shared.isEnabled = true
         
-        NotificationCenter.default.addObserver(self, selector: #selector(self.updateBadgeCount), name: NSNotification.Name(rawValue: GoalManager.goalsFetchedNotificationName), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(self.updateBadgeCount), name: NSNotification.Name(rawValue: GoalManager.goalsUpdatedNotificationName), object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(self.updateBadgeCount), name: NSNotification.Name(rawValue: CurrentUserManager.signedOutNotificationName), object: nil)
 
         backgroundUpdates.startUpdatingRegularlyInBackground()

--- a/BeeSwift/GalleryViewController.swift
+++ b/BeeSwift/GalleryViewController.swift
@@ -43,7 +43,7 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
         NotificationCenter.default.addObserver(self, selector: #selector(self.openGoalFromNotification(_:)), name: NSNotification.Name(rawValue: "openGoal"), object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(self.handleCreateGoalButtonPressed), name: NSNotification.Name(rawValue: "createGoalButtonPressed"), object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(self.userDefaultsDidChange), name: UserDefaults.didChangeNotification, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(self.handleGoalsFetchedNotification), name: NSNotification.Name(rawValue: GoalManager.goalsFetchedNotificationName), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(self.handleGoalsFetchedNotification), name: NSNotification.Name(rawValue: GoalManager.goalsUpdatedNotificationName), object: nil)
         
         self.collectionViewLayout = UICollectionViewFlowLayout()
         self.collectionView = UICollectionView(frame: self.view.frame, collectionViewLayout: self.collectionViewLayout!)

--- a/BeeSwift/GalleryViewController.swift
+++ b/BeeSwift/GalleryViewController.swift
@@ -224,9 +224,11 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
     }
     
     @objc func handleGoalsFetchedNotification() {
-        self.goals = ServiceLocator.goalManager.staleGoals() ?? []
-        self.lastUpdated = ServiceLocator.goalManager.goalsFetchedAt
-        self.didFetchGoals()
+        Task {
+            self.goals = ServiceLocator.goalManager.staleGoals() ?? []
+            self.lastUpdated = await ServiceLocator.goalManager.goalsFetchedAt
+            self.didFetchGoals()
+        }
     }
     
     @objc func settingsButtonPressed() {

--- a/BeeSwift/GoalManager.swift
+++ b/BeeSwift/GoalManager.swift
@@ -65,6 +65,11 @@ actor GoalManager {
         return Array(goals.values)
     }
 
+    func refreshGoal(_ goal: Goal) async throws {
+        let responseObject = try await requestManager.get(url: "/api/v1/users/\(currentUserManager.username!)/goals/\(goal.slug)?access_token=\(currentUserManager.accessToken!)&datapoints_count=5", parameters: nil)
+        goal.updateToMatch(json: JSON(responseObject!))
+    }
+
     /// Return the state of goals the last time they were fetched from the server. This could have been an arbitrarily long time ago.
     nonisolated func staleGoals() -> [Goal]? {
         if let goals = self.goalsBox.get() {

--- a/BeeSwift/GoalViewController.swift
+++ b/BeeSwift/GoalViewController.swift
@@ -308,10 +308,9 @@ class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTabl
             self.navigationItem.rightBarButtonItems?.append(UIBarButtonItem(image: UIImage.init(named: "Timer"), style: .plain, target: self, action: #selector(self.timerButtonPressed)))
         }
 
-        updateInterfaceToMatchGoal()
+        NotificationCenter.default.addObserver(self, selector: #selector(onGoalsUpdatedNotification), name: NSNotification.Name(rawValue: GoalManager.goalsUpdatedNotificationName), object: nil)
 
-        // TODO: We need to watch for goal updates and update the interface
-        
+        updateInterfaceToMatchGoal()
     }
 
     override func viewDidLayoutSubviews() {
@@ -321,6 +320,10 @@ class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTabl
         self.dateTextField.keyboardDistanceFromTextField = addDataPointAdditionalKeyboardDistance
         self.valueTextField.keyboardDistanceFromTextField = addDataPointAdditionalKeyboardDistance
         self.commentTextField.keyboardDistanceFromTextField = addDataPointAdditionalKeyboardDistance
+    }
+
+    @objc func onGoalsUpdatedNotification() {
+        updateInterfaceToMatchGoal()
     }
     
     @objc func syncTodayButtonPressed() {

--- a/BeeSwift/SynchronizedBox.swift
+++ b/BeeSwift/SynchronizedBox.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// Thread-safe container for a single wrapped variable
+/// Allows a single value to be read/written from multiple threads by locking access.
+/// This assumes the contained value is a struct or immutable - a mutable value could be modified in unsafe ways by
+/// users of this class.
+final class SynchronizedBox<Value> {
+    let lock = NSLock()
+    var innerValue: Value
+
+    init(_ innerValue: Value) {
+        self.innerValue = innerValue
+    }
+
+    func set(_ newValue: Value) {
+        lock.withLock {
+            self.innerValue = newValue
+        }
+    }
+
+    func get() -> Value {
+        lock.withLock {
+            self.innerValue
+        }
+    }
+}

--- a/BeeSwift/TimerViewController.swift
+++ b/BeeSwift/TimerViewController.swift
@@ -179,7 +179,7 @@ class TimerViewController: UIViewController {
                     MBProgressHUD.hideAllHUDs(for: self.view, animated: true)
                 })
                 if let goalVC = self.presentingViewController?.children.last as? GoalViewController {
-                    try await goalVC.ensureGoalAndGraphUpToDate()
+                    try await goalVC.updateGoalAndInterface()
                 }
                 self.resetButtonPressed()
             } catch {


### PR DESCRIPTION
This makes several changes to how parallelism is managed for goal update code:
* GoalManager is now an actor, making synchronization of goal updates simpler
* All logic around updating queued goals now lives in GoalManager, rather than in view code
* GoalManager notifies via NotificationCenter any time one or more goals may have changed. Consumers should listen to this event to update e.g. after queuing has completed.

Testing:
Updated a goal. Observed the data updated, and then later the image refreshed.