### PR TITLE
Add a screen to view and save logs

### DIFF
--- a/BeeSwift.xcodeproj/project.pbxproj
+++ b/BeeSwift.xcodeproj/project.pbxproj
@@ -74,6 +74,8 @@
 		E42CB452291727B200A35AB9 /* HealthKitError.swift in Sources */ = {isa = PBXBuildFile; fileRef = E42CB451291727B200A35AB9 /* HealthKitError.swift */; };
 		E42CB453291727B200A35AB9 /* HealthKitError.swift in Sources */ = {isa = PBXBuildFile; fileRef = E42CB451291727B200A35AB9 /* HealthKitError.swift */; };
 		E42CB454291727B200A35AB9 /* HealthKitError.swift in Sources */ = {isa = PBXBuildFile; fileRef = E42CB451291727B200A35AB9 /* HealthKitError.swift */; };
+		E43BEA842A036A9C00FC3A38 /* LogReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = E43BEA832A036A9C00FC3A38 /* LogReader.swift */; };
+		E43BEA862A036D4300FC3A38 /* LogReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E43BEA852A036D4300FC3A38 /* LogReaderTests.swift */; };
 		E43D9AFB2929C37D00FC1578 /* DatapointValueAccessory.swift in Sources */ = {isa = PBXBuildFile; fileRef = E43D9AFA2929C37D00FC1578 /* DatapointValueAccessory.swift */; };
 		E44CE7732993317B00394E87 /* ServiceLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E44CE7722993317B00394E87 /* ServiceLocator.swift */; };
 		E44CE774299332D900394E87 /* ServiceLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E44CE7722993317B00394E87 /* ServiceLocator.swift */; };
@@ -135,6 +137,7 @@
 		E4B0A33028C194C900055EA7 /* AddDataIntents.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = E540953B260FB6A100C30784 /* AddDataIntents.intentdefinition */; };
 		E4B0A33128C194C900055EA7 /* AddDataIntents.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = E540953B260FB6A100C30784 /* AddDataIntents.intentdefinition */; };
 		E4B0A33228C194CA00055EA7 /* AddDataIntents.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = E540953B260FB6A100C30784 /* AddDataIntents.intentdefinition */; };
+		E4E43D8829F39CE800697116 /* LogsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E43D8729F39CE800697116 /* LogsViewController.swift */; };
 		E4E6426A290E22E6004F3EA9 /* HealthKitConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1E618FF1E86980900D8ED93 /* HealthKitConfig.swift */; };
 		E4E6426B290E22E9004F3EA9 /* HealthKitConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1E618FF1E86980900D8ED93 /* HealthKitConfig.swift */; };
 		E4E6426C290E22EF004F3EA9 /* GoalHealthKitConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = E52094FD2741D72300CB766F /* GoalHealthKitConnection.swift */; };
