### PR TITLE
Introduce the Daystamp type

### DIFF
--- a/BeeKit/Daystamp.swift
+++ b/BeeKit/Daystamp.swift
@@ -1,0 +1,143 @@
+import Foundation
+
+public struct Daystamp: CustomStringConvertible, Strideable, Comparable, Equatable, Hashable {
+    public typealias Stride = Int
+
+    private static let daystampPattern = try! NSRegularExpression(pattern: "^(?<year>\\d{4})(?<month>\\d{2})(?<day>\\d{2})$")
+    private static let minutesInDay = 24 * 60
+
+    private static let calendar = {
+        var calendar = Calendar(identifier: .iso8601)
+        calendar.locale = Locale(identifier: "en_US_POSIX")
+        calendar.timeZone = TimeZone.autoupdatingCurrent
+        return calendar
+    }()
+
+    public let year, month, day: Int
+
+    init(year: Int, month: Int, day: Int) {
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    init(fromString daystamp: String) throws {
+        let range = NSRange(location: 0, length: daystamp.utf16.count)
+        guard let matchResult = Daystamp.daystampPattern.firstMatch(in: daystamp, range: range) else {
+            // TODO: This should throw an error instead
+            fatalError("That wasn't a daystamp!")
+        }
+
+        // Errors here are impossible as the regex has verifed these ranges exist and are numbers
+        let year = Int(daystamp[Range(matchResult.range(withName: "year"), in: daystamp)!])!
+        let month = Int(daystamp[Range(matchResult.range(withName: "month"), in: daystamp)!])!
+        let day = Int(daystamp[Range(matchResult.range(withName: "day"), in: daystamp)!])!
+
+        self.init(year: year, month: month, day: day)
+    }
+
+    init(fromDate date: Date, deadline: Int) {
+        let minutesAfterMidnight = Daystamp.calendar.component(.hour, from: date) * 60 + Daystamp.calendar.component(.minute, from: date)
+
+        let dayOffsetFromDeadline = if deadline < 0 {
+            // This is an early deadline. If the time is after the deadline we need to instead consider it the next day
+            if minutesAfterMidnight > Daystamp.minutesInDay + deadline {
+                1
+            } else {
+                0
+            }
+        } else {
+            // This is a late deadline. If the time is before the deadline, we should consider it the previous day
+            if minutesAfterMidnight < deadline {
+                -1
+            } else {
+                0
+            }
+        }
+        let adjustedDate = Daystamp.calendar.date(byAdding: DateComponents(calendar:Daystamp.calendar, day: dayOffsetFromDeadline), to: date)!
+
+        self.init(fromDate: adjustedDate)
+    }
+
+    /// Private constructor to make a daystamp from the components of a date which is used internally by the class for date math
+    /// Public users of the class should use init(fromDate:deadline) to make sure deadline adjustments are done correctly.
+    private init(fromDate date: Date) {
+        let components = Daystamp.calendar.dateComponents([.year, .month, .day], from: date)
+        self.init(year: components.year!, month: components.month!, day: components.day!)
+    }
+
+    static func now(deadline: Int) -> Daystamp {
+        return Daystamp(fromDate: Date(), deadline: deadline)
+    }
+
+    /// The Date corresponding to the start of this Daystamp (inclusive)
+    /// Note this uses the system timezone to determine when days start and end, which may not match the user's timezone
+    func start(deadline: Int) -> Date {
+        return Daystamp.calendar.date(from: DateComponents(calendar: Daystamp.calendar, year: year, month: month, day: day, minute: deadline))!
+    }
+
+    /// The Date corresponding to the end of this Daystamp (exclusive)
+    /// Note this uses the system timezone to determine when days start and end, which may not match the user's timezone
+    func end(deadline: Int) -> Date {
+        return self.advanced(by: 1).start(deadline: deadline)
+    }
+
+    public static func + (lhs: Daystamp, rhs: Int) -> Daystamp {
+        return lhs.advanced(by: rhs)
+    }
+
+    public static func - (lhs: Daystamp, rhs: Int) -> Daystamp {
+        return lhs.advanced(by: -rhs)
+    }
+
+    public static func - (lhs: Daystamp, rhs: Daystamp) -> Int {
+        return rhs.distance(to: lhs)
+    }
+
+    // Trait: CustomStringConvertible
+
+    public var description: String {
+        return String(format: "%04d%02d%02d", year, month, day)
+    }
+
+    // Trait: Strideable
+
+    public func distance(to other: Daystamp) -> Int {
+
+        let selfDate = Daystamp.calendar.date(from: DateComponents(calendar: Daystamp.calendar, year: year, month: month, day: day))!
+        let otherDate = Daystamp.calendar.date(from: DateComponents(calendar: Daystamp.calendar, year: other.year, month: other.month, day: other.day))!
+
+        return Calendar.current.dateComponents([.day], from: selfDate, to: otherDate).day!
+    }
+
+    public func advanced(by n: Int) -> Daystamp {
+        let date = Daystamp.calendar.date(from: DateComponents(calendar: Daystamp.calendar, year: year, month: month, day: day))!
+
+        let adjustedDate = Daystamp.calendar.date(byAdding: DateComponents(calendar:Daystamp.calendar, day: n), to: date)!
+        return Daystamp(fromDate: adjustedDate)
+    }
+
+    // Trait: Comparable
+
+    public static func < (lhs: Daystamp, rhs: Daystamp) -> Bool {
+        if lhs.year < rhs.year {
+            return true
+        } else if lhs.year > rhs.year {
+            return false
+        }
+
+        if lhs.month < rhs.month {
+            return true
+        } else if lhs.month > rhs.month {
+            return false
+        }
+
+        return lhs.day < rhs.day
+    }
+
+    // Trait: Equatable
+    // This is generated automatically for structs by the compiler
+
+    // Trait: Hashable
+    // This is generated automatically for structs by the compiler
+}

--- a/BeeKit/Daystamp.swift
+++ b/BeeKit/Daystamp.swift
@@ -1,5 +1,10 @@
 import Foundation
 
+/// Representation of the beeminder Daystamp concept
+///
+/// Roughly corresponds to a "Calendar Day". Somewhat compelx to handle as goals can have
+/// a custom "deadlaine" representing when their day starts/ends, which can include either the previous
+/// or following day. This class understands how to handle that concept when converting to and from real times.
 public struct Daystamp: CustomStringConvertible, Strideable, Comparable, Equatable, Hashable {
     public typealias Stride = Int
 
@@ -103,7 +108,6 @@ public struct Daystamp: CustomStringConvertible, Strideable, Comparable, Equatab
     // Trait: Strideable
 
     public func distance(to other: Daystamp) -> Int {
-
         let selfDate = Daystamp.calendar.date(from: DateComponents(calendar: Daystamp.calendar, year: year, month: month, day: day))!
         let otherDate = Daystamp.calendar.date(from: DateComponents(calendar: Daystamp.calendar, year: other.year, month: other.month, day: other.day))!
 

--- a/BeeKitTests/DaystampTests.swift
+++ b/BeeKitTests/DaystampTests.swift
@@ -1,0 +1,119 @@
+//
+//  DaystampTests.swift
+//  BeeKitTests
+//
+//  Created by Theo Spears on 7/11/23.
+//  Copyright © 2023 APB. All rights reserved.
+//
+
+import XCTest
+@testable import BeeKit
+
+final class DaystampTests: XCTestCase {
+    var previousTimezone: TimeZone!
+
+    let OneHourInMinutes = 60
+
+    func testFormatsAsString() throws {
+        let daystamp = Daystamp(year: 2023, month: 7, day: 11)
+        XCTAssertEqual(daystamp.description, "20230711")
+    }
+
+    func testParsesFromString() throws {
+        let daystamp = try Daystamp(fromString: "20230711")
+        XCTAssertEqual(daystamp.year, 2023)
+        XCTAssertEqual(daystamp.month, 7)
+        XCTAssertEqual(daystamp.day, 11)
+    }
+
+    func testConvertsFromDate() throws {
+        let date = date(year: 1970, month: 1, day: 1, hour: 0, minute: 0)
+        let daystamp = Daystamp(fromDate: date, deadline: 0)
+        XCTAssertEqual(daystamp.year, 1970)
+        XCTAssertEqual(daystamp.month, 1)
+        XCTAssertEqual(daystamp.day, 1)
+    }
+
+    func testConvertsFromDateWithPositiveDeadlineLaterInDay() throws {
+        let date = date(year: 1970, month: 1, day: 1, hour: 0, minute: 0)
+        let daystamp = Daystamp(fromDate: date, deadline: OneHourInMinutes)
+        XCTAssertEqual(daystamp.year, 1969)
+        XCTAssertEqual(daystamp.month, 12)
+        XCTAssertEqual(daystamp.day, 31)
+    }
+
+    func testConvertsFromDateWithPositiveDeadlineEarlierInDay() throws {
+        let date = date(year: 1970, month: 1, day: 1, hour: 2, minute: 0)
+        let daystamp = Daystamp(fromDate: date, deadline: OneHourInMinutes)
+        XCTAssertEqual(daystamp.year, 1970)
+        XCTAssertEqual(daystamp.month, 1)
+        XCTAssertEqual(daystamp.day, 1)
+    }
+
+    func testConvertsFromDateWithNegativeDeadlineLaterInDay() throws {
+        let date = date(year: 1970, month: 1, day: 1, hour: 0, minute: 0)
+        let daystamp = Daystamp(fromDate: date, deadline: -OneHourInMinutes)
+        XCTAssertEqual(daystamp.year, 1970)
+        XCTAssertEqual(daystamp.month, 1)
+        XCTAssertEqual(daystamp.day, 1)
+    }
+
+    func testConvertsFromDateWithNegativeDeadlineEarlierInDay() throws {
+        let date = date(year: 1970, month: 1, day: 1, hour: 23, minute: 0)
+        let daystamp = Daystamp(fromDate: date, deadline: -2 * OneHourInMinutes)
+        XCTAssertEqual(daystamp.year, 1970)
+        XCTAssertEqual(daystamp.month, 1)
+        XCTAssertEqual(daystamp.day, 2)
+    }
+
+    func testComparesCorrectly() throws {
+        XCTAssertLessThan(Daystamp(year: 2023, month: 7, day: 11), Daystamp(year: 2023, month: 7, day: 12))
+        XCTAssertLessThan(Daystamp(year: 2023, month: 7, day: 11), Daystamp(year: 2023, month: 8, day: 10))
+        XCTAssertLessThan(Daystamp(year: 2023, month: 7, day: 11), Daystamp(year: 2024, month: 6, day: 10))
+        XCTAssertEqual(Daystamp(year: 2023, month: 7, day: 11), Daystamp(year: 2023, month: 7, day: 11))
+    }
+
+    func testCanAddToDaystamp() throws {
+        XCTAssertEqual(Daystamp(year: 2023, month: 7, day: 11) + 1, Daystamp(year: 2023, month: 7, day: 12))
+        XCTAssertEqual(Daystamp(year: 2023, month: 7, day: 11) + 30, Daystamp(year: 2023, month: 8, day: 10))
+        XCTAssertEqual(Daystamp(year: 2023, month: 7, day: 11) + 365, Daystamp(year: 2024, month: 7, day: 10)) // Leap year!
+    }
+
+    func testCanSubtractFromDaystamp() throws {
+        XCTAssertEqual(Daystamp(year: 2023, month: 7, day: 11) - 1, Daystamp(year: 2023, month: 7, day: 10))
+        XCTAssertEqual(Daystamp(year: 2023, month: 7, day: 11) - 30, Daystamp(year: 2023, month: 6, day: 11))
+        XCTAssertEqual(Daystamp(year: 2023, month: 7, day: 11) - 365, Daystamp(year: 2022, month: 7, day: 11))
+    }
+
+    func testCanCountDaysBetweenDaystamps() throws {
+        XCTAssertEqual(Daystamp(year: 2023, month: 7, day: 12) - Daystamp(year: 2023, month: 7, day: 11), 1)
+        XCTAssertEqual(Daystamp(year: 2023, month: 8, day: 10) - Daystamp(year: 2023, month: 7, day: 11), 30)
+        XCTAssertEqual(Daystamp(year: 2024, month: 6, day: 11) - Daystamp(year: 2023, month: 6, day: 11), 366) // Leap year!
+    }
+
+    func testCanCalculateBoundsForZeroDeadline() throws {
+        XCTAssertEqual(Daystamp(year: 1970, month: 1, day: 1).start(deadline: 0), date(year: 1970, month: 1, day: 1, hour: 0, minute: 0))
+        XCTAssertEqual(Daystamp(year: 1970, month: 1, day: 1).end(deadline: 0), date(year: 1970, month: 1, day: 2, hour: 0, minute: 0))
+    }
+
+    func testCanCalculateBoundsForNegativeDeadline() throws {
+        XCTAssertEqual(Daystamp(year: 1970, month: 1, day: 1).start(deadline: -OneHourInMinutes), date(year: 1969, month: 12, day: 31, hour: 23, minute: 0))
+        XCTAssertEqual(Daystamp(year: 1970, month: 1, day: 1).end(deadline: -OneHourInMinutes), date(year: 1970, month: 1, day: 1, hour: 23, minute: 0))
+    }
+
+    func testCanCalculateBoundsForPositiveDeadline() throws {
+        XCTAssertEqual(Daystamp(year: 1970, month: 1, day: 1).start(deadline: OneHourInMinutes), date(year: 1970, month: 1, day: 1, hour: 1, minute: 0))
+        XCTAssertEqual(Daystamp(year: 1970, month: 1, day: 1).end(deadline: OneHourInMinutes), date(year: 1970, month: 1, day: 2, hour: 1, minute: 0))
+    }
+
+    func date(year: Int, month: Int, day: Int, hour: Int, minute: Int) -> Date {
+        let components = DateComponents(year: year, month: month, day: day, hour: hour, minute: minute)
+        return Calendar.current.date(from: components)!
+    }
+
+    func testCanIterateOverRange() throws {
+        let daystamp = Daystamp(year: 1970, month: 1, day: 1)
+        let range = daystamp...(daystamp + 3)
+        XCTAssertEqual(Array(range), [daystamp, daystamp + 1, daystamp + 2, daystamp + 3])
+    }
+}

--- a/BeeKitTests/DaystampTests.swift
+++ b/BeeKitTests/DaystampTests.swift
@@ -1,11 +1,3 @@
-//
-//  DaystampTests.swift
-//  BeeKitTests
-//
-//  Created by Theo Spears on 7/11/23.
-//  Copyright © 2023 APB. All rights reserved.
-//
-
 import XCTest
 @testable import BeeKit
 

--- a/BeeSwift.xcodeproj/project.pbxproj
+++ b/BeeSwift.xcodeproj/project.pbxproj
@@ -54,6 +54,8 @@
 		E43BEA842A036A9C00FC3A38 /* LogReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = E43BEA832A036A9C00FC3A38 /* LogReader.swift */; };
 		E43BEA862A036D4300FC3A38 /* LogReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E43BEA852A036D4300FC3A38 /* LogReaderTests.swift */; };
 		E43D9AFB2929C37D00FC1578 /* DatapointValueAccessory.swift in Sources */ = {isa = PBXBuildFile; fileRef = E43D9AFA2929C37D00FC1578 /* DatapointValueAccessory.swift */; };
+		E45470282B60E24500EE648B /* Daystamp.swift in Sources */ = {isa = PBXBuildFile; fileRef = E45470272B60E24500EE648B /* Daystamp.swift */; };
+		E454702A2B60E25C00EE648B /* DaystampTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E45470292B60E25C00EE648B /* DaystampTests.swift */; };
 		E457BE5D28C192B50012F5D0 /* IntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = E457BE5C28C192B50012F5D0 /* IntentHandler.swift */; };
 		E458C7F72AD10D68000DCA5C /* BeeKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E57BE6E02655EBD900BA540B /* BeeKit.framework */; };
 		E458C7FC2AD10D6E000DCA5C /* BeeKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E57BE6E02655EBD900BA540B /* BeeKit.framework */; };
