### PR TITLE
Remove unused variable

### DIFF
--- a/BeeSwift/Goal.swift
+++ b/BeeSwift/Goal.swift
@@ -357,7 +357,6 @@ class Goal {
                 success?()
                 return
             }
-            let daystamp = datapoint.daystamp
             let params = [
                 "value": "\(datapointValue)",
                 "comment": "Auto-updated via Apple Health",


### PR DESCRIPTION
We were finding the daystamp for a data point and then not using it, producing a build warning. Remove the variable to eliminate the warning.
