### PR TITLE
Authenticate against the beeminder api using HTTP Header

### DIFF
--- a/BeeKit/Managers/RequestManager.swift
+++ b/BeeKit/Managers/RequestManager.swift
@@ -29,9 +29,15 @@ public class RequestManager {
     public let baseURLString = Config.init().baseURLString
     private let logger = Logger(subsystem: "com.beeminder.beeminder", category: "RequestManager")
     
-    func rawRequest(url: String, method: HTTPMethod, parameters: [String: Any]?) async throws -> Any? {
+    func rawRequest(url: String, method: HTTPMethod, parameters: [String: Any]?, headers: HTTPHeaders) async throws -> Any? {
         let encoding: ParameterEncoding = if method == .get { URLEncoding.default } else { JSONEncoding.default }
-        let response = await AF.request("\(baseURLString)/\(url)", method: method, parameters: parameters, encoding: encoding, headers: HTTPHeaders.default)
+        let response = await AF.request(
+            "\(baseURLString)/\(url)",
+            method: method,
+            parameters: parameters,
+            encoding: encoding,
+            headers: HTTPHeaders.default + headers
+        )
             .validate()
             .serializingData(emptyRequestMethods: [HTTPMethod.post])
             .response
@@ -64,36 +70,44 @@ public class RequestManager {
     }
     
     public func get(url: String, parameters: [String: Any]?) async throws -> Any? {
-        return try await rawRequest(url: url, method: .get, parameters: authedParams(parameters))
+        return try await rawRequest(url: url, method: .get, parameters: parameters, headers: authenticationHeaders())
     }
     
     
     public func put(url: String, parameters: [String: Any]?) async throws -> Any? {
-        return try await rawRequest(url: url, method: .patch, parameters: authedParams(parameters))
+        return try await rawRequest(url: url, method: .patch, parameters: parameters, headers: authenticationHeaders())
     }
     
     public func post(url: String, parameters: [String: Any]?) async throws -> Any? {
-        return try await rawRequest(url: url, method: .post, parameters: authedParams(parameters))
+        return try await rawRequest(url: url, method: .post, parameters: parameters, headers: authenticationHeaders())
     }
     
     public func delete(url: String, parameters: [String: Any]?) async throws -> Any? {
-        return try await rawRequest(url: url, method: .delete, parameters: authedParams(parameters))
+        return try await rawRequest(url: url, method: .delete, parameters: parameters, headers: authenticationHeaders())
     }
     
     
-    func authedParams(_ params: [String: Any]?) -> Parameters? {
-        if params == nil { return ["access_token" : ServiceLocator.currentUserManager.accessToken ?? ""] }
-        if ServiceLocator.currentUserManager.accessToken != nil {
-            var localParams = params!
-            localParams["access_token"] = ServiceLocator.currentUserManager.accessToken!
-            return localParams
+    func authenticationHeaders() -> HTTPHeaders {
+        guard let accessToken = ServiceLocator.currentUserManager.accessToken else {
+            return HTTPHeaders()
         }
-        return params
+        return HTTPHeaders([
+            HTTPHeader(name: "Authorization", value: "Bearer " + accessToken)
+        ])
     }
 
     public func addDatapoint(urtext: String, slug: String) async throws -> Any? {
         let params = ["urtext": urtext, "requestid": UUID().uuidString]
         
         return try await post(url: "api/v1/users/\(ServiceLocator.currentUserManager.username!)/goals/\(slug)/datapoints.json", parameters: params)
+    }
+}
+
+extension HTTPHeaders {
+    static func + (lhs: HTTPHeaders, rhs: HTTPHeaders) -> HTTPHeaders {
+        var allHeaders = [HTTPHeader]()
+        allHeaders.append(contentsOf: lhs)
+        allHeaders.append(contentsOf: rhs)
+        return HTTPHeaders(allHeaders)
     }
 }

--- a/BeeKit/Managers/SignedRequestManager.swift
+++ b/BeeKit/Managers/SignedRequestManager.swift
@@ -17,13 +17,23 @@ public class SignedRequestManager {
     }
 
     public func signedGET(url: String, parameters: [String: Any]?) async throws -> Any? {
-        let params = signedParameters(requestManager.authedParams(parameters))
-        return try await requestManager.rawRequest(url: url, method: .get, parameters: params)
+        let params = signedParameters(parameters)
+        return try await requestManager.rawRequest(
+            url: url,
+            method: .get,
+            parameters: params,
+            headers: requestManager.authenticationHeaders()
+        )
     }
     
     public func signedPOST(url: String, parameters: [String: Any]?) async throws -> Any? {
-        let params = signedParameters(requestManager.authedParams(parameters))
-        return try await requestManager.rawRequest(url: url, method: .post, parameters: params)
+        let params = signedParameters(parameters)
+        return try await requestManager.rawRequest(
+            url: url,
+            method: .post,
+            parameters: params,
+            headers: requestManager.authenticationHeaders()
+        )
     }
     
     fileprivate func signedParameters(_ params: [String: Any]?) -> [String: Any]? {


### PR DESCRIPTION
The beeminder api now supports authenticating using the Authorization header, as an alternate to passing an access token as a parameter. Switch to using this form, as it keeps authentication information out of the URL, which means it is less likely to e.g. be leaked as part of logs, either on the client or server.

Testing:
* Verified read and write operations on the app worked
* Used debugger to check registering device token works
* Checked signing out and signing in still works
