### PR TITLE
Access token is always supplied by the RequestManager

### DIFF
--- a/BeeSwift.xcodeproj/project.pbxproj
+++ b/BeeSwift.xcodeproj/project.pbxproj
@@ -73,6 +73,7 @@
 		E41286F12A62E6840093D598 /* KeychainSwift in Frameworks */ = {isa = PBXBuildFile; productRef = E41286F02A62E6840093D598 /* KeychainSwift */; };
 		E41286F32A62E97B0093D598 /* KeychainSwift in Frameworks */ = {isa = PBXBuildFile; productRef = E41286F22A62E97B0093D598 /* KeychainSwift */; };
 		E41286F52A62E9840093D598 /* KeychainSwift in Frameworks */ = {isa = PBXBuildFile; productRef = E41286F42A62E9840093D598 /* KeychainSwift */; };
+		E417572D2A6446FE0029CDDA /* CurrentUserManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E417572C2A6446FE0029CDDA /* CurrentUserManagerTests.swift */; };
 		E42CB452291727B200A35AB9 /* HealthKitError.swift in Sources */ = {isa = PBXBuildFile; fileRef = E42CB451291727B200A35AB9 /* HealthKitError.swift */; };
 		E42CB453291727B200A35AB9 /* HealthKitError.swift in Sources */ = {isa = PBXBuildFile; fileRef = E42CB451291727B200A35AB9 /* HealthKitError.swift */; };
 		E42CB454291727B200A35AB9 /* HealthKitError.swift in Sources */ = {isa = PBXBuildFile; fileRef = E42CB451291727B200A35AB9 /* HealthKitError.swift */; };
@@ -339,6 +340,7 @@
 		A1EA154C1B01E6EC0052A6E6 /* DatapointTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatapointTableViewCell.swift; sourceTree = "<group>"; };
 		A1F8F07A232C05410060B83E /* Goal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Goal.swift; sourceTree = "<group>"; };
 		A1F9D1E9211B9B7600E2BC93 /* EditDatapointViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditDatapointViewController.swift; sourceTree = "<group>"; };
+		E417572C2A6446FE0029CDDA /* CurrentUserManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentUserManagerTests.swift; sourceTree = "<group>"; };
 		E42CB451291727B200A35AB9 /* HealthKitError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthKitError.swift; sourceTree = "<group>"; };
 		E43BEA832A036A9C00FC3A38 /* LogReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogReader.swift; sourceTree = "<group>"; };
 		E43BEA852A036D4300FC3A38 /* LogReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogReaderTests.swift; sourceTree = "<group>"; };
@@ -614,6 +616,7 @@
 				A196CB301AE4142F00B90A3E /* Supporting Files */,
 				E48E2713296B75E4008013C0 /* TotalSleepMinutesTests.swift */,
 				E43BEA852A036D4300FC3A38 /* LogReaderTests.swift */,
+				E417572C2A6446FE0029CDDA /* CurrentUserManagerTests.swift */,
 			);
 			path = BeeSwiftTests;
 			sourceTree = "<group>";
@@ -1181,6 +1184,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E417572D2A6446FE0029CDDA /* CurrentUserManagerTests.swift in Sources */,
 				E4B0A32E28C194C800055EA7 /* AddDataIntents.intentdefinition in Sources */,
 				E48E2714296B75E4008013C0 /* TotalSleepMinutesTests.swift in Sources */,
 				A196CB331AE4142F00B90A3E /* BeeSwiftTests.swift in Sources */,

--- a/BeeSwift.xcodeproj/project.pbxproj
+++ b/BeeSwift.xcodeproj/project.pbxproj
@@ -70,6 +70,9 @@
 		A1EA154D1B01E6EC0052A6E6 /* DatapointTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1EA154C1B01E6EC0052A6E6 /* DatapointTableViewCell.swift */; };
 		A1F8F07B232C05410060B83E /* Goal.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1F8F07A232C05410060B83E /* Goal.swift */; };
 		A1F9D1EA211B9B7600E2BC93 /* EditDatapointViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1F9D1E9211B9B7600E2BC93 /* EditDatapointViewController.swift */; };
