### PR TITLE
Pin to a specific simulator device and version

### DIFF
--- a/.github/workflows/fastlane-tests.yml
+++ b/.github/workflows/fastlane-tests.yml
@@ -20,7 +20,7 @@ jobs:
         ruby-version: '2.7.2'
         bundler-cache: true
     - name: Run tests
-      run: bundle exec fastlane test
+      run: bundle exec fastlane ci
     - name: Upload report
       uses: actions/upload-artifact@v4
       if: always() # always run even if the previous step fails

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -20,9 +20,20 @@ platform :ios do
     run_tests(
         scheme: "BeeSwift",
         reset_simulator: true,
+        xcodebuild_formatter: "xcpretty",
+    )
+  end
+  lane :ci do
+    sh("xcrun simctl delete all")
+    sh("xcrun simctl create Test-iPhone com.apple.CoreSimulator.SimDeviceType.iPhone-15 com.apple.CoreSimulator.SimRuntime.iOS-17-2")
+    run_tests(
+        scheme: "BeeSwift",
+        reset_simulator: true,
         include_simulator_logs: true,
         buildlog_path: "fastlane/test_output",
         xcodebuild_formatter: "xcpretty",
+        devices: ["Test-iPhone"],
+        ensure_devices_found: true,
     )
   end
   lane :build do


### PR DESCRIPTION
We have been seeing various issues with running UI tests in CI, including timeouts and issues with accessibility settings.

Various users online have seen success with particular configurations, especially using XCode 15.1 and using simulator with iOS 17.2. [1] Update fastlane to configure and use an appropriate simulator version in CI. 

[1] https://github.com/actions/runner-images/issues/7508#issuecomment-1880780025

Testing:
Will look at how the testing on this PR performas.
