### PR TITLE
Fix off-by-one error in Daystamp logic

### DIFF
--- a/BeeKit/Daystamp.swift
+++ b/BeeKit/Daystamp.swift
@@ -49,7 +49,7 @@ public struct Daystamp: CustomStringConvertible, Strideable, Comparable, Equatab
 
         let dayOffsetFromDeadline = if deadline < 0 {
             // This is an early deadline. If the time is after the deadline we need to instead consider it the next day
-            if secondsAfterMidnight > Daystamp.secondsInDay + deadline {
+            if secondsAfterMidnight >= Daystamp.secondsInDay + deadline {
                 1
             } else {
                 0

--- a/BeeKitTests/DaystampTests.swift
+++ b/BeeKitTests/DaystampTests.swift
@@ -58,6 +58,20 @@ final class DaystampTests: XCTestCase {
         XCTAssertEqual(daystamp.day, 2)
     }
 
+    func testConvertsFromDateAtStartOfNegativeDaystamp() throws {
+        // Ensure there is not an off-by one error when importing values right on the datestamp boundary
+        let date = date(year: 1970, month: 1, day: 1, hour: 23, minute: 0)
+        let daystamp = Daystamp(fromDate: date, deadline: -OneHourInSeconds)
+        XCTAssertEqual(daystamp, Daystamp(year: 1970, month: 1, day: 2))
+    }
+
+    func testConvertsFromDateAtStartOfPositiveDaystamp() throws {
+        // Ensure there is not an off-by one error when importing values right on the datestamp boundary
+        let date = date(year: 1970, month: 1, day: 1, hour: 1, minute: 0)
+        let daystamp = Daystamp(fromDate: date, deadline: OneHourInSeconds)
+        XCTAssertEqual(daystamp, Daystamp(year: 1970, month: 1, day: 1))
+    }
+
     func testComparesCorrectly() throws {
         XCTAssertLessThan(Daystamp(year: 2023, month: 7, day: 11), Daystamp(year: 2023, month: 7, day: 12))
         XCTAssertLessThan(Daystamp(year: 2023, month: 7, day: 11), Daystamp(year: 2023, month: 8, day: 10))


### PR DESCRIPTION
Previously the daystamp logic was treating events which fell exactly on the cut-off point as being part of the previous day. In fact they should be treated as part of the next day. This lead to Apple Health metrics being attributed to the wrong day.

Testing:
* Wrote unit test for this case
* With a stacked PR verified that healthkit metrics report correctly
