### PR TITLE
Upload fastlane log artifacts

### DIFF
--- a/.github/workflows/fastlane-tests.yml
+++ b/.github/workflows/fastlane-tests.yml
@@ -23,6 +23,7 @@ jobs:
       run: bundle exec fastlane test
     - name: Upload report
       uses: actions/upload-artifact@v4
+      if: always() # always run even if the previous step fails
       with:
         name: test-output
         path: fastlane/test_output

--- a/.github/workflows/fastlane-tests.yml
+++ b/.github/workflows/fastlane-tests.yml
@@ -21,16 +21,11 @@ jobs:
         bundler-cache: true
     - name: Run tests
       run: bundle exec fastlane test
-    - name: Upload logs
-      uses: actions/upload-artifact@v4
-      with:
-        name: simulator-logs
-        path: ~/Library/Logs/CoreSimulator
     - name: Upload report
       uses: actions/upload-artifact@v4
       with:
-        name: test-report.html
-        path: fastlane/test_output/report.html
+        name: test-output
+        path: fastlane/test_output
     - name: Publish Test Report
       uses: mikepenz/action-junit-report@v4
       if: always() # always run even if the previous step fails

--- a/.github/workflows/fastlane-tests.yml
+++ b/.github/workflows/fastlane-tests.yml
@@ -21,6 +21,16 @@ jobs:
         bundler-cache: true
     - name: Run tests
       run: bundle exec fastlane test
+    - name: Upload logs
+      uses: actions/upload-artifact@v4
+      with:
+        name: simulator-logs
+        path: ~/Library/Logs/CoreSimulator
+    - name: Upload report
+      uses: actions/upload-artifact@v4
+      with:
+        name: test-report.html
+        path: fastlane/test_output/report.html
     - name: Publish Test Report
       uses: mikepenz/action-junit-report@v4
       if: always() # always run even if the previous step fails

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -21,6 +21,7 @@ platform :ios do
         scheme: "BeeSwift",
         reset_simulator: true,
         include_simulator_logs: true,
+        buildlog_path: "fastlane/test_output",
     )
   end
   lane :build do

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -17,7 +17,12 @@ default_platform(:ios)
 
 platform :ios do
   lane :test do
-    run_tests(scheme: "BeeSwift")
+    run_tests(
+        scheme: "BeeSwift",
+        reset_simulator: true,
+        output_style: "raw"
+
+    )
   end
   lane :build do
     build_app(scheme: "BeeSwift")

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -22,6 +22,7 @@ platform :ios do
         reset_simulator: true,
         include_simulator_logs: true,
         buildlog_path: "fastlane/test_output",
+        xcodebuild_formatter: "xcpretty",
     )
   end
   lane :build do

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -21,8 +21,6 @@ platform :ios do
         scheme: "BeeSwift",
         reset_simulator: true,
         include_simulator_logs: true,
-        output_style: "raw"
-
     )
   end
   lane :build do

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -20,6 +20,7 @@ platform :ios do
     run_tests(
         scheme: "BeeSwift",
         reset_simulator: true,
+        include_simulator_logs: true,
         output_style: "raw"
 
     )


### PR DESCRIPTION
Update fastlane tests to collect and upload build logs as an artifact. These can the be manually downloaded to help debug build failures in CI.

Testing:
Verified that an artifact was created and had expected contents
