### PR TITLE
Update deprecated launch performance test

### DIFF
--- a/BeeSwiftUITests/BeeSwiftUITests.swift
+++ b/BeeSwiftUITests/BeeSwiftUITests.swift
@@ -34,7 +34,7 @@ class BeeSwiftUITests: XCTestCase {
 
     func testLaunchPerformance() {
         // This measures how long it takes to launch your application.
-        measure(metrics: [XCTOSSignpostMetric.applicationLaunch]) {
+        measure(metrics: [XCTApplicationLaunchMetric()]) {
             XCUIApplication().launch()
         }
     }


### PR DESCRIPTION
Apple has changed the intended metrics for tests which benchmark startup time. Switch to the new metric.

Testing:
Verify tests pass locally and also in CI
