### PR TITLE
Do not crash if goals do not have a mathishard property

### DIFF
--- a/BeeSwift.xcodeproj/project.pbxproj
+++ b/BeeSwift.xcodeproj/project.pbxproj
@@ -140,6 +140,7 @@
 		E4B0A33028C194C900055EA7 /* AddDataIntents.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = E540953B260FB6A100C30784 /* AddDataIntents.intentdefinition */; };
 		E4B0A33128C194C900055EA7 /* AddDataIntents.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = E540953B260FB6A100C30784 /* AddDataIntents.intentdefinition */; };
 		E4B0A33228C194CA00055EA7 /* AddDataIntents.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = E540953B260FB6A100C30784 /* AddDataIntents.intentdefinition */; };
+		E4B6FEC62A776A2900690376 /* GoalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4B6FEC52A776A2900690376 /* GoalTests.swift */; };
 		E4E43D8829F39CE800697116 /* LogsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E43D8729F39CE800697116 /* LogsViewController.swift */; };
 		E4E6426A290E22E6004F3EA9 /* HealthKitConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1E618FF1E86980900D8ED93 /* HealthKitConfig.swift */; };
 		E4E6426B290E22E9004F3EA9 /* HealthKitConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1E618FF1E86980900D8ED93 /* HealthKitConfig.swift */; };
@@ -359,6 +360,7 @@
 		E4B083382932F90400A71564 /* ConfigureHKMetricViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigureHKMetricViewController.swift; sourceTree = "<group>"; };
 		E4B0833A2934620500A71564 /* DatapointTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatapointTableViewController.swift; sourceTree = "<group>"; };
 		E4B0833C293810EB00A71564 /* DataPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataPoint.swift; sourceTree = "<group>"; };
+		E4B6FEC52A776A2900690376 /* GoalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalTests.swift; sourceTree = "<group>"; };
 		E4E43D8729F39CE800697116 /* LogsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogsViewController.swift; sourceTree = "<group>"; };
 		E4E6427B2910C3AB004F3EA9 /* HealthKitMetric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthKitMetric.swift; sourceTree = "<group>"; };
 		E4E6427F2910C3FB004F3EA9 /* QuantityHealthKitMetric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuantityHealthKitMetric.swift; sourceTree = "<group>"; };
@@ -617,6 +619,7 @@
 				E48E2713296B75E4008013C0 /* TotalSleepMinutesTests.swift */,
 				E43BEA852A036D4300FC3A38 /* LogReaderTests.swift */,
 				E417572C2A6446FE0029CDDA /* CurrentUserManagerTests.swift */,
+				E4B6FEC52A776A2900690376 /* GoalTests.swift */,
 			);
 			path = BeeSwiftTests;
 			sourceTree = "<group>";
@@ -1188,6 +1191,7 @@
 				E4B0A32E28C194C800055EA7 /* AddDataIntents.intentdefinition in Sources */,
 				E48E2714296B75E4008013C0 /* TotalSleepMinutesTests.swift in Sources */,
 				A196CB331AE4142F00B90A3E /* BeeSwiftTests.swift in Sources */,
