### PR TITLE
Goal view only sets suggested value once on load

### DIFF
--- a/BeeSwift/GoalViewController.swift
+++ b/BeeSwift/GoalViewController.swift
@@ -304,6 +304,7 @@ class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTabl
 
         NotificationCenter.default.addObserver(self, selector: #selector(onGoalsUpdatedNotification), name: NSNotification.Name(rawValue: GoalManager.goalsUpdatedNotificationName), object: nil)
 
+        setValueTextField()
         updateInterfaceToMatchGoal()
     }
 
@@ -431,9 +432,9 @@ class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTabl
     }
 
     func setValueTextField() {
-        if let suggestedNextValue = goal.suggestedNextValue {
-            self.valueTextField.text = "\(String(describing: suggestedNextValue))"
-        }
+        let suggestedNextValue = goal.suggestedNextValue ?? 1
+        valueTextField.text = "\(String(describing: suggestedNextValue))"
+        valueTextFieldValueChanged()
     }
 
     @objc func valueStepperValueChanged() {
@@ -543,8 +544,6 @@ class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTabl
         }
 
         self.refreshCountdown()
-        self.setValueTextField()
-        self.valueTextFieldValueChanged()
         self.deltasLabel.attributedText = self.goal!.attributedDeltaText
         if (!self.goal.queued!) {
             self.setGraphImage()


### PR DESCRIPTION
The goal screen tries to suggest a value based on recent past data.

In the past, this suggestion was updated every time the goal was updated/refreshed (as this might fetch new data). This lead to the user-selected value being overridden at annoying times, for example when navigating away from and returning to the app. Now instead we only set it once at load time. This might lead to stale values e.g. if goal data is out of date, but seems better than the previous behavior.

Testing:
Overrode the value, and checked pull to refresh did not change it
Checked switching away from the app and back did not change the value
Checked going back to the gallery and then back to the goal reset the value
