### PR TITLE
Fix race condition crash when getting goal connections

### DIFF
--- a/BeeSwift/HealthStoreManager.swift
+++ b/BeeSwift/HealthStoreManager.swift
@@ -135,11 +135,12 @@ class HealthStoreManager :NSObject {
                     connections[goal.id] = GoalHealthKitConnection(goal: goal, metric: metric, healthStore: healthStore)
                 }
             }
-
         }
+
+        let connection = connections[goal.id]
         connectionsSemaphore.signal()
 
-        return connections[goal.id]
+        return connection
     }
 
     private func requestAuthorization(read: Set<HKObjectType>) async throws {


### PR DESCRIPTION
There is a mutable map linking goals to health kit data sources. While all writes to
this were protected by a mutex, reads were not. It appears it is not safe to read from
this connection while writing to it, so this lead to crashes. Fix by also wrapping the
read.

Testing:
Launched the app and checked it could sync goals