+				E4B6FEC62A776A2900690376 /* GoalTests.swift in Sources */,
 				E43BEA862A036D4300FC3A38 /* LogReaderTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/BeeSwift/Goal.swift
+++ b/BeeSwift/Goal.swift
@@ -115,10 +115,11 @@ class Goal {
 
         self.recent_data = ExistingDataPoint.fromJSONArray(array: json["recent_data"].arrayValue).reversed()
 
-        let math_is_hard = json["mathishard"].arrayValue
-        self.derived_goaldate = math_is_hard[0].number!
-        self.derived_goalval = math_is_hard[1].number!
-        self.derived_rate = math_is_hard[2].number!
+        // In rare cases goals can be corrupted and not have a mathishard value. We don't particularly care about
+        // behavior in this rare case as long as the app does not crash, so default to a nonsense value
+        self.derived_goaldate = json["mathishard"][0].number ?? 0
+        self.derived_goalval = json["mathishard"][1].number ?? 0
+        self.derived_rate = json["mathishard"][2].number ?? 0
     }
 
     var rateString :String {

--- a/BeeSwiftTests/GoalTests.swift
+++ b/BeeSwiftTests/GoalTests.swift
@@ -1,0 +1,180 @@
+//
+//  GoalTests.swift
+//  BeeSwiftTests
+//
+//  Created by Theo Spears on 7/30/23.
+//  Copyright © 2023 APB. All rights reserved.
+//
+
+import XCTest
+import SwiftyJSON
+@testable import BeeSwift
+
+final class GoalTests: XCTestCase {
+
+    func testCreateGoalFromJSON() throws {
+        // This is a partial copy of the beeminder api response, reduced to
+        // only fields which are used by the app
+        let testJSON = JSON(parseJSON: """
+        {
+          "slug": "test-goal",
+          "title": "Goal for Testing Purposes",
+          "rate": 1,
+          "graph_url": "https://cdn.beeminder.com/uploads/879fb101-0111-4f06-a704-1e5e316c5afc.png",
+          "thumb_url": "https://cdn.beeminder.com/uploads/879fb101-0111-4f06-a704-1e5e316c5afc-thumb.png",
+          "losedate": 2000271599,
+          "deadline": 0,
+          "leadtime": 0,
+          "alertstart": 34200,
+          "use_defaults": true,
+          "id": "737aaa34f0118a330852e4bd",
+          "queued": false,
+          "yaw": 1,
+          "lane": 3582,
+          "runits": "d",
+          "limsum": "100 in 200 days",
+          "won": false,
+          "delta_text": "✔ ✔ ✔",
+          "safebump": 3828,
+          "safesum": "safe for 200 days",
+          "lasttouch": "2022-12-07T03:21:40.000Z",
+          "safebuf": 3583,
+          "todayta": false,
+          "hhmmformat": false,
+          "yaxis": "cumulative total test-goal",
+          "initday": 1668963600,
+          "curval": 4000,
+          "dir": 1,
+          "pledge": 0,
+          "mathishard": [
+            2000217600,
+            3828,
+            1
+          ],
+          "recent_data": [
+            {
+              "id": {
+                "$oid": "888000000000000000000001"
+              },
+              "comment": "Auto-entered via Apple Health",
+              "value": 10.5,
+              "daystamp": "20221203"
+            },
+            {
+              "id": {
+                "$oid": "888000000000000000000002"
+              },
+              "comment": "Auto-entered via Apple Health",
+              "value": 20.5,
+              "daystamp": "20221130"
+            },
+            {
+              "id": {
+                "$oid": "888000000000000000000003"
+              },
+              "comment": "Auto-updated via Apple Health",
+              "value": 30.5,
+              "daystamp": "20221126"
+            },
+            {
+              "id": {
+                "$oid": "888000000000000000000004"
+              },
+              "comment": "Auto-updated via Apple Health",
+              "value": 5.5,
+              "daystamp": "20221125"
+            },
+            {
+              "id": {
+                "$oid": "888000000000000000000005"
+              },
+              "comment": "Auto-updated via Apple Health",
+              "value": 1.5,
+              "daystamp": "20221121"
+            }
+          ]
+        }
+        """)
+
+        let goal = Goal(json: testJSON)
+
+        XCTAssertEqual(goal.slug, "test-goal")
+        XCTAssertEqual(goal.title, "Goal for Testing Purposes")
+        XCTAssertEqual(goal.rate, 1)
+        XCTAssertEqual(goal.graph_url, "https://cdn.beeminder.com/uploads/879fb101-0111-4f06-a704-1e5e316c5afc.png")
+        XCTAssertEqual(goal.thumb_url, "https://cdn.beeminder.com/uploads/879fb101-0111-4f06-a704-1e5e316c5afc-thumb.png")
+        XCTAssertEqual(goal.losedate, 2000271599)
+        XCTAssertEqual(goal.deadline, 0)
+        XCTAssertEqual(goal.leadtime, 0)
+        XCTAssertEqual(goal.alertstart, 34200)
+        XCTAssertEqual(goal.use_defaults, true)
+        XCTAssertEqual(goal.id, "737aaa34f0118a330852e4bd")
+        XCTAssertEqual(goal.queued, false)
+        XCTAssertEqual(goal.yaw, 1)
+        XCTAssertEqual(goal.lane, 3582)
+        XCTAssertEqual(goal.runits, "d")
+        XCTAssertEqual(goal.limsum, "100 in 200 days")
+        XCTAssertEqual(goal.won, false)
+        XCTAssertEqual(goal.delta_text, "✔ ✔ ✔")
+        XCTAssertEqual(goal.safebump, 3828)
+        XCTAssertEqual(goal.safesum, "safe for 200 days")
+        XCTAssertEqual(goal.lasttouch, 1670383300)
+        XCTAssertEqual(goal.safebuf, 3583)
+        XCTAssertEqual(goal.todayta, false)
+        XCTAssertEqual(goal.hhmmformat, false)
+        XCTAssertEqual(goal.yaxis, "cumulative total test-goal")
+        XCTAssertEqual(goal.initday, 1668963600)
+        XCTAssertEqual(goal.curval, 4000)
+        XCTAssertEqual(goal.dir, 1)
+        XCTAssertEqual(goal.pledge, 0)
+        XCTAssertEqual(goal.derived_goaldate, 2000217600)
+        XCTAssertEqual(goal.derived_goalval, 3828)
+        XCTAssertEqual(goal.derived_rate, 1)
+        XCTAssertEqual(goal.recent_data!.count, 5)
+
+    }
+
+    func testCanCreateGoalWithoutMathIsHard() throws {
+        let testJSON = JSON(parseJSON: """
+        {
+          "slug": "test-goal",
+          "title": "Goal for Testing Purposes",
+          "rate": 1,
+          "graph_url": "https://cdn.beeminder.com/uploads/879fb101-0111-4f06-a704-1e5e316c5afc.png",
+          "thumb_url": "https://cdn.beeminder.com/uploads/879fb101-0111-4f06-a704-1e5e316c5afc-thumb.png",
+          "losedate": 2000271599,
+          "deadline": 0,
+          "leadtime": 0,
+          "alertstart": 34200,
+          "use_defaults": true,
+          "id": "737aaa34f0118a330852e4bd",
+          "queued": false,
+          "yaw": 1,
+          "lane": 3582,
+          "runits": "d",
+          "limsum": "100 in 200 days",
+          "won": false,
+          "delta_text": "✔ ✔ ✔",
+          "safebump": 3828,
+          "safesum": "safe for 200 days",
+          "lasttouch": "2022-12-07T03:21:40.000Z",
+          "safebuf": 3583,
+          "todayta": false,
+          "hhmmformat": false,
+          "yaxis": "cumulative total test-goal",
+          "initday": 1668963600,
+          "curval": 4000,
+          "dir": 1,
+          "pledge": 0,
+          "recent_data": []
+        }
+        """)
+
+        let goal = Goal(json: testJSON)
+
+        XCTAssertEqual(goal.derived_goaldate, 0)
+        XCTAssertEqual(goal.derived_goalval, 0)
+        XCTAssertEqual(goal.derived_rate, 0)
+    }
+
+}


### PR DESCRIPTION
While it is intended that the api returns a value for `mathishard` for all
goals there appear to exist some corrupt goals where this is not the case, and
this currently causes the app to crash, preventing access to all the other
goals. Be more tolerant to this property not existing.

Testing:
Wrote unit tests to validate the app can parse these response payloads without
crashing.