+		E41286F12A62E6840093D598 /* KeychainSwift in Frameworks */ = {isa = PBXBuildFile; productRef = E41286F02A62E6840093D598 /* KeychainSwift */; };
+		E41286F32A62E97B0093D598 /* KeychainSwift in Frameworks */ = {isa = PBXBuildFile; productRef = E41286F22A62E97B0093D598 /* KeychainSwift */; };
+		E41286F52A62E9840093D598 /* KeychainSwift in Frameworks */ = {isa = PBXBuildFile; productRef = E41286F42A62E9840093D598 /* KeychainSwift */; };
 		E42CB452291727B200A35AB9 /* HealthKitError.swift in Sources */ = {isa = PBXBuildFile; fileRef = E42CB451291727B200A35AB9 /* HealthKitError.swift */; };
 		E42CB453291727B200A35AB9 /* HealthKitError.swift in Sources */ = {isa = PBXBuildFile; fileRef = E42CB451291727B200A35AB9 /* HealthKitError.swift */; };
 		E42CB454291727B200A35AB9 /* HealthKitError.swift in Sources */ = {isa = PBXBuildFile; fileRef = E42CB451291727B200A35AB9 /* HealthKitError.swift */; };
@@ -389,6 +392,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E41286F52A62E9840093D598 /* KeychainSwift in Frameworks */,
 				E462BA4A29ADAAB800E80EF0 /* SnapKit in Frameworks */,
 				A142492E1FD0A56A007736B3 /* HealthKit.framework in Frameworks */,
 				E462BA5129ADAB4F00E80EF0 /* MBProgressHUD in Frameworks */,
@@ -410,6 +414,7 @@
 				E57BE6F52655EBE000BA540B /* BeeKit.framework in Frameworks */,
 				A1B672401B0989E800584782 /* UIKit.framework in Frameworks */,
 				E486DE2629B0403700F338B2 /* OrderedCollections in Frameworks */,
+				E41286F12A62E6840093D598 /* KeychainSwift in Frameworks */,
 				E462BA5A29AEF02500E80EF0 /* IQKeyboardManagerSwift in Frameworks */,
 				E462BA3C29AC453D00E80EF0 /* AlamofireNetworkActivityIndicator in Frameworks */,
 				A1B6723E1B0989DF00584782 /* Foundation.framework in Frameworks */,
@@ -448,6 +453,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E41286F32A62E97B0093D598 /* KeychainSwift in Frameworks */,
 				E486DE2A29B0410A00F338B2 /* OrderedCollections in Frameworks */,
 				E462BA4D29ADAB3900E80EF0 /* SwiftyJSON in Frameworks */,
 				E462BA5329ADACAC00E80EF0 /* Alamofire in Frameworks */,
@@ -749,6 +755,7 @@
 				E462BA5429ADACB600E80EF0 /* Alamofire */,
 				E462BA5629AEEF9D00E80EF0 /* AlamofireImage */,
 				E486DE2729B040FB00F338B2 /* OrderedCollections */,
+				E41286F42A62E9840093D598 /* KeychainSwift */,
 			);
 			productName = BeeSwiftToday;
 			productReference = A12E694D1BD3EF0200AB94C2 /* BeeSwiftToday.appex */;
@@ -782,6 +789,7 @@
 				E462BA4729ADAA1C00E80EF0 /* SnapKit */,
 				E462BA5929AEF02500E80EF0 /* IQKeyboardManagerSwift */,
 				E486DE2529B0403700F338B2 /* OrderedCollections */,
+				E41286F02A62E6840093D598 /* KeychainSwift */,
 			);
 			productName = BeeSwift;
 			productReference = A196CB141AE4142E00B90A3E /* BeeSwift.app */;
@@ -859,6 +867,7 @@
 				E462BA4C29ADAB3900E80EF0 /* SwiftyJSON */,
 				E462BA5229ADACAC00E80EF0 /* Alamofire */,
 				E486DE2929B0410A00F338B2 /* OrderedCollections */,
