### PR TITLE
Refreshing gaols should only trigger a graph refresh for autodata goals

### DIFF
--- a/BeeSwift/GoalViewController.swift
+++ b/BeeSwift/GoalViewController.swift
@@ -373,7 +373,9 @@ class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTabl
             do {
                 if self.goal.isLinkedToHealthKit {
                     try await ServiceLocator.healthStoreManager.updateWithRecentData(goal: self.goal, days: 7)
-                } else {
+                } else if goal.isDataProvidedAutomatically {
+                    // Don't force a refresh for manual goals. While doing so is harmless, it queues the goal which means we show a
+                    // lemniscate for a few seconds, making the refresh slower.
                     try await ServiceLocator.goalManager.forceAutodataRefresh(self.goal)
                 }
                 try await self.updateGoalAndInterface()


### PR DESCRIPTION
Previously we would trigger a graph refresh on reload for all goals. This wans't a big deal in the past because the UI didn't differentiate that state, but now we show a lemniscate for queued goals it means all pulls to refresh would trigger a lemniscate, making the refresh operation take several seconds to quiesce.

Now instead only trigger this refresh on goals with autodata, so manual goals refresh quicker.

Testing:
Refreshed a goal with autodata and saw the lemniscate
Refreshed a goal with manual data and saw no lemniscate
