### PR TITLE
Ignore metadata when suggesting next value

### DIFF
--- a/BeeKit/Goal.swift
+++ b/BeeKit/Goal.swift
@@ -317,6 +317,12 @@ public class Goal {
         return self.autodata == "apple"
     }
 
+    /// A hint for the value the user is likely to enter, based on past data points
+    public var suggestedNextValue: NSNumber? {
+        guard let recentData = self.recent_data else { return nil }
+        return recentData.last?.value
+    }
+
     /// The daystamp corresponding to the day of the goal's creation, thus the first day we should add data points for.
     var initDaystamp: Daystamp {
         let initDate = Date(timeIntervalSince1970: self.initday!.doubleValue)

--- a/BeeKit/Goal.swift
+++ b/BeeKit/Goal.swift
@@ -320,7 +320,15 @@ public class Goal {
     /// A hint for the value the user is likely to enter, based on past data points
     public var suggestedNextValue: NSNumber? {
         guard let recentData = self.recent_data else { return nil }
-        return recentData.last?.value
+        for dataPoint in recentData.reversed() {
+            let comment = dataPoint.comment
+            // Ignore data points with comments suggesting they aren't a real value
+            if comment.contains("#DERAIL") || comment.contains("#SELFDESTRUCT") || comment.contains("#RESTART") || comment.contains("#TARE") {
+                continue
+            }
+            return dataPoint.value
+        }
+        return nil
     }
 
     /// The daystamp corresponding to the day of the goal's creation, thus the first day we should add data points for.

--- a/BeeSwift/GoalViewController.swift
+++ b/BeeSwift/GoalViewController.swift
@@ -431,8 +431,8 @@ class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTabl
     }
 
     func setValueTextField() {
-        if let lastDatapoint = self.goal!.recent_data?.last {
-            self.valueTextField.text = "\(String(describing: lastDatapoint.value))"
+        if let suggestedNextValue = goal.suggestedNextValue {
+            self.valueTextField.text = "\(String(describing: suggestedNextValue))"
         }
     }
 

--- a/BeeSwiftTests/GoalTests.swift
+++ b/BeeSwiftTests/GoalTests.swift
@@ -177,4 +177,65 @@ final class GoalTests: XCTestCase {
         XCTAssertEqual(goal.derived_rate, 0)
     }
 
+    func testSuggestedNextValueBasedOnLastValue() throws {
+        var testJSON = requiredGoalJson()
+        testJSON["recent_data"] = [
+            ["value": 1, "daystamp": "20221130"],
+            ["value": 2, "daystamp": "20221126"],
+            ["value": 3.5, "daystamp": "20221125"],
+        ]
+        let goal = Goal(json: testJSON)
+
+        XCTAssertEqual(goal.suggestedNextValue, 1)
+    }
+
+    func testSuggestedNextValueEmptyIfNoData() throws {
+        var testJSON = requiredGoalJson()
+        testJSON["recent_data"] = []
+        let goal = Goal(json: testJSON)
+
+        XCTAssertEqual(goal.suggestedNextValue, nil)
+    }
+
+    func testSuggestedNextValueIgnoresDerailsAndSelfDestructs() throws {
+        var testJSON = requiredGoalJson()
+        testJSON["recent_data"] = [
+            ["value": 0, "daystamp": "20221131", "comment": "Goal #RESTART Point"],
+            ["value": 0, "daystamp": "20221131", "comment": "This will #SELFDESTRUCT"],
+            ["value": 0, "daystamp": "20221130", "comment": "#DERAIL ON THE 1st"],
+            ["value": 2, "daystamp": "20221126"],
+            ["value": 3.5, "daystamp": "20221125"],
+        ]
+        let goal = Goal(json: testJSON)
+
+        XCTAssertEqual(goal.suggestedNextValue, 2)
+    }
+
+    /// Return the minimum set of required attributes for creating a goal
+    func requiredGoalJson() -> JSON {
+        return JSON(parseJSON: """
+        {
+            "id": "737aaa34f0118a330852e4bd",
+            "title": "Goal for Testing Purposes",
+            "slug": "test-goal",
+            "initday": 1668963600,
+            "deadline": 0,
+            "leadtime": 0,
+            "alertstart": 34200,
+            "queued": false,
+            "losedate": 2000271599,
+            "runits": "d",
+            "yaxis": "cumulative total test-goal",
+            "won": false,
+            "yaw": 1,
+            "lane": 3582,
+            "dir": 1,
+            "use_defaults": true,
+            "pledge": 0,
+            "hhmmformat": false,
+            "todayta": false
+        }
+        """)
+
+    }
 }


### PR DESCRIPTION
When choosing the default value to suggest for a new data point, the app looks at recent data points. Previously it would always choose the most recent value, but this was not useful if the most recent value was e.g. a derailment, or a pessimistic presumptive data point. Change the logic to now ignore these points when finding a value.

Testing:
Manually checked in the app with a goal with relevant data point
Wrote unit tests to extercise the various cases
