### PR TITLE
Fix calculation for meditation minutes

### DIFF
--- a/BeeKit/HeathKit/MindfulSessionHealthKitMetric.swift
+++ b/BeeKit/HeathKit/MindfulSessionHealthKitMetric.swift
@@ -8,8 +8,46 @@ class MindfulSessionHealthKitMetric : CategoryHealthKitMetric {
         super.init(humanText: humanText, databaseString: databaseString, category: category, hkSampleType: HKObjectType.categoryType(forIdentifier: .mindfulSession)!)
     }
 
-    override func valueInAppropriateUnits(rawValue: Double) -> Double {
-        return rawValue / minuteInSeconds
+    override func hkDatapointValueForSamples(samples: [HKSample], startOfDate: Date) -> Double {
+        let endOfDate = startOfDate.addingTimeInterval(24 * 60 * 60)
+
+        let orderedSamples = samples.sorted(by: { $0.startDate < $1.startDate })
+
+        var spanStart: Optional<Date> = nil
+        var spanEnd: Optional<Date> = nil
+        var totalSeconds = 0.0
+
+        for sample in orderedSamples {
+            if sample.hasUndeterminedDuration {
+                continue
+            }
+
+            let sampleStart = max(sample.startDate, startOfDate)
+            let sampleEnd = min(sample.endDate, endOfDate)
+
+            if let start = spanStart, let end = spanEnd {
+                // There is an existing span to examine
+                if sampleStart <= end {
+                    // If the sample overlaps with the current span, extend the span
+                    spanEnd = max(end, sampleEnd)
+                } else {
+                    // Otherwise, add the span to the total and start a new span
+                    totalSeconds += end.timeIntervalSince(start)
+                    spanStart = sampleStart
+                    spanEnd = sampleEnd
+                }
+            } else {
+                // No prior span, start with this one
+                spanStart = sampleStart
+                spanEnd = sampleEnd
+            }
+        }
+        if let end = spanEnd {
+            totalSeconds += end.timeIntervalSince(spanStart!)
+        }
+
+        let totalMinutes = totalSeconds / minuteInSeconds
+        return totalMinutes.rounded()
     }
 
     override func units(healthStore : HKHealthStore) async throws -> HKUnit {


### PR DESCRIPTION
Previously meditation minutes used the same algorithm as we used for time in bed. This was overly generous. It would count minutes containing meditation, which is different from the apple algorithm which counts total duration rounded to the nearest minute.

Update the calculation used in the app to match the Apple algorithm.

Fixes #452

Testing:
Put various test data into the simulator, and checked beeminder synced appropriately.