### PR TITLE
Correctly clear Apple Health Integration

### DIFF
--- a/BeeKit/Managers/RequestManager.swift
+++ b/BeeKit/Managers/RequestManager.swift
@@ -30,7 +30,8 @@ public class RequestManager {
     private let logger = Logger(subsystem: "com.beeminder.beeminder", category: "RequestManager")
     
     func rawRequest(url: String, method: HTTPMethod, parameters: [String: Any]?) async throws -> Any? {
-        let response = await AF.request("\(baseURLString)/\(url)", method: method, parameters: parameters, encoding: URLEncoding.default, headers: HTTPHeaders.default)
+        let encoding: ParameterEncoding = if method == .get { URLEncoding.default } else { JSONEncoding.default }
+        let response = await AF.request("\(baseURLString)/\(url)", method: method, parameters: parameters, encoding: encoding, headers: HTTPHeaders.default)
             .validate()
             .serializingData(emptyRequestMethods: [HTTPMethod.post])
             .response

--- a/BeeSwift/Settings/RemoveHKMetricViewController.swift
+++ b/BeeSwift/Settings/RemoveHKMetricViewController.swift
@@ -69,7 +69,7 @@ class RemoveHKMetricViewController: UIViewController {
     @objc func removeButtonPressed() {
         guard self.goal != nil else { return }
         self.goal?.autodata = ""
-        let params: [String: [String: String]] = ["ii_params": ["name": "", "metric": ""]]
+        let params: [String: [String: String?]] = ["ii_params": ["name": nil, "metric": nil]]
         let hud = MBProgressHUD.showAdded(to: self.view, animated: true)
         hud.mode = .indeterminate
 

--- a/BeeSwift/Settings/RemoveHKMetricViewController.swift
+++ b/BeeSwift/Settings/RemoveHKMetricViewController.swift
@@ -69,7 +69,7 @@ class RemoveHKMetricViewController: UIViewController {
     @objc func removeButtonPressed() {
         guard self.goal != nil else { return }
         self.goal?.autodata = ""
-        let params: [String: [String: String?]] = ["ii_params": ["name": nil, "metric": nil]]
+        let params: [String: [String: String?]] = ["ii_params": ["name": nil, "metric": ""]]
         let hud = MBProgressHUD.showAdded(to: self.view, animated: true)
         hud.mode = .indeterminate
 


### PR DESCRIPTION
Previously when attempting to disconnect Apple Health goals they would enter a state where they no longer updated, but beeminder.com still considered them autodata, and thus e.g. changing the deadline was forbidden. This was because we were setting the autodata name to an empty string, rather than null. Sending null was not supported via the URL encoding schema the app was using, so switch to sending parameters as JSON instead and send nil.

Fixes #248
