### PR TITLE
Remove display of goal pledge amounts

### DIFF
--- a/BeeSwift/GoalViewController.swift
+++ b/BeeSwift/GoalViewController.swift
@@ -432,7 +432,7 @@ class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTabl
     
     @objc func refreshCountdown() {
         self.countdownLabel.textColor = self.goal.countdownColor
-        self.countdownLabel.text = self.goal.capitalSafesum() + " or pay $\(self.goal.pledge)"
+        self.countdownLabel.text = self.goal.capitalSafesum()
     }
     
     func setGraphImage() {


### PR DESCRIPTION
This removes pledge amounts from the goal view, so only the
remaining time is shown. It is still possible to sort by pledge.

Testing:
Viewed the gallery and goal details in the simulator
