### PR TITLE
Fix crash when modifying notification settings

### DIFF
--- a/BeeSwift/EditDefaultNotificationsViewController.swift
+++ b/BeeSwift/EditDefaultNotificationsViewController.swift
@@ -24,8 +24,9 @@ class EditDefaultNotificationsViewController: EditNotificationsViewController {
     }
     
     override func sendLeadTimeToServer(_ timer : Timer) {
+        // We must not use `timer` in the Task as it may change once this method returns
+        let userInfo = timer.userInfo! as! Dictionary<String, NSNumber>
         Task { @MainActor in
-            let userInfo = timer.userInfo! as! Dictionary<String, NSNumber>
             guard let leadtime = userInfo["leadtime"] else { return }
             let params = [ "default_leadtime" : leadtime ]
             do {

--- a/BeeSwift/EditGoalNotificationsViewController.swift
+++ b/BeeSwift/EditGoalNotificationsViewController.swift
@@ -60,8 +60,9 @@ class EditGoalNotificationsViewController : EditNotificationsViewController {
     }
     
     override func sendLeadTimeToServer(_ timer : Timer) {
+        // We must not use `timer` in the Task as it may change once this method returns
+        let userInfo = timer.userInfo! as! Dictionary<String, NSNumber>
         Task { @MainActor in
-            let userInfo = timer.userInfo! as! Dictionary<String, NSNumber>
             let leadtime = userInfo["leadtime"]
             let params = [ "leadtime" : leadtime, "use_defaults" : false ]
             do {


### PR DESCRIPTION
In #344 we made various functions run their behavior inside async Tasks. In
the case of timer callback methods this was unsafe as it meant we ran the code
after the method returned, which means properties on the timer were no longer
set as expected. Solve this by moving all access to timer properties outside
the Task.

Testing:
Repeatedly modified settings in the app without exercising the crash
