### PR TITLE
Limit precise of some Apple Health metrics

### DIFF
--- a/BeeKit/HeathKit/HealthKitConfig.swift
+++ b/BeeKit/HeathKit/HealthKitConfig.swift
@@ -29,7 +29,7 @@ public class HealthKitConfig : NSObject {
             WorkoutMinutesHealthKitMetric.init(humanText: "Workout minutes", databaseString: "workoutMinutes", category: .Activity),
 
             // Body Measurements
-            QuantityHealthKitMetric.init(humanText: "Weight", databaseString: "weight", category: .BodyMeasurements, hkQuantityTypeIdentifier: .bodyMass),
+            QuantityHealthKitMetric.init(humanText: "Weight", databaseString: "weight", category: .BodyMeasurements, hkQuantityTypeIdentifier: .bodyMass, precision: [HKUnit.pound(): 1, HKUnit.gramUnit(with: .kilo): 1]),
 
             // Heart
 

--- a/BeeKit/HeathKit/HealthKitConfig.swift
+++ b/BeeKit/HeathKit/HealthKitConfig.swift
@@ -16,11 +16,11 @@ public class HealthKitConfig : NSObject {
     public let metrics : [HealthKitMetric] = {
         var allMetrics : [HealthKitMetric] = [
             // Activity
-            QuantityHealthKitMetric.init(humanText: "Active energy", databaseString: "activeEnergy", category: .Activity, hkQuantityTypeIdentifier: .activeEnergyBurned),
+            QuantityHealthKitMetric.init(humanText: "Active energy", databaseString: "activeEnergy", category: .Activity, hkQuantityTypeIdentifier: .activeEnergyBurned, precision: [HKUnit.largeCalorie(): 0]),
             QuantityHealthKitMetric.init(humanText: "Cycling distance", databaseString: "cyclingDistance", category: .Activity, hkQuantityTypeIdentifier: .distanceCycling),
             QuantityHealthKitMetric.init(humanText: "Exercise time", databaseString: "exerciseTime", category: .Activity, hkQuantityTypeIdentifier: .appleExerciseTime),
             QuantityHealthKitMetric.init(humanText: "Nike Fuel", databaseString: "nikeFuel", category: .Activity, hkQuantityTypeIdentifier: .nikeFuel),
-            QuantityHealthKitMetric.init(humanText: "Resting energy", databaseString: "basalEnergy", category: .Activity, hkQuantityTypeIdentifier: .basalEnergyBurned),
+            QuantityHealthKitMetric.init(humanText: "Resting energy", databaseString: "basalEnergy", category: .Activity, hkQuantityTypeIdentifier: .basalEnergyBurned, precision: [HKUnit.largeCalorie(): 0]),
             StandHoursHealthKitMetric.init(humanText: "Stand hours", databaseString: "standHour", category: .Activity),
             QuantityHealthKitMetric.init(humanText: "Steps", databaseString: "steps", category: .Activity, hkQuantityTypeIdentifier: .stepCount, precision: [HKUnit.count(): 0]),
             QuantityHealthKitMetric.init(humanText: "Swimming distance", databaseString: "swimDistance", category: .Activity, hkQuantityTypeIdentifier: .distanceSwimming),

--- a/BeeKit/HeathKit/HealthKitConfig.swift
+++ b/BeeKit/HeathKit/HealthKitConfig.swift
@@ -22,7 +22,7 @@ public class HealthKitConfig : NSObject {
             QuantityHealthKitMetric.init(humanText: "Nike Fuel", databaseString: "nikeFuel", category: .Activity, hkQuantityTypeIdentifier: .nikeFuel),
             QuantityHealthKitMetric.init(humanText: "Resting energy", databaseString: "basalEnergy", category: .Activity, hkQuantityTypeIdentifier: .basalEnergyBurned),
             StandHoursHealthKitMetric.init(humanText: "Stand hours", databaseString: "standHour", category: .Activity),
-            QuantityHealthKitMetric.init(humanText: "Steps", databaseString: "steps", category: .Activity, hkQuantityTypeIdentifier: .stepCount),
+            QuantityHealthKitMetric.init(humanText: "Steps", databaseString: "steps", category: .Activity, hkQuantityTypeIdentifier: .stepCount, precision: [HKUnit.count(): 0]),
             QuantityHealthKitMetric.init(humanText: "Swimming distance", databaseString: "swimDistance", category: .Activity, hkQuantityTypeIdentifier: .distanceSwimming),
             QuantityHealthKitMetric.init(humanText: "Swimming strokes", databaseString: "swimStrokes", category: .Activity, hkQuantityTypeIdentifier: .swimmingStrokeCount),
             QuantityHealthKitMetric.init(humanText: "Walking/running distance", databaseString: "walkRunDistance", category: .Activity, hkQuantityTypeIdentifier: .distanceWalkingRunning),

--- a/BeeKit/HeathKit/HealthKitConfig.swift
+++ b/BeeKit/HeathKit/HealthKitConfig.swift
@@ -29,7 +29,7 @@ public class HealthKitConfig : NSObject {
             WorkoutMinutesHealthKitMetric.init(humanText: "Workout minutes", databaseString: "workoutMinutes", category: .Activity),
 
             // Body Measurements
-            QuantityHealthKitMetric.init(humanText: "Weight", databaseString: "weight", category: .BodyMeasurements, hkQuantityTypeIdentifier: .bodyMass, precision: [HKUnit.pound(): 1, HKUnit.gramUnit(with: .kilo): 1]),
+            QuantityHealthKitMetric.init(humanText: "Weight", databaseString: "weight", category: .BodyMeasurements, hkQuantityTypeIdentifier: .bodyMass, precision: [HKUnit.pound(): 1, HKUnit.gramUnit(with: .kilo): 2]),
 
             // Heart
 

--- a/BeeKit/HeathKit/QuantityHealthKitMetric.swift
+++ b/BeeKit/HeathKit/QuantityHealthKitMetric.swift
@@ -15,12 +15,14 @@ class QuantityHealthKitMetric : HealthKitMetric {
     let databaseString : String
     let category : HealthKitCategory
     let hkQuantityTypeIdentifier : HKQuantityTypeIdentifier
+    let precision: [HKUnit: Int]
 
-    internal init(humanText: String, databaseString: String, category : HealthKitCategory, hkQuantityTypeIdentifier: HKQuantityTypeIdentifier) {
+    internal init(humanText: String, databaseString: String, category : HealthKitCategory, hkQuantityTypeIdentifier: HKQuantityTypeIdentifier, precision: [HKUnit: Int] = [:]) {
         self.humanText = humanText
         self.databaseString = databaseString
         self.category = category
         self.hkQuantityTypeIdentifier = hkQuantityTypeIdentifier
+        self.precision = precision
     }
 
     func sampleType() -> HKSampleType {
@@ -109,9 +111,14 @@ class QuantityHealthKitMetric : HealthKitMetric {
                 }
             }()
 
-            guard let datapointValue = value else {
+            guard var datapointValue = value else {
                 logger.error("updateBeeminderWithStatsCollection(\(self.databaseString, privacy: .public)): No datapoint value")
                 continue
+            }
+
+            if let unitPrecision = precision[unit] {
+                let roundingFactor = pow(10.0, Double(unitPrecision))
+                datapointValue = round(datapointValue * roundingFactor) / roundingFactor
             }
 
             let id = "apple-health-" + daystamp.description


### PR DESCRIPTION
BeeSwift just reports apple health metrics at the same precision as they are provided by HealthKit. This can lead to a silly amount of precision, e.g. 6+ decimal points for steps. Here we introduce a mechanism to limit precision, and use it for a few experimental metrics.

Testing:
Ran on device and checked metric values reported appropriately.