### PR TITLE
Do not crash today widget when goals unavailable

### DIFF
--- a/BeeSwift/GoalManager.swift
+++ b/BeeSwift/GoalManager.swift
@@ -198,6 +198,10 @@ actor GoalManager {
         self.goalsBox.set(nil)
         self.goalsFetchedAt = Date(timeIntervalSince1970: 0)
         currentUserManager.removeObject(forKey: cachedLastFetchedGoalsKey)
+
+        if let sharedDefaults = UserDefaults(suiteName: Constants.appGroupIdentifier) {
+            sharedDefaults.removeObject(forKey: "todayGoalDictionaries")
+        }
     }
 
     // MARK: Today Widget

--- a/BeeSwiftToday/TodayViewController.swift
+++ b/BeeSwiftToday/TodayViewController.swift
@@ -45,7 +45,8 @@ class TodayViewController: UIViewController {
     
     @objc func updateDataSource() {
         let defaults = UserDefaults(suiteName: Constants.appGroupIdentifier)
-        self.goalDictionaries = defaults?.object(forKey: "todayGoalDictionaries") as! Array<NSDictionary>
+        // Goal dictionaries will not be available if the user is logged out or has never fetched goals
+        self.goalDictionaries = defaults?.object(forKey: "todayGoalDictionaries") as? Array<NSDictionary> ?? Array()
     }
 }
 


### PR DESCRIPTION
The today widget previously assumed that the app had made goals available, and
would crash if it was empty. This could happen if the user had never logged in,
or never fetched goals. Now instead just show an empty UI. We could ideally show
an error state, but given today widgets are deprecated we'll accept not crashing.

To test this more easily also clear the today widget on logout. This should fix
#236.

Testing:
Logged out and verified the today widget did not crash in the xcode debugger