@@ -320,6 +322,8 @@
 		E44CE7722993317B00394E87 /* ServiceLocator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceLocator.swift; sourceTree = "<group>"; };
 		E44CE77E2993351100394E87 /* CryptoKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CryptoKit.framework; path = System/Library/Frameworks/CryptoKit.framework; sourceTree = SDKROOT; };
 		E44CE782299338C500394E87 /* GoalManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalManager.swift; sourceTree = "<group>"; };
+		E45470272B60E24500EE648B /* Daystamp.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Daystamp.swift; sourceTree = "<group>"; };
+		E45470292B60E25C00EE648B /* DaystampTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DaystampTests.swift; sourceTree = "<group>"; };
 		E457BE5C28C192B50012F5D0 /* IntentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntentHandler.swift; sourceTree = "<group>"; };
 		E46070EE2B36A4D900305DB4 /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		E46070F72B3FEFD400305DB4 /* BeeminderPersistantContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeeminderPersistantContainer.swift; sourceTree = "<group>"; };
@@ -711,6 +715,7 @@
 				E5DF493624DC69A200260560 /* Config.swift.sample */,
 				E4B0833C293810EB00A71564 /* DataPoint.swift */,
 				E46FF15A2984C522009F8C7A /* DateUtils.swift */,
