### PR TITLE
Use the daystamp type for tracking daystamps

### DIFF
--- a/BeeKit/DataPoint.swift
+++ b/BeeKit/DataPoint.swift
@@ -5,7 +5,7 @@ import SwiftyJSON
 
 public protocol DataPoint {
     var requestid: String { get }
-    var daystamp: String { get }
+    var daystamp: Daystamp { get }
     var value: NSNumber { get }
     var comment: String { get }
 }
@@ -14,29 +14,29 @@ public protocol DataPoint {
 public struct ExistingDataPoint : DataPoint {
     public let id: String
     public let requestid: String
-    public let daystamp: String
+    public let daystamp: Daystamp
     public let value: NSNumber
     public let comment: String
 
-    init(json: JSON) {
+    init(json: JSON) throws {
         // To maximize compatibility with server changes we only parse fields
         // which are actually used, not all that exist
         id = json["id"]["$oid"].string ?? json["id"].stringValue
-        daystamp = json["daystamp"].stringValue
+        daystamp = try Daystamp(fromString: json["daystamp"].stringValue)
         value = json["value"].numberValue
         comment = json["comment"].stringValue
         requestid = json["requestid"].stringValue
     }
 
-    static func fromJSONArray(array: [JSON]) -> [ExistingDataPoint] {
-        return array.map { ExistingDataPoint(json: $0) }
+    static func fromJSONArray(array: [JSON]) throws -> [ExistingDataPoint] {
+        return try array.map { try ExistingDataPoint(json: $0) }
     }
 }
 
 /// A data point we have created locally (e.g. from user input, or HealthKit)
 public struct NewDataPoint : DataPoint {
     public let requestid: String
-    public let daystamp: String
+    public let daystamp: Daystamp
     public let value: NSNumber
     public let comment: String
 }

--- a/BeeKit/HeathKit/CategoryHealthKitMetric.swift
+++ b/BeeKit/HeathKit/CategoryHealthKitMetric.swift
@@ -67,7 +67,7 @@ class CategoryHealthKitMetric : HealthKitMetric {
 
         let id = "apple-heath-" + daystamp
         let datapointValue = self.hkDatapointValueForSamples(samples: samples, startOfDate: bounds.start)
-        return NewDataPoint(requestid: id, daystamp: daystamp, value: NSNumber(value: datapointValue), comment: "Auto-entered via Apple Health")
+        return NewDataPoint(requestid: id, daystamp: try Daystamp(fromString: daystamp), value: NSNumber(value: datapointValue), comment: "Auto-entered via Apple Health")
     }
 
     internal func dayStampFromDayOffset(dayOffset : Int, deadline : Int) throws -> String {

--- a/BeeKit/HeathKit/QuantityHealthKitMetric.swift
+++ b/BeeKit/HeathKit/QuantityHealthKitMetric.swift
@@ -149,7 +149,7 @@ class QuantityHealthKitMetric : HealthKitMetric {
             let daystamp = formatter.string(from: datapointDate)
 
             let id = "apple-health-" + daystamp
-            results.append(NewDataPoint(requestid: id, daystamp: daystamp, value: NSNumber(value: datapointValue), comment: "Auto-entered via Apple Health"))
+            results.append(NewDataPoint(requestid: id, daystamp: try Daystamp(fromString: daystamp), value: NSNumber(value: datapointValue), comment: "Auto-entered via Apple Health"))
         }
 
         return results

--- a/BeeSwift/Components/DatapointTableViewController.swift
+++ b/BeeSwift/Components/DatapointTableViewController.swift
@@ -84,8 +84,7 @@ class DatapointTableViewController : UIViewController, UITableViewDelegate, UITa
     }
 
     func displayText(datapoint: DataPoint) -> String {
-        let daystamp = Int(datapoint.daystamp) ?? 0
-        let day = daystamp != 0 ? String(format: "%02d", daystamp % 100) : "??" // Day is two least significant digits of daystamp
+        let day = datapoint.daystamp.day
 
         var formattedValue: String
         if hhmmformat {

--- a/BeeSwift/EditDatapointViewController.swift
+++ b/BeeSwift/EditDatapointViewController.swift
@@ -65,7 +65,7 @@ class EditDatapointViewController: UIViewController, UITextFieldDelegate {
         let daystamp = self.datapoint.daystamp
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyyMMdd"
-        self.datePicker.date = dateFormatter.date(from: daystamp)!
+        self.datePicker.date = dateFormatter.date(from: daystamp.description)!
 
         self.datePicker.snp.makeConstraints { (make) in
             make.left.right.equalTo(formView).inset(10)


### PR DESCRIPTION
This updates the codebase to make usage of the daystamp type introduced in #430. Not all potential usages are updated, but most of those around Goal and Datapoint and surrounding code.

Testing:
* Verified I could launch the app and view data
* Verify that editing datapoints manually worked correctly
* Spot checked a few Apple Health metrics still looked right