+				E41286F22A62E97B0093D598 /* KeychainSwift */,
 			);
 			productName = BeeSwiftIntents;
 			productReference = E5F7C490260FC5300095684F /* BeeSwiftIntents.appex */;
@@ -981,6 +990,7 @@
 				E462BA4629ADAA1C00E80EF0 /* XCRemoteSwiftPackageReference "SnapKit" */,
 				E462BA5829AEF02500E80EF0 /* XCRemoteSwiftPackageReference "IQKeyboardManager" */,
 				E486DE2429B0403700F338B2 /* XCRemoteSwiftPackageReference "swift-collections" */,
+				E41286EF2A62E6840093D598 /* XCRemoteSwiftPackageReference "keychain-swift" */,
 			);
 			productRefGroup = A196CB151AE4142E00B90A3E /* Products */;
 			projectDirPath = "";
@@ -1961,6 +1971,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		E41286EF2A62E6840093D598 /* XCRemoteSwiftPackageReference "keychain-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/evgenyneu/keychain-swift.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 20.0.0;
+			};
+		};
 		E462BA3429AC44EA00E80EF0 /* XCRemoteSwiftPackageReference "Alamofire" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Alamofire/Alamofire.git";
@@ -2028,6 +2046,21 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		E41286F02A62E6840093D598 /* KeychainSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E41286EF2A62E6840093D598 /* XCRemoteSwiftPackageReference "keychain-swift" */;
+			productName = KeychainSwift;
+		};
+		E41286F22A62E97B0093D598 /* KeychainSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E41286EF2A62E6840093D598 /* XCRemoteSwiftPackageReference "keychain-swift" */;
+			productName = KeychainSwift;
+		};
+		E41286F42A62E9840093D598 /* KeychainSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E41286EF2A62E6840093D598 /* XCRemoteSwiftPackageReference "keychain-swift" */;
+			productName = KeychainSwift;
+		};
 		E462BA3529AC44EA00E80EF0 /* Alamofire */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = E462BA3429AC44EA00E80EF0 /* XCRemoteSwiftPackageReference "Alamofire" */;

--- a/BeeSwift.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/BeeSwift.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -37,6 +37,15 @@
       }
     },
     {
+      "identity" : "keychain-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/evgenyneu/keychain-swift.git",
+      "state" : {
+        "revision" : "d108a1fa6189e661f91560548ef48651ed8d93b9",
+        "version" : "20.0.0"
+      }
+    },
+    {
       "identity" : "mbprogresshud",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jdg/MBProgressHUD.git",

--- a/BeeSwift/BeeSwift.entitlements
+++ b/BeeSwift/BeeSwift.entitlements
@@ -20,5 +20,9 @@
 	<array>
 		<string>group.beeminder.beeminder</string>
 	</array>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)group.beeminder.beeminder</string>
+	</array>
 </dict>
 </plist>

