### PR TITLE
Dismiss the edit datapoint dialog after making a change

### DIFF
--- a/BeeSwift/EditDatapointViewController.swift
+++ b/BeeSwift/EditDatapointViewController.swift
@@ -238,9 +238,10 @@ class EditDatapointViewController: UIViewController, UITextFieldDelegate {
                 let hud = MBProgressHUD.forView(self.view)
                 hud?.mode = .customView
                 hud?.customView = UIImageView(image: UIImage(named: "BasicCheckmark"))
-                hud?.hide(animated: true, afterDelay: 2)
-                DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-                    self.navigationController?.popViewController(animated: true)
+                hud?.hide(animated: true, afterDelay: 0.5)
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                    self.logger.info("Dismissing popup")
+                    self.navigationController?.dismiss(animated: true)
                 }
             } catch {
                 logger.error("Error deleting datapoint for goal \(self.goal.slug): \(error)")

--- a/BeeSwift/EditDatapointViewController.swift
+++ b/BeeSwift/EditDatapointViewController.swift
@@ -19,13 +19,13 @@ class EditDatapointViewController: UIViewController, UITextFieldDelegate {
     private let margin = 10
     
     var datapoint : ExistingDataPoint
-    var goalSlug : String
+    var goal : Goal!
     fileprivate var datePicker = InlineDatePicker()
     fileprivate var valueField = UITextField()
     fileprivate var commentField = UITextField()
 
-    init(goalSlug: String, datapoint: ExistingDataPoint) {
-        self.goalSlug = goalSlug
+    init(goal: Goal, datapoint: ExistingDataPoint) {
+        self.goal = goal
         self.datapoint = datapoint
         super.init(nibName: nil, bundle: nil)
     }
@@ -212,13 +212,13 @@ class EditDatapointViewController: UIViewController, UITextFieldDelegate {
                 let params = [
                     "urtext": self.urtext()
                 ]
-                let _ = try await ServiceLocator.requestManager.put(url: "api/v1/users/\(ServiceLocator.currentUserManager.username!)/goals/\(self.goalSlug)/datapoints/\(self.datapoint.id).json", parameters: params)
+                let _ = try await ServiceLocator.requestManager.put(url: "api/v1/users/\(ServiceLocator.currentUserManager.username!)/goals/\(self.goal.slug)/datapoints/\(self.datapoint.id).json", parameters: params)
                 let hud = MBProgressHUD.forView(self.view)
                 hud?.mode = .customView
                 hud?.customView = UIImageView(image: UIImage(named: "BasicCheckmark"))
                 hud?.hide(animated: true, afterDelay: 2)
             } catch {
-                logger.error("Error updating datapoint for goal \(self.goalSlug): \(error)")
+                logger.error("Error updating datapoint for goal \(self.goal.slug): \(error)")
                 let _ = MBProgressHUD.hide(for: self.view, animated: true)
             }
         }
@@ -230,7 +230,7 @@ class EditDatapointViewController: UIViewController, UITextFieldDelegate {
             hud.mode = .indeterminate
 
             do {
-                let _ = try await ServiceLocator.requestManager.delete(url: "api/v1/users/\(ServiceLocator.currentUserManager.username!)/goals/\(self.goalSlug)/datapoints/\(self.datapoint.id).json", parameters: nil)
+                let _ = try await ServiceLocator.requestManager.delete(url: "api/v1/users/\(ServiceLocator.currentUserManager.username!)/goals/\(self.goal.slug)/datapoints/\(self.datapoint.id).json", parameters: nil)
 
                 let hud = MBProgressHUD.forView(self.view)
                 hud?.mode = .customView
@@ -240,7 +240,7 @@ class EditDatapointViewController: UIViewController, UITextFieldDelegate {
                     self.navigationController?.popViewController(animated: true)
                 }
             } catch {
-                logger.error("Error deleting datapoint for goal \(self.goalSlug): \(error)")
+                logger.error("Error deleting datapoint for goal \(self.goal.slug): \(error)")
 
             }
         }

--- a/BeeSwift/EditDatapointViewController.swift
+++ b/BeeSwift/EditDatapointViewController.swift
@@ -213,6 +213,8 @@ class EditDatapointViewController: UIViewController, UITextFieldDelegate {
                     "urtext": self.urtext()
                 ]
                 let _ = try await ServiceLocator.requestManager.put(url: "api/v1/users/\(ServiceLocator.currentUserManager.username!)/goals/\(self.goal.slug)/datapoints/\(self.datapoint.id).json", parameters: params)
+                try await ServiceLocator.goalManager.refreshGoal(self.goal)
+
                 let hud = MBProgressHUD.forView(self.view)
                 hud?.mode = .customView
                 hud?.customView = UIImageView(image: UIImage(named: "BasicCheckmark"))
@@ -231,6 +233,7 @@ class EditDatapointViewController: UIViewController, UITextFieldDelegate {
 
             do {
                 let _ = try await ServiceLocator.requestManager.delete(url: "api/v1/users/\(ServiceLocator.currentUserManager.username!)/goals/\(self.goal.slug)/datapoints/\(self.datapoint.id).json", parameters: nil)
+                try await ServiceLocator.goalManager.refreshGoal(self.goal)
 
                 let hud = MBProgressHUD.forView(self.view)
                 hud?.mode = .customView

--- a/BeeSwift/EditDatapointViewController.swift
+++ b/BeeSwift/EditDatapointViewController.swift
@@ -215,13 +215,15 @@ class EditDatapointViewController: UIViewController, UITextFieldDelegate {
                 let _ = try await ServiceLocator.requestManager.put(url: "api/v1/users/\(ServiceLocator.currentUserManager.username!)/goals/\(self.goal.slug)/datapoints/\(self.datapoint.id).json", parameters: params)
                 try await ServiceLocator.goalManager.refreshGoal(self.goal)
 
-                let hud = MBProgressHUD.forView(self.view)
-                hud?.mode = .customView
-                hud?.customView = UIImageView(image: UIImage(named: "BasicCheckmark"))
-                hud?.hide(animated: true, afterDelay: 2)
+                hud.mode = .customView
+                hud.customView = UIImageView(image: UIImage(named: "BasicCheckmark"))
+                hud.hide(animated: true, afterDelay: 0.5)
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                    self.navigationController?.dismiss(animated: true)
+                }
             } catch {
                 logger.error("Error updating datapoint for goal \(self.goal.slug): \(error)")
-                let _ = MBProgressHUD.hide(for: self.view, animated: true)
+                hud.hide(animated: false)
             }
         }
     }
@@ -235,17 +237,15 @@ class EditDatapointViewController: UIViewController, UITextFieldDelegate {
                 let _ = try await ServiceLocator.requestManager.delete(url: "api/v1/users/\(ServiceLocator.currentUserManager.username!)/goals/\(self.goal.slug)/datapoints/\(self.datapoint.id).json", parameters: nil)
                 try await ServiceLocator.goalManager.refreshGoal(self.goal)
 
-                let hud = MBProgressHUD.forView(self.view)
-                hud?.mode = .customView
-                hud?.customView = UIImageView(image: UIImage(named: "BasicCheckmark"))
-                hud?.hide(animated: true, afterDelay: 0.5)
+                hud.mode = .customView
+                hud.customView = UIImageView(image: UIImage(named: "BasicCheckmark"))
+                hud.hide(animated: true, afterDelay: 0.5)
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                    self.logger.info("Dismissing popup")
                     self.navigationController?.dismiss(animated: true)
                 }
             } catch {
                 logger.error("Error deleting datapoint for goal \(self.goal.slug): \(error)")
-
+                hud.hide(animated: false)
             }
         }
     }

--- a/BeeSwift/GoalViewController.swift
+++ b/BeeSwift/GoalViewController.swift
@@ -401,7 +401,7 @@ class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTabl
         guard !self.goal.hideDataEntry() else { return }
         guard let existingDatapoint = datapoint as? ExistingDataPoint else { return }
 
-        let editDatapointViewController = EditDatapointViewController(goalSlug: goal.slug, datapoint: existingDatapoint)
+        let editDatapointViewController = EditDatapointViewController(goal: goal, datapoint: existingDatapoint)
         let navigationController = UINavigationController(rootViewController: editDatapointViewController)
         navigationController.modalPresentationStyle = .formSheet
         self.present(navigationController, animated: true, completion: nil)


### PR DESCRIPTION
Previously after updating or deleting a data point the dialog would just stay on the screen, until the user manually dismissed it. This was in part because otherwise after dismissing it would look like the user's change hadn't applied. The situation is better now because we show the lemniscate while there are pending goal updates.

Update the behavior to refresh goals after making a change, and then after the initial request (though likely with queuing) we will dismiss the dialog.

Testing:
Updated a data point and observed the goal refreshed and the dialog hid
Same for deleting a data point
