### PR TITLE
Support webcredentials for easier login

### DIFF
--- a/BeeSwift/BeeSwift.entitlements
+++ b/BeeSwift/BeeSwift.entitlements
@@ -7,6 +7,7 @@
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>webcredentials:beeminder.com</string>
+		<string>webcredentials:www.beeminder.com</string>
 	</array>
 	<key>com.apple.developer.healthkit</key>
 	<true/>

--- a/apple-app-site-association
+++ b/apple-app-site-association
@@ -1,0 +1,5 @@
+{
+   "webcredentials": {
+      "apps": [ "8TW9V9HVES.com.beeminder.beeminder" ]
+   }
+}


### PR DESCRIPTION
iOS supports using web credentials to login to apps. It looks like BeeSwift intended to support this, but it wasn't working properly. The main fix here was adding a relevant file to the beeminder server, but we also
* Add the relevant file to this repo, for reference
* Also add www.beeminder.com as a compatible domain

Testing:
Viewed login screen on phone and confirmed password manager credentials were offered.