@@ -336,6 +339,8 @@
 		A1F9D1E9211B9B7600E2BC93 /* EditDatapointViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditDatapointViewController.swift; sourceTree = "<group>"; };
 		A1FF19131DE8EEA900FD0527 /* NewGoalCollectionViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NewGoalCollectionViewCell.swift; sourceTree = "<group>"; };
 		E42CB451291727B200A35AB9 /* HealthKitError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthKitError.swift; sourceTree = "<group>"; };
+		E43BEA832A036A9C00FC3A38 /* LogReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogReader.swift; sourceTree = "<group>"; };
+		E43BEA852A036D4300FC3A38 /* LogReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogReaderTests.swift; sourceTree = "<group>"; };
 		E43D9AFA2929C37D00FC1578 /* DatapointValueAccessory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatapointValueAccessory.swift; sourceTree = "<group>"; };
 		E44CE7722993317B00394E87 /* ServiceLocator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceLocator.swift; sourceTree = "<group>"; };
 		E44CE77E2993351100394E87 /* CryptoKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CryptoKit.framework; path = System/Library/Frameworks/CryptoKit.framework; sourceTree = SDKROOT; };
@@ -351,6 +356,7 @@
 		E4B083382932F90400A71564 /* ConfigureHKMetricViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigureHKMetricViewController.swift; sourceTree = "<group>"; };
 		E4B0833A2934620500A71564 /* DatapointTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatapointTableViewController.swift; sourceTree = "<group>"; };
 		E4B0833C293810EB00A71564 /* DataPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataPoint.swift; sourceTree = "<group>"; };
+		E4E43D8729F39CE800697116 /* LogsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogsViewController.swift; sourceTree = "<group>"; };
 		E4E6427B2910C3AB004F3EA9 /* HealthKitMetric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthKitMetric.swift; sourceTree = "<group>"; };
 		E4E6427F2910C3FB004F3EA9 /* QuantityHealthKitMetric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuantityHealthKitMetric.swift; sourceTree = "<group>"; };
 		E4E642832910C442004F3EA9 /* CategoryHealthKitMetric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryHealthKitMetric.swift; sourceTree = "<group>"; };
@@ -566,6 +572,8 @@
 				A1BD0D171AEB30A5001EDE8B /* GoalViewController.swift */,
 				A1E618E11E78158700D8ED93 /* HealthKitConfigViewController.swift */,
 				A1F8F07A232C05410060B83E /* Goal.swift */,
+				E43BEA832A036A9C00FC3A38 /* LogReader.swift */,
+				E4E43D8729F39CE800697116 /* LogsViewController.swift */,
 				A1453B3E1AEDFCC8006F48DA /* SignInViewController.swift */,
 				A149B36F1AEF528C00F19A09 /* SettingsViewController.swift */,
 				A1A8BDE51FEAE8DD007D61D6 /* ConfigureNotificationsViewController.swift */,
@@ -601,6 +609,7 @@
 				A196CB321AE4142F00B90A3E /* BeeSwiftTests.swift */,
 				A196CB301AE4142F00B90A3E /* Supporting Files */,
 				E48E2713296B75E4008013C0 /* TotalSleepMinutesTests.swift */,
+				E43BEA852A036D4300FC3A38 /* LogReaderTests.swift */,
 			);
 			path = BeeSwiftTests;
 			sourceTree = "<group>";
@@ -1106,6 +1115,7 @@
 				A1781AB31DE50F59000B96C5 /* BSTextField.swift in Sources */,
 				E4B083392932F90400A71564 /* ConfigureHKMetricViewController.swift in Sources */,
 				A1BD0D1C1AEB34E0001EDE8B /* GalleryNavigationController.swift in Sources */,
+				E43BEA842A036A9C00FC3A38 /* LogReader.swift in Sources */,
 				A196CB1F1AE4142F00B90A3E /* GalleryViewController.swift in Sources */,
 				A1BE73AA1E8B45BF00DEC4DB /* ChooseHKMetricViewController.swift in Sources */,
 				A149147B1BE79FD50060600A /* EditNotificationsViewController.swift in Sources */,
@@ -1148,6 +1158,7 @@
 				E43D9AFB2929C37D00FC1578 /* DatapointValueAccessory.swift in Sources */,
 				A1BD0D181AEB30A5001EDE8B /* GoalViewController.swift in Sources */,
 				A196CB1A1AE4142E00B90A3E /* AppDelegate.swift in Sources */,
+				E4E43D8829F39CE800697116 /* LogsViewController.swift in Sources */,
 				A1453B351AED9184006F48DA /* UIColorExtension.swift in Sources */,
 				A11BA9A41FCE54E3004BB425 /* HealthStoreManager.swift in Sources */,
 				A15FF4201AEB621000A9AD22 /* GoalCollectionViewCell.swift in Sources */,
@@ -1166,6 +1177,7 @@
 				E4B0A32E28C194C800055EA7 /* AddDataIntents.intentdefinition in Sources */,
 				E48E2714296B75E4008013C0 /* TotalSleepMinutesTests.swift in Sources */,
 				A196CB331AE4142F00B90A3E /* BeeSwiftTests.swift in Sources */,
