### PR TITLE
Do not hard-crash on missing usernames

### DIFF
--- a/BeeKit/Goal.swift
+++ b/BeeKit/Goal.swift
@@ -350,7 +350,7 @@ public class Goal {
         Task { @MainActor in
             let params = ["sort" : "daystamp", "count" : 7] as [String : Any]
             do {
-                let response = try await ServiceLocator.requestManager.get(url: "api/v1/users/\(ServiceLocator.currentUserManager.username!)/goals/\(self.slug)/datapoints.json", parameters: params)
+                let response = try await ServiceLocator.requestManager.get(url: "api/v1/users/{username}/goals/\(self.slug)/datapoints.json", parameters: params)
                 let responseJSON = JSON(response!)
                 success(try ExistingDataPoint.fromJSONArray(array: responseJSON.arrayValue))
             } catch {
@@ -377,7 +377,7 @@ public class Goal {
                 "comment": "Auto-updated via Apple Health",
             ]
             do {
-                let _ = try await ServiceLocator.requestManager.put(url: "api/v1/users/\(ServiceLocator.currentUserManager.username!)/goals/\(self.slug)/datapoints/\(datapoint.id).json", parameters: params)
+                let _ = try await ServiceLocator.requestManager.put(url: "api/v1/users/{username}/goals/\(self.slug)/datapoints/\(datapoint.id).json", parameters: params)
                 success?()
             } catch {
                 errorCompletion?()
@@ -388,7 +388,7 @@ public class Goal {
     func deleteDatapoint(datapoint : ExistingDataPoint) {
         Task { @MainActor in
             do {
-                let _ = try await ServiceLocator.requestManager.delete(url: "api/v1/users/\(ServiceLocator.currentUserManager.username!)/goals/\(self.slug)/datapoints/\(datapoint.id)", parameters: nil)
+                let _ = try await ServiceLocator.requestManager.delete(url: "api/v1/users/{username}/goals/\(self.slug)/datapoints/\(datapoint.id)", parameters: nil)
             } catch {
                 logger.error("Error deleting datapoint: \(error)")
             }
@@ -398,7 +398,7 @@ public class Goal {
     func postDatapoint(params : [String : String], success : ((Any?) -> Void)?, failure : ((Error?, String?) -> Void)?) {
         Task { @MainActor in
             do {
-                let response = try await ServiceLocator.requestManager.post(url: "api/v1/users/\(ServiceLocator.currentUserManager.username!)/goals/\(self.slug)/datapoints.json", parameters: params)
+                let response = try await ServiceLocator.requestManager.post(url: "api/v1/users/{username}/goals/\(self.slug)/datapoints.json", parameters: params)
                 success?(response)
             } catch {
                 failure?(error, error.localizedDescription)
@@ -408,7 +408,7 @@ public class Goal {
 
     func fetchDatapoints(sort: String, per: Int, page: Int) async throws -> [ExistingDataPoint] {
         let params = ["sort" : sort, "per" : per, "page": page] as [String : Any]
-        let response = try await ServiceLocator.requestManager.get(url: "api/v1/users/\(ServiceLocator.currentUserManager.username!)/goals/\(self.slug)/datapoints.json", parameters: params)
+        let response = try await ServiceLocator.requestManager.get(url: "api/v1/users/{username}/goals/\(self.slug)/datapoints.json", parameters: params)
         let responseJSON = JSON(response!)
         return try ExistingDataPoint.fromJSONArray(array: responseJSON.arrayValue)
     }

--- a/BeeKit/Managers/CurrentUserManager.swift
+++ b/BeeKit/Managers/CurrentUserManager.swift
@@ -110,7 +110,7 @@ public class CurrentUserManager {
         // Fetch a user from the persistent store
         let request = NSFetchRequest<User>(entityName: "User")
         // TODO: Handle (or at least log) an error here
-        let users = try? (context ?? container.viewContext).fetch(request)
+        let users = try? (context ?? container.newBackgroundContext()).fetch(request)
         return users?.first
     }
 
@@ -153,7 +153,7 @@ public class CurrentUserManager {
     public var username :String? {
         return user()?.username
     }
-    
+
     public func defaultLeadTime() -> NSNumber {
         return (user()?.defaultLeadTime ?? 0) as NSNumber
     }
@@ -280,4 +280,8 @@ public class CurrentUserManager {
             NotificationCenter.default.post(name: Notification.Name(rawValue: CurrentUserManager.signedOutNotificationName), object: self)
         }.value
     }
+}
+
+public enum CurrentUserManagerError : Error {
+    case loggedOut
 }

--- a/BeeSwift/EditDatapointViewController.swift
+++ b/BeeSwift/EditDatapointViewController.swift
@@ -212,7 +212,7 @@ class EditDatapointViewController: UIViewController, UITextFieldDelegate {
                 let params = [
                     "urtext": self.urtext()
                 ]
-                let _ = try await ServiceLocator.requestManager.put(url: "api/v1/users/\(ServiceLocator.currentUserManager.username!)/goals/\(self.goal.slug)/datapoints/\(self.datapoint.id).json", parameters: params)
+                let _ = try await ServiceLocator.requestManager.put(url: "api/v1/users/{username}/goals/\(self.goal.slug)/datapoints/\(self.datapoint.id).json", parameters: params)
                 try await ServiceLocator.goalManager.refreshGoal(self.goal)
 
                 hud.mode = .customView
@@ -234,7 +234,7 @@ class EditDatapointViewController: UIViewController, UITextFieldDelegate {
             hud.mode = .indeterminate
 
             do {
-                let _ = try await ServiceLocator.requestManager.delete(url: "api/v1/users/\(ServiceLocator.currentUserManager.username!)/goals/\(self.goal.slug)/datapoints/\(self.datapoint.id).json", parameters: nil)
+                let _ = try await ServiceLocator.requestManager.delete(url: "api/v1/users/{username}/goals/\(self.goal.slug)/datapoints/\(self.datapoint.id).json", parameters: nil)
                 try await ServiceLocator.goalManager.refreshGoal(self.goal)
 
                 hud.mode = .customView

--- a/BeeSwift/Settings/ConfigureHKMetricViewController.swift
+++ b/BeeSwift/Settings/ConfigureHKMetricViewController.swift
@@ -157,7 +157,7 @@ class ConfigureHKMetricViewController : UIViewController {
             params = ["ii_params" : ["name" : "apple", "metric" : self.goal.healthKitMetric!]]
 
             do {
-                let _ = try await ServiceLocator.requestManager.put(url: "api/v1/users/\(ServiceLocator.currentUserManager.username!)/goals/\(self.goal.slug).json", parameters: params)
+                let _ = try await ServiceLocator.requestManager.put(url: "api/v1/users/{username}/goals/\(self.goal.slug).json", parameters: params)
                 hud.mode = .customView
                 hud.customView = UIImageView(image: UIImage(named: "BasicCheckmark"))
                 hud.hide(animated: true, afterDelay: 2)

--- a/BeeSwift/Settings/EditDefaultNotificationsViewController.swift
+++ b/BeeSwift/Settings/EditDefaultNotificationsViewController.swift
@@ -32,7 +32,7 @@ class EditDefaultNotificationsViewController: EditNotificationsViewController {
             guard let leadtime = userInfo["leadtime"] else { return }
             let params = [ "default_leadtime" : leadtime ]
             do {
-                let _ = try await ServiceLocator.requestManager.put(url: "api/v1/users/\(ServiceLocator.currentUserManager.username!).json", parameters: params)
+                let _ = try await ServiceLocator.requestManager.put(url: "api/v1/users/{username}.json", parameters: params)
                 ServiceLocator.currentUserManager.setDefaultLeadTime(leadtime)
             } catch {
                 logger.error("Error setting default leadtime: \(error)")
@@ -52,7 +52,7 @@ class EditDefaultNotificationsViewController: EditNotificationsViewController {
                 self.updateAlertstartLabel(self.midnightOffsetFromTimePickerView())
                 let params = ["default_alertstart" : self.midnightOffsetFromTimePickerView()]
                 do {
-                    let _ = try await ServiceLocator.requestManager.put(url: "api/v1/users/\(ServiceLocator.currentUserManager.username!).json", parameters: params)
+                    let _ = try await ServiceLocator.requestManager.put(url: "api/v1/users/{username}.json", parameters: params)
                     ServiceLocator.currentUserManager.setDefaultAlertstart(self.midnightOffsetFromTimePickerView())
                 } catch {
                     logger.error("Error setting default alert start: \(error)")
@@ -63,7 +63,7 @@ class EditDefaultNotificationsViewController: EditNotificationsViewController {
                 self.updateDeadlineLabel(self.midnightOffsetFromTimePickerView())
                 let params = ["default_deadline" : self.midnightOffsetFromTimePickerView()]
                 do {
-                    let _ = try await ServiceLocator.requestManager.put(url: "api/v1/users/\(ServiceLocator.currentUserManager.username!).json", parameters: params)
+                    let _ = try await ServiceLocator.requestManager.put(url: "api/v1/users/{username}.json", parameters: params)
                     ServiceLocator.currentUserManager.setDefaultDeadline(self.midnightOffsetFromTimePickerView())
                 } catch {
                     logger.error("Error setting default deadline: \(error)")

--- a/BeeSwift/Settings/EditGoalNotificationsViewController.swift
+++ b/BeeSwift/Settings/EditGoalNotificationsViewController.swift
@@ -68,7 +68,7 @@ class EditGoalNotificationsViewController : EditNotificationsViewController {
             let leadtime = userInfo["leadtime"]
             let params = [ "leadtime" : leadtime, "use_defaults" : false ]
             do {
-                let _ = try await ServiceLocator.requestManager.put(url: "api/v1/users/\(ServiceLocator.currentUserManager.username!)/goals/\(self.goal!.slug).json", parameters: params as [String : Any])
+                let _ = try await ServiceLocator.requestManager.put(url: "api/v1/users/{username}/goals/\(self.goal!.slug).json", parameters: params as [String : Any])
                 self.goal!.leadtime = leadtime!
                 self.goal!.use_defaults = NSNumber(value: false as Bool)
                 self.useDefaultsSwitch.isOn = false
@@ -85,7 +85,7 @@ class EditGoalNotificationsViewController : EditNotificationsViewController {
                 self.updateAlertstartLabel(self.midnightOffsetFromTimePickerView())
                 do {
                     let params = ["alertstart" : self.midnightOffsetFromTimePickerView(), "use_defaults" : false]
-                    let _ = try await ServiceLocator.requestManager.put(url: "api/v1/users/\(ServiceLocator.currentUserManager.username!)/goals/\(self.goal!.slug).json", parameters: params)
+                    let _ = try await ServiceLocator.requestManager.put(url: "api/v1/users/{username}/goals/\(self.goal!.slug).json", parameters: params)
                     self.goal!.alertstart = self.midnightOffsetFromTimePickerView()
                     self.goal!.use_defaults = NSNumber(value: false as Bool)
                     self.useDefaultsSwitch.isOn = false
@@ -98,7 +98,7 @@ class EditGoalNotificationsViewController : EditNotificationsViewController {
                 self.updateDeadlineLabel(self.midnightOffsetFromTimePickerView())
                 do {
                     let params = ["deadline" : self.midnightOffsetFromTimePickerView(), "use_defaults" : false]
-                    let _ = try await ServiceLocator.requestManager.put(url: "api/v1/users/\(ServiceLocator.currentUserManager.username!)/goals/\(self.goal!.slug).json", parameters: params)
+                    let _ = try await ServiceLocator.requestManager.put(url: "api/v1/users/{username}/goals/\(self.goal!.slug).json", parameters: params)
                     self.goal?.deadline = self.midnightOffsetFromTimePickerView()
                     self.goal!.use_defaults = NSNumber(value: false as Bool)
                     self.useDefaultsSwitch.isOn = false
@@ -120,7 +120,7 @@ class EditGoalNotificationsViewController : EditNotificationsViewController {
                 Task { @MainActor in
                     do {
                         let params = ["use_defaults" : true]
-                        let _ = try await ServiceLocator.requestManager.put(url: "api/v1/users/\(ServiceLocator.currentUserManager.username!)/goals/\(self.goal!.slug).json", parameters: params)
+                        let _ = try await ServiceLocator.requestManager.put(url: "api/v1/users/{username}/goals/\(self.goal!.slug).json", parameters: params)
                         self.goal?.use_defaults = NSNumber(value: true as Bool)
                     } catch {
                         self.logger.error("Error setting goal to use defaults: \(error)")
@@ -155,7 +155,7 @@ class EditGoalNotificationsViewController : EditNotificationsViewController {
             Task { @MainActor in
                 do {
                     let params = ["use_defaults" : false]
-                    let _ = try await ServiceLocator.requestManager.put(url: "api/v1/users/\(ServiceLocator.currentUserManager.username!)/goals/\(self.goal!.slug).json", parameters: params)
+                    let _ = try await ServiceLocator.requestManager.put(url: "api/v1/users/{username}/goals/\(self.goal!.slug).json", parameters: params)
                         self.goal?.use_defaults = NSNumber(value: false as Bool)
                 } catch {
                     logger.error("Error setting goal to NOT use defaults: \(error)")

--- a/BeeSwift/Settings/RemoveHKMetricViewController.swift
+++ b/BeeSwift/Settings/RemoveHKMetricViewController.swift
@@ -75,7 +75,7 @@ class RemoveHKMetricViewController: UIViewController {
 
         Task { @MainActor in
             do {
-                let responseObject = try await ServiceLocator.requestManager.put(url: "api/v1/users/\(ServiceLocator.currentUserManager.username!)/goals/\(self.goal!.slug).json", parameters: params)
+                let responseObject = try await ServiceLocator.requestManager.put(url: "api/v1/users/{username}/goals/\(self.goal!.slug).json", parameters: params)
 
                 self.goal = Goal(json: JSON(responseObject!))
 

--- a/BeeSwift/TimerViewController.swift
+++ b/BeeSwift/TimerViewController.swift
@@ -174,7 +174,7 @@ class TimerViewController: UIViewController {
         Task { @MainActor in
             do {
                 let params = ["urtext": self.urtext(), "requestid": UUID().uuidString]
-                let _ = try await ServiceLocator.requestManager.post(url: "api/v1/users/\(ServiceLocator.currentUserManager.username!)/goals/\(self.slug!)/datapoints.json", parameters: params)
+                let _ = try await ServiceLocator.requestManager.post(url: "api/v1/users/{username}/goals/\(self.slug!)/datapoints.json", parameters: params)
                 hud.mode = .text
                 hud.label.text = "Added!"
                 DispatchQueue.main.asyncAfter(deadline: .now() + 2, execute: {


### PR DESCRIPTION
Previously we were using `username!` to look up usernames. This would throw a fatal exception if the username was not available, crashing the app. In particular attempts to update HealthKit metrics could hit this after logging out from the app.

Avoid this by centralizing the username lookup logic in the request manager making URLs in the app slightly more readable, and have it throw a catchable exception. This could theoretically cause issues in the case that a URL contains an additional `{username}` string, but this seems unlikely.

Testing:
Launched the app on my phone and checked it could load goals.
Signed out and did not immediately experience a crash.
