### PR TITLE
Read and write requestids for datapoints with HealthKit

### DIFF
--- a/BeeSwift/DataPoint.swift
+++ b/BeeSwift/DataPoint.swift
@@ -4,6 +4,7 @@ import Foundation
 import SwiftyJSON
 
 protocol DataPoint {
+    var requestid: String { get }
     var daystamp: String { get }
     var value: NSNumber { get }
     var comment: String { get }
@@ -12,6 +13,7 @@ protocol DataPoint {
 /// A data point received from the server. This will have had an ID allocated
 struct ExistingDataPoint : DataPoint {
     let id: String
+    let requestid: String
     let daystamp: String
     let value: NSNumber
     let comment: String
@@ -23,6 +25,7 @@ struct ExistingDataPoint : DataPoint {
         daystamp = json["daystamp"].stringValue
         value = json["value"].numberValue
         comment = json["comment"].stringValue
+        requestid = json["requestid"].stringValue
     }
 
     static func fromJSONArray(array: [JSON]) -> [ExistingDataPoint] {
@@ -32,6 +35,7 @@ struct ExistingDataPoint : DataPoint {
 
 /// A data point we have created locally (e.g. from user input, or HealthKit)
 struct NewDataPoint : DataPoint {
+    let requestid: String
     let daystamp: String
     let value: NSNumber
     let comment: String

--- a/BeeSwift/Goal.swift
+++ b/BeeSwift/Goal.swift
@@ -316,12 +316,6 @@ class Goal {
     var isLinkedToHealthKit: Bool {
         return self.autodata == "apple"
     }
-    
-    func minuteStamp() -> String {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "YYYYMMddHHmm"
-        return formatter.string(from: Date())
-    }
 
     /// The daystamp corresponding to the day of the goal's creation, thus the first day we should add data points for.
     var initDaystamp: String {
@@ -364,11 +358,9 @@ class Goal {
                 return
             }
             let daystamp = datapoint.daystamp
-            let requestId = "\(daystamp)-\(self.minuteStamp())"
             let params = [
                 "value": "\(datapointValue)",
                 "comment": "Auto-updated via Apple Health",
-                "requestid": requestId
             ]
             do {
                 let _ = try await ServiceLocator.requestManager.put(url: "api/v1/users/\(ServiceLocator.currentUserManager.username!)/goals/\(self.slug)/datapoints/\(datapoint.id).json", parameters: params)
@@ -474,8 +466,7 @@ class Goal {
                 return
             }
 
-            let requestId = "\(newDataPoint.daystamp)-\(minuteStamp())"
-            let params = ["urtext": "\(newDataPoint.daystamp.suffix(2)) \(newDataPoint.value) \"\(newDataPoint.comment)\"", "requestid": requestId]
+            let params = ["urtext": "\(newDataPoint.daystamp.suffix(2)) \(newDataPoint.value) \"\(newDataPoint.comment)\"", "requestid": newDataPoint.requestid]
 
             logger.notice("Creating new datapoint for \(self.id, privacy: .public) on \(newDataPoint.daystamp, privacy: .public): \(newDataPoint.value, privacy: .private)")
 

--- a/BeeSwift/HeathKit/CategoryHealthKitMetric.swift
+++ b/BeeSwift/HeathKit/CategoryHealthKitMetric.swift
@@ -65,8 +65,9 @@ class CategoryHealthKitMetric : HealthKitMetric {
             healthStore.execute(query)
         })
 
+        let id = "apple-heath-" + daystamp
         let datapointValue = self.hkDatapointValueForSamples(samples: samples, startOfDate: bounds.start)
-        return NewDataPoint(daystamp: daystamp, value: NSNumber(value: datapointValue), comment: "Auto-entered via Apple Health")
+        return NewDataPoint(requestid: id, daystamp: daystamp, value: NSNumber(value: datapointValue), comment: "Auto-entered via Apple Health")
     }
 
     internal func dayStampFromDayOffset(dayOffset : Int, deadline : Int) throws -> String {

--- a/BeeSwift/HeathKit/QuantityHealthKitMetric.swift
+++ b/BeeSwift/HeathKit/QuantityHealthKitMetric.swift
@@ -148,7 +148,8 @@ class QuantityHealthKitMetric : HealthKitMetric {
             formatter.dateFormat = "yyyyMMdd"
             let daystamp = formatter.string(from: datapointDate)
 
-            results.append(NewDataPoint(daystamp: daystamp, value: NSNumber(value: datapointValue), comment: "Auto-entered via Apple Health"))
+            let id = "apple-health-" + daystamp
+            results.append(NewDataPoint(requestid: id, daystamp: daystamp, value: NSNumber(value: datapointValue), comment: "Auto-entered via Apple Health"))
         }
 
         return results


### PR DESCRIPTION
This prepares for supporting point-by-point syncing of data from HealthKit. In particular
1) HealthKit data sources now provide a requestid for the datapoints they generate
2) We always read requestid from the server (now they are always sent)

This will start writing new IDs immediately, and in the future means we can use the IDs to sync when we have multiple datapoints per day.

Testing:
* [ ] Deleted some existing data points, synced with apple heath, and checked they got requestids as expected
* [ ] Checked the app can still update existing points via apple health
* [ ] Confirmed data points still load without crashing