+				E43BEA862A036D4300FC3A38 /* LogReaderTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/BeeSwift/LogReader.swift
+++ b/BeeSwift/LogReader.swift
@@ -1,0 +1,57 @@
+//  LogReader.swift
+//  BeeSwift
+//
+//  Wrapper for fetching logs from the system log store
+
+import Foundation
+import OSLog
+
+
+@available(iOS 15.0, *)
+class LogReader {
+    private var allMessagesTask: Task<[OSLogEntryLog], Never>!
+
+    init() {
+        allMessagesTask = Task.detached(priority: .userInitiated) {
+            do {
+                let store = try OSLogStore(scope: .currentProcessIdentifier)
+                let position = store.position(timeIntervalSinceLatestBoot: 1)
+                return try store
+                    .getEntries(at: position)
+                    .compactMap { $0 as? OSLogEntryLog }
+            } catch {
+                return []
+            }
+        }
+    }
+
+    func getLogMessages(showSystemMessages: Bool, errorLevel: OSLogEntryLog.Level) async -> String {
+        return await allMessagesTask.value
+            .filter { showSystemMessages || $0.subsystem == Bundle.main.bundleIdentifier! }
+            .filter { $0.level.rawValue >= errorLevel.rawValue }
+            .map { "[\($0.date.formatted())] [\($0.category)] \($0.composedMessage)" }
+            .joined(separator: "\n")
+    }
+
+    func saveLogsToFile(showSystemMessages: Bool, errorLevel: OSLogEntryLog.Level) async -> URL {
+        // Create a temporary log file
+        let fileManager = FileManager.default
+        let tempDir = fileManager.temporaryDirectory
+        let tempFile = tempDir.appendingPathComponent(logFileName())
+        let tempFileURL = URL(fileURLWithPath: tempFile.path)
+
+        // Write the logs to the temporary file
+        let logs = await getLogMessages(showSystemMessages: showSystemMessages, errorLevel: errorLevel)
+        try? logs.write(to: tempFileURL, atomically: true, encoding: .utf8)
+
+        return tempFileURL
+    }
+
+    func logFileName() -> String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+        dateFormatter.dateFormat = "yyyy-MM-dd HH-mm-ss"
+        let date = dateFormatter.string(from: Date())
+        return "BeeSwift Logs \(date).txt"
+    }
+}

--- a/BeeSwift/LogsViewController.swift
+++ b/BeeSwift/LogsViewController.swift
@@ -1,0 +1,122 @@
+//  LogsViewController.swift
+//  BeeSwift
+//
+//  A screen to view and share application logs
+
+import Foundation
+import OSLog
+import OrderedCollections
+
+
+@available(iOS 15.0, *)
+class LogsViewController: UIViewController {
+
+    let logTextView = UITextView()
+    let systemLogsToggle = UIButton()
+    let errorLevelButton = UIButton()
+
+    let logReader = LogReader()
+
+    var showSystemMessages = false
+    var errorLevel = OSLogEntryLog.Level.debug
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        self.view.backgroundColor = .black
+        self.title = "Logs"
+
+        // Add a share link to the navigationcontroller which shares the contents of the log when clicked
+        let shareButton = UIBarButtonItem(barButtonSystemItem: .action, target: self, action: #selector(shareLogs))
+        self.navigationItem.rightBarButtonItem = shareButton
+
+        view.addSubview(systemLogsToggle)
+        systemLogsToggle.setTitle("App Only", for: .normal)
+        systemLogsToggle.configuration = .gray()
+        systemLogsToggle.snp.makeConstraints{ (make) in
+            make.left.equalTo(view.safeAreaLayoutGuide.snp.leftMargin).offset(10)
+            make.top.equalTo(view)
+        }
+        systemLogsToggle.addTarget(self, action: #selector(systemMessagesToggleTapped), for: .touchUpInside)
+
+        view.addSubview(errorLevelButton)
+        errorLevelButton.setTitle("Debug", for: .normal)
+        errorLevelButton.configuration = .gray()
+        errorLevelButton.snp.makeConstraints{ (make) in
+            make.left.equalTo(systemLogsToggle.snp.right).offset(10)
+            make.right.equalTo(view.safeAreaLayoutGuide.snp.rightMargin).offset(-10)
+            make.top.equalTo(view)
+            make.bottom.equalTo(systemLogsToggle.snp.bottom)
+            make.width.equalTo(systemLogsToggle.snp.width)
+        }
+        errorLevelButton.addTarget(self, action: #selector(errorLevelButtonTapped), for: .touchUpInside)
+
+        view.addSubview(logTextView)
+        logTextView.isEditable = false
+        logTextView.isScrollEnabled = true
+        logTextView.snp.makeConstraints { (make) in
+            make.top.equalTo(systemLogsToggle.snp.bottom).offset(10)
+            make.left.right.bottom.equalTo(view)
+        }
+
+        loadLogs()
+    }
+
+    func loadLogs() {
+        Task { @MainActor in
+            let hud = MBProgressHUD.showAdded(to: view, animated: false)
+            self.logTextView.text = await self.logReader.getLogMessages(showSystemMessages: showSystemMessages, errorLevel: errorLevel)
+            hud.hide(animated: false)
+        }
+    }
+
+    @objc
+    func shareLogs() {
+        Task { @MainActor in
+            let logFile = await logReader.saveLogsToFile(showSystemMessages: showSystemMessages, errorLevel: errorLevel)
+            let activityViewController = UIActivityViewController(activityItems: [logFile], applicationActivities: nil)
+            activityViewController.popoverPresentationController?.barButtonItem = self.navigationItem.rightBarButtonItem
+            activityViewController.completionWithItemsHandler = { activityType, completed, returnedItems, error in
+                try? FileManager.default.removeItem(at: logFile)
+            }
+            self.present(activityViewController, animated: true, completion: nil)
+        }
+    }
+
+    @objc
+    func systemMessagesToggleTapped() {
+        showSystemMessages = !showSystemMessages
+        if showSystemMessages {
+            systemLogsToggle.setTitle("App and System", for: .normal)
+        } else {
+            systemLogsToggle.setTitle("App Only", for: .normal)
+        }
+        loadLogs()
+    }
+
+    @objc
+    func errorLevelButtonTapped() {
+        let errorLevelAlert = UIAlertController(title: "Choose Error Level", message: nil, preferredStyle: .actionSheet)
+
+        let errorLevels: OrderedDictionary<String, OSLogEntryLog.Level> = [
+            "Debug": .debug,
+            "Info": .info,
+            "Notice": .notice,
+            "Error": .error,
+            "Fault": .fault
+        ]
+
+        for (title, level) in errorLevels {
+            let action = UIAlertAction(title: title, style: .default) { _ in
+                self.errorLevel = level
+                self.errorLevelButton.setTitle(title, for: .normal)
+                self.loadLogs()
+            }
+            errorLevelAlert.addAction(action)
+        }
+        errorLevelAlert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
+
+        self.present(errorLevelAlert, animated: true, completion: nil)
+    }
+}
+

--- a/BeeSwift/SettingsViewController.swift
+++ b/BeeSwift/SettingsViewController.swift
@@ -36,18 +36,40 @@ class SettingsViewController: UIViewController {
         self.tableView.tableFooterView = UIView()
         self.tableView.register(SettingsTableViewCell.self, forCellReuseIdentifier: self.cellReuseIdentifier)
 
+
+        let versionLabel = BSLabel()
+        self.view.addSubview(versionLabel)
+        versionLabel.snp.makeConstraints { (make) in
+            make.width.equalTo(self.view)
+        }
+        versionLabel.textAlignment = .center
         if let info = Bundle.main.infoDictionary {
             let appVersion = info["CFBundleShortVersionString"] as? String ?? "Unknown"
             let appBuild = info[kCFBundleVersionKey as String] as? String ?? "Unknown"
-
-            let versionLabel = BSLabel()
             versionLabel.text = "Version: \(appVersion) (\(appBuild))"
-            self.view.addSubview(versionLabel)
-            versionLabel.snp.makeConstraints { (make) in
-                make.bottom.equalTo(self.view.safeAreaLayoutGuide.snp.bottomMargin).offset(-10)
+        } else {
+            versionLabel.text = "Version: Unknown"
+        }
+
+        if #available(iOS 15.0, *) {
+            let logsLabel = UILabel()
+            self.view.addSubview(logsLabel)
+            logsLabel.textAlignment = .center
+            logsLabel.text = "Debug Logs »"
+            logsLabel.font = UIFont(name: "Avenir-Light", size: 16)!
+            logsLabel.textColor = .systemBlue
+            logsLabel.isUserInteractionEnabled = true
+            logsLabel.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(showLogsTapped)))
+
+            logsLabel.snp.makeConstraints { (make) in
+                make.top.equalTo(versionLabel.snp.bottom).offset(10)
+                make.bottom.equalTo(self.view.safeAreaLayoutGuide.snp.bottomMargin)
                 make.width.equalTo(self.view)
             }
-            versionLabel.textAlignment = .center
+        } else {
+            versionLabel.snp.makeConstraints { (make) in
+                make.bottom.equalTo(self.view.safeAreaLayoutGuide.snp.bottomMargin).offset(-10)
+            }
         }
     }
 
@@ -62,7 +84,15 @@ class SettingsViewController: UIViewController {
             await ServiceLocator.currentUserManager.signOut()
             self.navigationController?.popViewController(animated: true)
         }
-    }    
+    }
+
+    @objc
+    func showLogsTapped() {
+        if #available(iOS 15.0, *) {
+            self.navigationController?.pushViewController(LogsViewController(), animated: true)
+        }
+    }
+
 }
 
 extension SettingsViewController : UITableViewDataSource, UITableViewDelegate {

--- a/BeeSwiftTests/LogReaderTests.swift
+++ b/BeeSwiftTests/LogReaderTests.swift
@@ -1,0 +1,47 @@
+//
+//  LogReaderTests.swift
+//  BeeSwiftTests
+//
+//  Created by Theo Spears on 5/3/23.
+//  Copyright © 2023 APB. All rights reserved.
+//
+
+import XCTest
+import OSLog
+
+@testable import BeeSwift
+
+@available(iOS 15.0, *)
+final class LogReaderTests: XCTestCase {
+    private let logger = Logger(subsystem: "com.beeminder.beeminder", category: "LogReaderTests")
+
+    override func setUp() async throws {
+        logger.info("Sample Log Info")
+        logger.error("Sample Log Error")
+    }
+
+    func testGetLogMessages() async throws {
+        let logReader = LogReader()
+        let logs = await logReader.getLogMessages(showSystemMessages: false, errorLevel: .debug)
+        XCTAssert(logs.contains("Sample Log Info"))
+    }
+
+    func testFiltersByLevel() async throws {
+        let logReader = LogReader()
+        let logs = await logReader.getLogMessages(showSystemMessages: false, errorLevel: .error)
+        XCTAssertFalse(logs.contains("Sample Log Info"))
+        XCTAssert(logs.contains("Sample Log Error"))
+    }
+
+    func testSavesToFile() async throws {
+        let logReader = LogReader()
+        let logFile = await logReader.saveLogsToFile(showSystemMessages: false, errorLevel: .debug)
+
+        // Confirm it contains log sample
+        let contents = try String(contentsOf: logFile, encoding: .utf8)
+        XCTAssert(contents.contains("Sample Log Info"))
+
+        let fileManager = FileManager.default
+        try fileManager.removeItem(atPath: logFile.path)
+    }
+}


### PR DESCRIPTION
When debugging issues with background notifications it has been a pain to use sysdiagnose to extract and find the logs. To simplify the process the app can now display its own logs. Also make it possible to share the logs via normal mechanisms, for example to share with support.

Testing:
Manually tested viewing and sharing logs
Added unit tests for the log reading/saving code