--- a/BeeSwift/CurrentUserManager.swift
+++ b/BeeSwift/CurrentUserManager.swift
@@ -21,18 +21,20 @@ class CurrentUserManager {
     
     fileprivate let beemiosSecret = "C0QBFPWqDykIgE6RyQ2OJJDxGxGXuVA2CNqcJM185oOOl4EQTjmpiKgcwjki"
     
-    fileprivate let accessTokenKey = "access_token"
-    fileprivate let usernameKey = "username"
-    fileprivate let deadbeatKey = "deadbeat"
-    fileprivate let defaultLeadtimeKey = "default_leadtime"
-    fileprivate let defaultAlertstartKey = "default_alertstart"
-    fileprivate let defaultDeadlineKey = "default_deadline"
-    fileprivate let beemTZKey = "timezone"
+    internal static let accessTokenKey = "access_token"
+    internal static let usernameKey = "username"
+    internal static let deadbeatKey = "deadbeat"
+    internal static let defaultLeadtimeKey = "default_leadtime"
+    internal static let defaultAlertstartKey = "default_alertstart"
+    internal static let defaultDeadlineKey = "default_deadline"
+    internal static let beemTZKey = "timezone"
 
-    private let keychain = KeychainSwift(keyPrefix: "CurrentUserManager_")
+    internal static let keychainPrefix = "CurrentUserManager_"
+
+    private let keychain = KeychainSwift(keyPrefix: CurrentUserManager.keychainPrefix)
     private let requestManager: RequestManager
     
-    var allKeys: [String] {
+    fileprivate static var allKeys: [String] {
         [accessTokenKey, usernameKey, deadbeatKey, defaultLeadtimeKey, defaultAlertstartKey, defaultDeadlineKey, beemTZKey]
     }
     
@@ -50,7 +52,7 @@ class CurrentUserManager {
     /// group-scoped settings object. Values written by old versions of the app may be in the previous store
     /// so we migrate any such values on initialization.
     private func migrateValues() {
-        for key in allKeys {
+        for key in CurrentUserManager.allKeys {
             let standardValue = UserDefaults.standard.object(forKey: key)
             let groupValue = userDefaults.object(forKey: key)
             
@@ -64,13 +66,13 @@ class CurrentUserManager {
 
         // Ensure that the user's access token is stored in the keychain, and only in the
         // keychain. This will require the user to login again if they downgrade.
-        let maybeKeychainAccessToken = keychain.get(accessTokenKey)
-        let maybeUserDefaultsAccessToken = userDefaults.object(forKey: accessTokenKey) as? String
+        let maybeKeychainAccessToken = keychain.get(CurrentUserManager.accessTokenKey)
+        let maybeUserDefaultsAccessToken = userDefaults.object(forKey: CurrentUserManager.accessTokenKey) as? String
         if let userDefaultsAccessToken = maybeUserDefaultsAccessToken, maybeKeychainAccessToken == nil {
             setAccessToken(userDefaultsAccessToken)
         }
-        userDefaults.removeObject(forKey: accessTokenKey)
-        UserDefaults.standard.removeObject(forKey: accessTokenKey)
+        userDefaults.removeObject(forKey: CurrentUserManager.accessTokenKey)
+        UserDefaults.standard.removeObject(forKey: CurrentUserManager.accessTokenKey)
     }
     
     /// Write a value to the UserDefaults store
@@ -89,36 +91,36 @@ class CurrentUserManager {
 
     
     var accessToken :String? {
-        return keychain.get(accessTokenKey)
+        return keychain.get(CurrentUserManager.accessTokenKey)
     }
     
     var username :String? {
-        return userDefaults.object(forKey: usernameKey) as! String?
+        return userDefaults.object(forKey: CurrentUserManager.usernameKey) as! String?
     }
     
     var signingUp : Bool = false
     
     func defaultLeadTime() -> NSNumber {
-        return (userDefaults.object(forKey: self.defaultLeadtimeKey) ?? 0) as! NSNumber
+        return (userDefaults.object(forKey: CurrentUserManager.defaultLeadtimeKey) ?? 0) as! NSNumber
     }
     
     func setDefaultLeadTime(_ leadtime : NSNumber) {
-        self.set(leadtime, forKey: self.defaultLeadtimeKey)    }
+        self.set(leadtime, forKey: CurrentUserManager.defaultLeadtimeKey)    }
     
     func defaultAlertstart() -> NSNumber {
-        return (userDefaults.object(forKey: self.defaultAlertstartKey) ?? 0) as! NSNumber
+        return (userDefaults.object(forKey: CurrentUserManager.defaultAlertstartKey) ?? 0) as! NSNumber
     }
     
     func setDefaultAlertstart(_ alertstart : NSNumber) {
-        self.set(alertstart, forKey: self.defaultAlertstartKey)
+        self.set(alertstart, forKey: CurrentUserManager.defaultAlertstartKey)
     }
     
     func defaultDeadline() -> NSNumber {
-        return (userDefaults.object(forKey: self.defaultDeadlineKey) ?? 0) as! NSNumber
+        return (userDefaults.object(forKey: CurrentUserManager.defaultDeadlineKey) ?? 0) as! NSNumber
     }
     
     func setDefaultDeadline(_ deadline : NSNumber) {
-        self.set(deadline, forKey: self.defaultDeadlineKey)
+        self.set(deadline, forKey: CurrentUserManager.defaultDeadlineKey)
     }
     
     func signedIn() -> Bool {
@@ -126,23 +128,23 @@ class CurrentUserManager {
     }
     
     func isDeadbeat() -> Bool {
-        return userDefaults.object(forKey: deadbeatKey) != nil
+        return userDefaults.object(forKey: CurrentUserManager.deadbeatKey) != nil
     }
     
     func timezone() -> String {
-        return userDefaults.object(forKey: beemTZKey) as? String ?? "Unknown"
+        return userDefaults.object(forKey: CurrentUserManager.beemTZKey) as? String ?? "Unknown"
     }
     
     func setDeadbeat(_ deadbeat: Bool) {
         if deadbeat {
-            self.set(true, forKey: deadbeatKey)
+            self.set(true, forKey: CurrentUserManager.deadbeatKey)
         } else {
-            self.removeObject(forKey: deadbeatKey)
+            self.removeObject(forKey: CurrentUserManager.deadbeatKey)
         }
     }
     
     func setAccessToken(_ accessToken: String) {
-        keychain.set(accessToken, forKey: accessTokenKey, withAccess: .accessibleAfterFirstUnlock)
+        keychain.set(accessToken, forKey: CurrentUserManager.accessTokenKey, withAccess: .accessibleAfterFirstUnlock)
     }
     
     func signInWithEmail(_ email: String, password: String) async {
@@ -158,12 +160,12 @@ class CurrentUserManager {
         if responseJSON["deadbeat"].boolValue {
             self.setDeadbeat(true)
         }
-        self.setAccessToken(responseJSON[accessTokenKey].string!)
-        self.set(responseJSON[usernameKey].string!, forKey: usernameKey)
-        self.set(responseJSON[defaultAlertstartKey].number!, forKey: defaultAlertstartKey)
-        self.set(responseJSON[defaultDeadlineKey].number!, forKey: defaultDeadlineKey)
-        self.set(responseJSON[defaultLeadtimeKey].number!, forKey: defaultLeadtimeKey)
-        self.set(responseJSON[beemTZKey].string!, forKey: beemTZKey)
+        self.setAccessToken(responseJSON[CurrentUserManager.accessTokenKey].string!)
+        self.set(responseJSON[CurrentUserManager.usernameKey].string!, forKey: CurrentUserManager.usernameKey)
+        self.set(responseJSON[CurrentUserManager.defaultAlertstartKey].number!, forKey: CurrentUserManager.defaultAlertstartKey)
+        self.set(responseJSON[CurrentUserManager.defaultDeadlineKey].number!, forKey: CurrentUserManager.defaultDeadlineKey)
+        self.set(responseJSON[CurrentUserManager.defaultLeadtimeKey].number!, forKey: CurrentUserManager.defaultLeadtimeKey)
+        self.set(responseJSON[CurrentUserManager.beemTZKey].string!, forKey: CurrentUserManager.beemTZKey)
         await Task { @MainActor in
             NotificationCenter.default.post(name: Notification.Name(rawValue: CurrentUserManager.signedInNotificationName), object: self)
         }.value
@@ -191,9 +193,9 @@ class CurrentUserManager {
             NotificationCenter.default.post(name: Notification.Name(rawValue: CurrentUserManager.willSignOutNotificationName), object: self)
         }.value
 
-        keychain.delete(accessTokenKey)
-        self.removeObject(forKey: deadbeatKey)
-        self.removeObject(forKey: usernameKey)
+        keychain.delete(CurrentUserManager.accessTokenKey)
+        self.removeObject(forKey: CurrentUserManager.deadbeatKey)
+        self.removeObject(forKey: CurrentUserManager.usernameKey)
 
         await Task { @MainActor in
             NotificationCenter.default.post(name: Notification.Name(rawValue: CurrentUserManager.signedOutNotificationName), object: self)

--- a/BeeSwift/EditDatapointViewController.swift
+++ b/BeeSwift/EditDatapointViewController.swift
@@ -185,7 +185,6 @@ class EditDatapointViewController: UIViewController, UITextFieldDelegate {
 
             do {
                 let params = [
-                    "access_token": ServiceLocator.currentUserManager.accessToken!,
                     "urtext": self.urtext()
                 ]
                 let _ = try await ServiceLocator.requestManager.put(url: "api/v1/users/\(ServiceLocator.currentUserManager.username!)/goals/\(self.goalSlug)/datapoints/\(self.datapoint.id).json", parameters: params)
@@ -202,14 +201,11 @@ class EditDatapointViewController: UIViewController, UITextFieldDelegate {
     
     func deleteDatapoint() {
         Task { @MainActor in
-            let params = [
-                "access_token": ServiceLocator.currentUserManager.accessToken!
-            ]
             let hud = MBProgressHUD.showAdded(to: self.view, animated: true)
             hud.mode = .indeterminate
 
             do {
-                let _ = try await ServiceLocator.requestManager.delete(url: "api/v1/users/\(ServiceLocator.currentUserManager.username!)/goals/\(self.goalSlug)/datapoints/\(self.datapoint.id).json", parameters: params)
+                let _ = try await ServiceLocator.requestManager.delete(url: "api/v1/users/\(ServiceLocator.currentUserManager.username!)/goals/\(self.goalSlug)/datapoints/\(self.datapoint.id).json", parameters: nil)
 
                 let hud = MBProgressHUD.forView(self.view)
                 hud?.mode = .customView

--- a/BeeSwift/Goal.swift
+++ b/BeeSwift/Goal.swift
@@ -358,7 +358,6 @@ class Goal {
             let daystamp = datapoint.daystamp
             let requestId = "\(daystamp)-\(self.minuteStamp())"
             let params = [
-                "access_token": ServiceLocator.currentUserManager.accessToken!,
                 "value": "\(datapointValue)",
                 "comment": "Auto-updated via Apple Health",
                 "requestid": requestId
@@ -468,7 +467,7 @@ class Goal {
             }
 
             let requestId = "\(newDataPoint.daystamp)-\(minuteStamp())"
-            let params = ["access_token": ServiceLocator.currentUserManager.accessToken!, "urtext": "\(newDataPoint.daystamp.suffix(2)) \(newDataPoint.value) \"\(newDataPoint.comment)\"", "requestid": requestId]
+            let params = ["urtext": "\(newDataPoint.daystamp.suffix(2)) \(newDataPoint.value) \"\(newDataPoint.comment)\"", "requestid": requestId]
 
             logger.notice("Creating new datapoint for \(self.id, privacy: .public) on \(newDataPoint.daystamp, privacy: .public): \(newDataPoint.value, privacy: .private)")
 

--- a/BeeSwift/GoalManager.swift
+++ b/BeeSwift/GoalManager.swift
@@ -205,8 +205,10 @@ actor GoalManager {
     private func updateTodayWidget() {
         if let sharedDefaults = UserDefaults(suiteName: Constants.appGroupIdentifier) {
             sharedDefaults.set(self.todayGoalDictionaries(), forKey: "todayGoalDictionaries")
-            // Note this key is different to accessTokenKey
-            sharedDefaults.set(currentUserManager.accessToken, forKey: "accessToken")
+
+            // We used to explicitly need to pass the access token to the today widget. This is no longer needed
+            // but make sure any previously saved value is cleaned up.
+            sharedDefaults.removeObject(forKey: "accessToken")
         }
     }
 

--- a/BeeSwift/GoalManager.swift
+++ b/BeeSwift/GoalManager.swift
@@ -79,14 +79,14 @@ actor GoalManager {
     }
 
     func refreshGoal(_ goal: Goal) async throws {
-        let responseObject = try await requestManager.get(url: "/api/v1/users/\(currentUserManager.username!)/goals/\(goal.slug)?access_token=\(currentUserManager.accessToken!)&datapoints_count=5", parameters: nil)
+        let responseObject = try await requestManager.get(url: "/api/v1/users/\(currentUserManager.username!)/goals/\(goal.slug)?datapoints_count=5", parameters: nil)
         goal.updateToMatch(json: JSON(responseObject!))
 
         await performPostGoalUpdateBookkeeping()
     }
 
     func forceAutodataRefresh(_ goal: Goal) async throws {
-        let _ = try await requestManager.get(url: "/api/v1/users/\(currentUserManager.username!)/goals/\(goal.slug)/refresh_graph.json?access_token=\(currentUserManager.accessToken!)&datapoints_count=5", parameters: nil)
+        let _ = try await requestManager.get(url: "/api/v1/users/\(currentUserManager.username!)/goals/\(goal.slug)/refresh_graph.json", parameters: nil)
     }
 
     /// Update the set of goals to match those in the provided json. Existing Goal objects will be re-used when they match an ID in the json

--- a/BeeSwiftIntents/BeeSwiftIntents.entitlements
+++ b/BeeSwiftIntents/BeeSwiftIntents.entitlements
@@ -6,5 +6,9 @@
 	<array>
 		<string>group.beeminder.beeminder</string>
 	</array>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)group.beeminder.beeminder</string>
+	</array>
 </dict>
 </plist>

--- a/BeeSwiftTests/CurrentUserManagerTests.swift
+++ b/BeeSwiftTests/CurrentUserManagerTests.swift
@@ -21,5 +21,8 @@ final class CurrentUserManagerTests: XCTestCase {
 
         let currentUserManager = CurrentUserManager(requestManager: ServiceLocator.requestManager)
         XCTAssertEqual(currentUserManager.accessToken, "migrated_access_token")
+
+        // The value should also have been removed from UserDefaults
+        XCTAssertNil(userDefaults.object(forKey: "access_token"))
     }
 }

--- a/BeeSwiftTests/CurrentUserManagerTests.swift
+++ b/BeeSwiftTests/CurrentUserManagerTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+import KeychainSwift
+@testable import BeeSwift
+
+final class CurrentUserManagerTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        let keychain = KeychainSwift(keyPrefix: "CurrentUserManager_")
+        keychain.delete("access_token")
+    }
+
+    func testCanSetAndRetrieveAccessToken() throws {
+        let currentUserManager = CurrentUserManager(requestManager: ServiceLocator.requestManager)
+        currentUserManager.setAccessToken("test_access_token")
+        XCTAssertEqual(currentUserManager.accessToken, "test_access_token")
+    }
+
+    func testCanMigrateAccessToken() throws {
+        let userDefaults = UserDefaults(suiteName: Constants.appGroupIdentifier)!
+        userDefaults.set("migrated_access_token", forKey: "access_token")
+
+        let currentUserManager = CurrentUserManager(requestManager: ServiceLocator.requestManager)
+        XCTAssertEqual(currentUserManager.accessToken, "migrated_access_token")
+    }
+}

--- a/BeeSwiftTests/CurrentUserManagerTests.swift
+++ b/BeeSwiftTests/CurrentUserManagerTests.swift
@@ -5,8 +5,8 @@ import KeychainSwift
 final class CurrentUserManagerTests: XCTestCase {
 
     override func setUpWithError() throws {
-        let keychain = KeychainSwift(keyPrefix: "CurrentUserManager_")
-        keychain.delete("access_token")
+        let keychain = KeychainSwift(keyPrefix: CurrentUserManager.keychainPrefix)
+        keychain.delete(CurrentUserManager.accessTokenKey)
     }
 
     func testCanSetAndRetrieveAccessToken() throws {
@@ -17,12 +17,12 @@ final class CurrentUserManagerTests: XCTestCase {
 
     func testCanMigrateAccessToken() throws {
         let userDefaults = UserDefaults(suiteName: Constants.appGroupIdentifier)!
-        userDefaults.set("migrated_access_token", forKey: "access_token")
+        userDefaults.set("migrated_access_token", forKey: CurrentUserManager.accessTokenKey)
 
         let currentUserManager = CurrentUserManager(requestManager: ServiceLocator.requestManager)
         XCTAssertEqual(currentUserManager.accessToken, "migrated_access_token")
 
         // The value should also have been removed from UserDefaults
-        XCTAssertNil(userDefaults.object(forKey: "access_token"))
+        XCTAssertNil(userDefaults.object(forKey: CurrentUserManager.accessTokenKey))
     }
 }

--- a/BeeSwiftToday/BeeSwiftToday.entitlements
+++ b/BeeSwiftToday/BeeSwiftToday.entitlements
@@ -6,5 +6,9 @@
 	<array>
 		<string>group.beeminder.beeminder</string>
 	</array>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)group.beeminder.beeminder</string>
+	</array>
 </dict>
 </plist>

--- a/BeeSwiftToday/TodayTableViewCell.swift
+++ b/BeeSwiftToday/TodayTableViewCell.swift
@@ -118,9 +118,6 @@ class TodayTableViewCell: UITableViewCell {
         let hud = MBProgressHUD.showAdded(to: self, animated: true)
         hud.mode = .indeterminate
         self.addDataButton.isUserInteractionEnabled = false
-
-        let defaults = UserDefaults(suiteName: Constants.appGroupIdentifier)
-        guard let token = defaults?.object(forKey: "accessToken") as? String else { return }
         
         // if the goal's deadline is after midnight, and it's after midnight,
         // but before the deadline,
@@ -151,7 +148,7 @@ class TodayTableViewCell: UITableViewCell {
         formatter.locale = Locale(identifier: "en_US")
         formatter.dateFormat = "d"
         
-        let params = ["access_token": token, "urtext": "\(formatter.string(from: Date(timeIntervalSinceNow: offset*24*3600))) \(Int(self.valueStepper.value)) \"Added via iOS widget\"", "requestid": UUID().uuidString]
+        let params = ["urtext": "\(formatter.string(from: Date(timeIntervalSinceNow: offset*24*3600))) \(Int(self.valueStepper.value)) \"Added via iOS widget\"", "requestid": UUID().uuidString]
         guard let slug = self.goalDictionary["slug"] as? String else { return }
 
         Task { @MainActor in
@@ -174,12 +171,9 @@ class TodayTableViewCell: UITableViewCell {
     @objc func refreshGoal() {
         Task { @MainActor in
             guard let slug = self.goalDictionary["slug"] as? String else { return }
-            let defaults = UserDefaults(suiteName: Constants.appGroupIdentifier)
-            guard let token = defaults?.object(forKey: "accessToken") as? String else { return }
 
-            let parameters = ["access_token": token]
             do {
-                let responseObject = try await ServiceLocator.requestManager.get(url: "api/v1/users/me/goals/\(slug)", parameters: parameters)
+                let responseObject = try await ServiceLocator.requestManager.get(url: "api/v1/users/me/goals/\(slug)", parameters: [:])
                 let goalJSON = JSON(responseObject!)
                 if (!goalJSON["queued"].bool!) {
                     self.pollTimer?.invalidate()


### PR DESCRIPTION
The BeeSwift RequestManager adds authentication information to all
requests. However, in the past this would not work in some scenarios, for
example when code is running from extensions. To work around this some actions
would also explicitly add the access token to the URL.

RequestManager should now always add the credentials (as they are stored in a
location shared with the app group) and so this should no longer be necessary.
Remove all locations in the code base where we manually passed through credentials
to simplify the code, and reduce the chance of them ending up in logs.

Testing:
* [x] Verify you can still add and refresh in the today extension
* [x] Verify you can still add data through shortcuts
* [x] Verify modified endpoints in the main beeswift app still work
