### PR TITLE
Sort by urgency instead of deadline

### DIFF
--- a/BeeKit/Goal.swift
+++ b/BeeKit/Goal.swift
@@ -51,6 +51,7 @@ public class Goal {
     public var queued: Bool?
     public var todayta: Bool = false
     public var hhmmformat: Bool = false
+    public var urgencykey: String = ""
     public var recent_data: [ExistingDataPoint]?
 
     // These are obtained from mathishard
@@ -112,6 +113,7 @@ public class Goal {
         self.healthKitMetric = json["healthkitmetric"].string
         self.todayta = json["todayta"].bool!
         self.hhmmformat = json["hhmmformat"].bool!
+        self.urgencykey = json["urgencykey"].string!
 
         self.recent_data = (try? ExistingDataPoint.fromJSONArray(array: json["recent_data"].arrayValue).reversed()) ?? []
 

--- a/BeeKit/Util/Constants.swift
+++ b/BeeKit/Util/Constants.swift
@@ -22,9 +22,9 @@ public struct Constants {
     public static let recentDataGoalSortString = "Recent Data"
     public static let nameGoalSortString = "Name"
     public static let pledgeGoalSortString = "Pledge"
-    public static let deadlineGoalSortString = "Deadline"
+    public static let urgencyGoalSortString = "Urgency"
     public static let healthKitUpdateDictionaryKey = "healthKitUpdateDictionary"
-    public static let goalSortOptions = [Constants.nameGoalSortString, Constants.deadlineGoalSortString, Constants.pledgeGoalSortString, Constants.recentDataGoalSortString]
+    public static let goalSortOptions = [Constants.urgencyGoalSortString, Constants.nameGoalSortString, Constants.pledgeGoalSortString, Constants.recentDataGoalSortString]
     public static let appGroupIdentifier = "group.beeminder.beeminder"
 }
 

--- a/BeeSwift/Gallery/GalleryViewController.swift
+++ b/BeeSwift/Gallery/GalleryViewController.swift
@@ -428,26 +428,8 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
                 }
             }
 
-            // Default sort ordering
-
-            // Primary Criteria: Sooner deadline/goal end first
-            let goal1Date = min(goal1.losedate.intValue, goal1.derived_goaldate.intValue)
-            let goal2Date = min(goal2.losedate.intValue, goal2.derived_goaldate.intValue)
-            if goal1Date < goal2Date {
-                return true
-            } else if goal2Date < goal1Date {
-                return false
-            }
-
-            // Secondary Criteria: Larger pledge amount first
-            if goal2.pledge.intValue < goal1.pledge.intValue {
-                return true
-            } else if goal1.pledge.intValue < goal2.pledge.intValue {
-                return false
-            }
-
-            // Tertiary Criteria: Lexographically earlier slug first
-            return goal1.slug < goal2.slug
+            // urgencykey is guaranteed to result in goals sorting into the canonical order
+            return goal1.urgencykey < goal2.urgencykey
         })
         self.updateFilteredGoals(searchText: self.searchBar.text ?? "")
     }

--- a/BeeSwiftTests/GoalTests.swift
+++ b/BeeSwiftTests/GoalTests.swift
@@ -40,6 +40,7 @@ final class GoalTests: XCTestCase {
           "lasttouch": "2022-12-07T03:21:40.000Z",
           "safebuf": 3583,
           "todayta": false,
+          "urgencykey": "FROx;PPRx;DL4102469999;P1000000000;test-goal",
           "hhmmformat": false,
           "yaxis": "cumulative total test-goal",
           "initday": 1668963600,
@@ -121,6 +122,7 @@ final class GoalTests: XCTestCase {
         XCTAssertEqual(goal.lasttouch, 1670383300)
         XCTAssertEqual(goal.safebuf, 3583)
         XCTAssertEqual(goal.todayta, false)
+        XCTAssertEqual(goal.urgencykey, "FROx;PPRx;DL4102469999;P1000000000;test-goal")
         XCTAssertEqual(goal.hhmmformat, false)
         XCTAssertEqual(goal.yaxis, "cumulative total test-goal")
         XCTAssertEqual(goal.initday, 1668963600)
@@ -160,6 +162,7 @@ final class GoalTests: XCTestCase {
           "lasttouch": "2022-12-07T03:21:40.000Z",
           "safebuf": 3583,
           "todayta": false,
+          "urgencykey": "FROx;PPRx;DL4102469999;P1000000000;test-goal",
           "hhmmformat": false,
           "yaxis": "cumulative total test-goal",
           "initday": 1668963600,
@@ -233,7 +236,8 @@ final class GoalTests: XCTestCase {
             "use_defaults": true,
             "pledge": 0,
             "hhmmformat": false,
-            "todayta": false
+            "todayta": false,
+            "urgencykey": "FROx;PPRx;DL4102469999;P1000000000;test-goal"
         }
         """)
 


### PR DESCRIPTION
Beeminder has moved from sorting by deadline to sorting by Urgency. Update the app to use the new name, and also rely on the server provided `urgencykey` to determine sort order.