### PR TITLE
Fix context errors when updating User model

### DIFF
--- a/BeeKit/Managers/CurrentUserManager.swift
+++ b/BeeKit/Managers/CurrentUserManager.swift
@@ -106,11 +106,11 @@ public class CurrentUserManager {
     }
 
 
-    private func user() -> User? {
+    private func user(context: NSManagedObjectContext? = nil) -> User? {
         // Fetch a user from the persistent store
         let request = NSFetchRequest<User>(entityName: "User")
         // TODO: Handle (or at least log) an error here
-        let users = try? container.viewContext.fetch(request)
+        let users = try? (context ?? container.viewContext).fetch(request)
         return users?.first
     }
 
@@ -118,7 +118,7 @@ public class CurrentUserManager {
         let context = container.newBackgroundContext()
 
         // Delete any existing users. We expect at most one, but delete all to be safe.
-        while let user = self.user() {
+        while let user = self.user(context: context) {
             context.delete(user)
         }
         try context.save()

--- a/BeeKit/Managers/CurrentUserManager.swift
+++ b/BeeKit/Managers/CurrentUserManager.swift
@@ -154,8 +154,6 @@ public class CurrentUserManager {
         return user()?.username
     }
     
-    public var signingUp : Bool = false
-    
     public func defaultLeadTime() -> NSNumber {
         return (user()?.defaultLeadTime ?? 0) as NSNumber
     }
@@ -282,5 +280,4 @@ public class CurrentUserManager {
             NotificationCenter.default.post(name: Notification.Name(rawValue: CurrentUserManager.signedOutNotificationName), object: self)
         }.value
     }
-    
 }

--- a/BeeSwift/SignInViewController.swift
+++ b/BeeSwift/SignInViewController.swift
@@ -174,7 +174,6 @@ class SignInViewController : UIViewController, UITextFieldDelegate, SFSafariView
     }
     
     @objc func chooseSignInButtonPressed() {
-        ServiceLocator.currentUserManager.signingUp = false
         //self.divider.isHidden = false
         //self.backToSignUpButton.isHidden = false
         self.emailTextField.isHidden = false


### PR DESCRIPTION
The first attempt at using CoreData for the user had a number of issues around incorrectly handling context. In particular:
* User objects were fetched and deleted in different contexts, leading to a crash on logout
* Many changes were never saved

Be more thoughtful about passing around contexts to avoid this issue.

Testing:
Ran app on simulator and verified I could log out
