### PR TITLE
Sort gallery goals according to intended algorithm

### DIFF
--- a/BeeSwift/GalleryViewController.swift
+++ b/BeeSwift/GalleryViewController.swift
@@ -438,7 +438,27 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
                     return goal1.pledge.intValue > goal2.pledge.intValue
                 }
             }
-            return goal1.losedate.intValue < goal2.losedate.intValue
+
+            // Default sort ordering
+
+            // Primary Criteria: Sooner deadline/goal end first
+            let goal1Date = min(goal1.losedate.intValue, goal1.derived_goaldate.intValue)
+            let goal2Date = min(goal2.losedate.intValue, goal2.derived_goaldate.intValue)
+            if goal1Date < goal2Date {
+                return true
+            } else if goal2Date < goal1Date {
+                return false
+            }
+
+            // Secondary Criteria: Larger pledge amount first
+            if goal2.pledge.intValue < goal1.pledge.intValue {
+                return true
+            } else if goal1.pledge.intValue < goal2.pledge.intValue {
+                return false
+            }
+
+            // Tertiary Criteria: Lexographically earlier slug first
+            return goal1.slug < goal2.slug
         })
         self.updateFilteredGoals(searchText: self.searchBar.text ?? "")
     }

--- a/BeeSwift/Goal.swift
+++ b/BeeSwift/Goal.swift
@@ -52,6 +52,11 @@ class Goal {
     var todayta: Bool = false
     var hhmmformat: Bool = false
     var recent_data: [ExistingDataPoint]?
+
+    // These are obtained from mathishard
+    var derived_goaldate: NSNumber = 0
+    var derived_goalval: NSNumber = 0
+    var derived_rate: NSNumber = 0
     
     init(json: JSON) {
         self.id = json["id"].string!
@@ -109,6 +114,11 @@ class Goal {
         self.hhmmformat = json["hhmmformat"].bool!
 
         self.recent_data = ExistingDataPoint.fromJSONArray(array: json["recent_data"].arrayValue).reversed()
+
+        let math_is_hard = json["mathishard"].arrayValue
+        self.derived_goaldate = math_is_hard[0].number!
+        self.derived_goalval = math_is_hard[1].number!
+        self.derived_rate = math_is_hard[2].number!
     }
 
     var rateString :String {


### PR DESCRIPTION
Beeminder has an intended gallery default sort order of

    min(losedate, goaldate), -pledge, slug

This is not implemented universally, but is the intended behavior. Here we update the app
to sort by this fully determined sort, rather than the partial ordering it was using before.
This also guarantees the sort is stable.

Test Plan:
Observed my gallery was sorted appropriately.
