### PR TITLE
Remove forgot password link

### DIFF
--- a/BeeSwift/SignInViewController.swift
+++ b/BeeSwift/SignInViewController.swift
@@ -26,16 +26,6 @@ class SignInViewController : UIViewController, UITextFieldDelegate, SFSafariView
     var backToSignUpButton = BSButton()
     var signInButton = BSButton()
     var divider = UIView()
-    lazy var resetPasswordButton: BSButton = {
-        let button = BSButton()
-        button.setTitle("Forgot password?", for: .normal)
-        button.titleLabel?.font = UIFont.beeminder.defaultFontHeavy
-        button.setTitleColor(UIColor.label, for: .normal)
-        button.backgroundColor = UIColor.systemBackground
-        button.addTarget(self, action: #selector(SignInViewController.resetPasswordTapped), for: .touchUpInside)
-
-        return button
-    }()
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -104,15 +94,6 @@ class SignInViewController : UIViewController, UITextFieldDelegate, SFSafariView
             make.height.equalTo(Constants.defaultTextFieldHeight)
         }
 
-        scrollView.addSubview(self.resetPasswordButton)
-        self.resetPasswordButton.isHidden = true
-        self.resetPasswordButton.snp.makeConstraints { (make) -> Void in
-            make.left.equalTo(self.passwordTextField)
-            make.right.equalTo(self.passwordTextField)
-            make.top.equalTo(self.passwordTextField.snp.bottom).offset(15)
-            make.height.equalTo(Constants.defaultTextFieldHeight)
-        }
-        
         scrollView.addSubview(self.signInButton)
         self.signInButton.isHidden = true
         self.signInButton.setTitle("Sign In", for: UIControl.State())
@@ -123,7 +104,7 @@ class SignInViewController : UIViewController, UITextFieldDelegate, SFSafariView
         self.signInButton.snp.makeConstraints { (make) -> Void in
             make.left.equalTo(self.passwordTextField)
             make.right.equalTo(self.passwordTextField)
-            make.top.equalTo(self.resetPasswordButton.snp.bottom).offset(15)
+            make.top.equalTo(self.passwordTextField.snp.bottom).offset(15)
             make.height.equalTo(Constants.defaultTextFieldHeight)
         }
         
@@ -206,7 +187,6 @@ class SignInViewController : UIViewController, UITextFieldDelegate, SFSafariView
         self.headerLabel.isHidden = false
         self.signInButton.isHidden = false
         self.signUpButton.isHidden = true
-        self.resetPasswordButton.isHidden = false
         self.divider.snp.remakeConstraints { (make) -> Void in
             make.left.equalTo(self.signInButton)
             make.right.equalTo(self.signInButton)
@@ -254,23 +234,5 @@ class SignInViewController : UIViewController, UITextFieldDelegate, SFSafariView
             self.signInButtonPressed()
         }
         return true
-    }
-    
-    @objc func resetPasswordTapped() {
-        let config = SFSafariViewController.Configuration()
-        config.entersReaderIfAvailable = true;
-        let safariVC = SFSafariViewController(url: self.passwordResetUrl, configuration: config);
-        self.present(safariVC, animated: true, completion: nil)
-    }
-    
-    
-    var passwordResetUrl: URL {
-        return URL(string: "https://www.beeminder.com/users/password/new")!
-    }
-    
-    // MARK: - SFSafariViewControllerDelegate
-    
-    func safariViewControllerDidFinish(_ controller: SFSafariViewController) {
-        controller.dismiss(animated: true, completion: nil)
     }
 }


### PR DESCRIPTION
Remove forgotten password link from the app, as it allows navigating
to the main beeminder site.

Testing:
In simulator, verified
* Link does not appear
* Login still works
