### PR TITLE
Only run tests once in fastlane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -17,8 +17,7 @@ default_platform(:ios)
 
 platform :ios do
   lane :test do
-    run_tests(scheme: "BeeSwiftTests")
-    run_tests(scheme: "BeeSwiftUITests")
+    run_tests(scheme: "BeeSwift")
   end
   lane :build do
     build_app(scheme: "BeeSwift")


### PR DESCRIPTION
Something about our fastlane configuration was resulting in some tests being run twice, slowing test runs. Update to only run all tests once.

Testing:
Verify this PR runs tests
