### PR TITLE
Use consistent colors throughout the app

### DIFF
--- a/BeeSwift/GalleryViewController.swift
+++ b/BeeSwift/GalleryViewController.swift
@@ -90,7 +90,7 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
         
         let deadbeatLabel = BSLabel()
         self.deadbeatView.addSubview(deadbeatLabel)
-        deadbeatLabel.textColor = UIColor.red
+        deadbeatLabel.textColor = .beeminder.red
         deadbeatLabel.numberOfLines = 0
         deadbeatLabel.font = UIFont.beeminder.defaultFontHeavy.withSize(13)
         deadbeatLabel.text = "Hey! Beeminder couldn't charge your credit card, so you can't see your graphs. Please update your card on beeminder.com or email support@beeminder.com if this is a mistake."
@@ -110,7 +110,7 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
         }
         
         self.outofdateView.addSubview(self.outofdateLabel)
-        self.outofdateLabel.textColor = .red
+        self.outofdateLabel.textColor = .beeminder.red
         self.outofdateLabel.numberOfLines = 0
         self.outofdateLabel.font = UIFont.beeminder.defaultFontHeavy.withSize(12)
         self.outofdateLabel.textAlignment = .center
@@ -333,7 +333,7 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
         var color = UIColor.black
         if let lastUpdated = self.lastUpdated {
             if lastUpdated.timeIntervalSinceNow < -3600 {
-                color = UIColor.red
+                color = .beeminder.red
                 lastTextString = "Last updated: a long time ago..."
             }
             else if lastUpdated.timeIntervalSinceNow < -120 {
@@ -350,7 +350,7 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
             }
         }
         else {
-            color = UIColor.red
+            color = .beeminder.red
             lastTextString = "Last updated: a long time ago..."
         }
         let lastText: NSMutableAttributedString = NSMutableAttributedString(string: lastTextString)

--- a/BeeSwift/Goal.swift
+++ b/BeeSwift/Goal.swift
@@ -185,13 +185,13 @@ class Goal {
     var countdownColor :UIColor {
         guard let buf = self.safebuf?.intValue else { return UIColor.beeminder.gray }
         if buf < 1 {
-            return UIColor.systemRed
+            return UIColor.beeminder.red
         }
         else if buf < 2 {
-            return UIColor.systemOrange
+            return UIColor.beeminder.orange
         }
         else if buf < 3 {
-            return UIColor.systemBlue
+            return UIColor.beeminder.blue
         }
         return UIColor.beeminder.green
     }
@@ -298,7 +298,7 @@ class Goal {
     }
     
     var deltaColorsWhenBelowIsGoodSide: [UIColor] {
-        return [UIColor.beeminder.green, UIColor.systemBlue, UIColor.systemOrange]
+        return [UIColor.beeminder.green, UIColor.beeminder.blue, UIColor.beeminder.orange]
     }
     
     var deltaColorsWhenAboveIsGoodSide: [UIColor] {

--- a/BeeSwift/UIColorExtension.swift
+++ b/BeeSwift/UIColorExtension.swift
@@ -15,7 +15,11 @@ extension UIColor {
         static var green: UIColor {
             return UIColor(red: 81.0/255.0, green: 163.0/255.0, blue: 81.0/255.0, alpha: 1)
         }
-    
+
+        static var blue: UIColor = UIColor.systemBlue
+        static var orange: UIColor = UIColor.systemOrange
+        static var red: UIColor = UIColor.systemRed
+
         static var gray: UIColor {
             return UIColor(white: 0.7, alpha: 1.0)
         }


### PR DESCRIPTION
This adds all the colors used through the app to the beeminder UIColor
extension and updates call sites to use it. This should make it possible
to update colors in one place if we want to make future tweaks.

This only updates colors which are controlled by the app, so for example
will not affect the charts, or the borders around them.

Testing:
Loaded the app and clicked around
