### PR TITLE
Updating Pull Requests should cancel previous runs

### DIFF
--- a/.github/workflows/fastlane-tests.yml
+++ b/.github/workflows/fastlane-tests.yml
@@ -3,6 +3,10 @@ name: Fastlane Tests
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: macos-13


### PR DESCRIPTION
When iterating on PRs sometimes we queue up a large number of test runs. We only really care about the last of these, so arrange for later runs to cancel any run in progress using the technique outlined in https://stackoverflow.com/a/72408109
