### PR TITLE
Update HealthKit on app launch

### DIFF
--- a/BeeSwift/AppDelegate.swift
+++ b/BeeSwift/AppDelegate.swift
@@ -146,6 +146,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     private func refreshGoalsAndLogErrors() {
         Task { @MainActor in
             do {
+                let _ = try await ServiceLocator.healthStoreManager.updateAllGoalsWithRecentData(days: 7)
+            } catch {
+                logger.error("Error updating from healthkit: \(error)")
+            }
+            do {
                 let _ = try await ServiceLocator.goalManager.fetchGoals()
             } catch {
                 logger.error("Error refreshing goals: \(error)")


### PR DESCRIPTION
Always update health metrics from apple before syncing with the server, for example on app launch. Because beeminder often update goals async, this doesn't guarantee that we will always show correct data reflecting the latest healthkit data, but should increase the chance. As the app polls for goals which are recalculating it means it should also show the correct data shortly after loading.

This might help a little with perceived Apple Health unreliabilty.

Testing:
Launched the app on a real device and observed data