+				E45470272B60E24500EE648B /* Daystamp.swift */,
 				A1F8F07A232C05410060B83E /* Goal.swift */,
 				E57BE6E32655EBDA00BA540B /* Info.plist */,
 				E44CE7722993317B00394E87 /* ServiceLocator.swift */,
@@ -722,6 +727,7 @@
 			isa = PBXGroup;
 			children = (
 				E57BE6EF2655EBE000BA540B /* BeeKitTests.swift */,
+				E45470292B60E25C00EE648B /* DaystampTests.swift */,
 				E57BE6F12655EBE000BA540B /* Info.plist */,
 			);
 			path = BeeKitTests;
@@ -1188,6 +1194,7 @@
 				E458C8092AD11C13000DCA5C /* SynchronizedBox.swift in Sources */,
 				E458C8102AD11C87000DCA5C /* CategoryHealthKitMetric.swift in Sources */,
 				E458C8192AD11CB0000DCA5C /* StandHoursHealthKitMetric.swift in Sources */,
+				E45470282B60E24500EE648B /* Daystamp.swift in Sources */,
 				E458C8042AD11BC3000DCA5C /* SignedRequestManager.swift in Sources */,
 				E458C8162AD11CA2000DCA5C /* HealthKitError.swift in Sources */,
 				E458C8122AD11C90000DCA5C /* GoalHealthKitConnection.swift in Sources */,
@@ -1226,6 +1233,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E454702A2B60E25C00EE648B /* DaystampTests.swift in Sources */,
 				E4B0A33228C194CA00055EA7 /* AddDataIntents.intentdefinition in Sources */,
 				E57BE6F02655EBE000BA540B /* BeeKitTests.swift in Sources */,
 			);

--- a/BeeSwift.xcodeproj/xcshareddata/xcschemes/BeeKitTests.xcscheme
+++ b/BeeSwift.xcodeproj/xcshareddata/xcschemes/BeeKitTests.xcscheme
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1520"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E57BE6E72655EBDF00BA540B"
+               BuildableName = "BeeKitTests.xctest"
+               BlueprintName = "BeeKitTests"
+               ReferencedContainer = "container:BeeSwift.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
Introduce a new daystamp type to handle the complexity of beeminder daystamps. In particular, this is aware that the conversion of datetimes to daystamps depends on the deadline for the goal, and handles this correctly.

This should allow us to consolidate a large amount of date/time handling code from across the app into a single (tested!) class.

Testing:
Introduced unit tests to exercise the most important behavior
