### PR TITLE
Remove the "delta text" UI section

### DIFF
--- a/BeeKit/Goal.swift
+++ b/BeeKit/Goal.swift
@@ -21,7 +21,6 @@ public class Goal {
     private let datapointValueEpsilon = 0.00000001
 
     public var autodata: String = ""
-    public var delta_text: String = ""
     public var graph_url: String?
     public var healthKitMetric: String?
     public var id: String = ""
@@ -31,10 +30,7 @@ public class Goal {
     public var thumb_url: String?
     public var title: String = ""
     public var won: NSNumber = 0
-    public var yaw: NSNumber = 0
-    public var safebump: NSNumber?
     public var safebuf: NSNumber = 0
-    public var curval: NSNumber?
     public var limsum: String?
     public var safesum: String?
     public var initday: NSNumber?
@@ -80,15 +76,11 @@ public class Goal {
 
         self.queued = json["queued"].bool!
         self.yaxis = json["yaxis"].string!
-        self.delta_text = json["delta_text"].string ?? ""
         self.won = json["won"].number!
-        self.yaw = json["yaw"].number!
         self.limsum = json["limsum"].string
         self.safesum = json["safesum"].string
         self.safebuf = json["safebuf"].number!
         self.use_defaults = json["use_defaults"].bool! as NSNumber
-        self.safebump = json["safebump"].number
-        self.curval = json["curval"].number
         self.pledge = json["pledge"].number!
         self.autodata = json["autodata"].string ?? ""
         
@@ -133,58 +125,6 @@ public class Goal {
         }
         if self.autodata.count > 0 { return self.autodata.capitalized }
         return nil
-    }
-    
-    public var attributedDeltaText :NSAttributedString {
-        if self.delta_text.count == 0 { return NSAttributedString.init(string: "") }
-        if self.delta_text.components(separatedBy: "✔").count == 4 {
-            if (self.safebump!.doubleValue - self.curval!.doubleValue > 0) {
-                let attString :NSMutableAttributedString = NSMutableAttributedString(string: String(format: "+ %.2f", self.safebump!.doubleValue - self.curval!.doubleValue))
-                attString.addAttribute(NSAttributedString.Key.foregroundColor, value: UIColor.beeminder.green, range: NSRange(location: 0, length: attString.string.count))
-                return attString
-            }
-            return NSMutableAttributedString(string: "")
-        }
-        var spaceIndices :Array<Int> = [0]
-        
-        for i in 0...self.delta_text.count - 1 {
-            if self.delta_text[delta_text.index(delta_text.startIndex, offsetBy: i)] == " " {
-                spaceIndices.append(i)
-            }
-        }
-        
-        spaceIndices.append(self.delta_text.count)
-        
-        let attString :NSMutableAttributedString = NSMutableAttributedString(string: self.delta_text)
-        
-        for i in 0..<spaceIndices.count {
-            if i + 1 >= spaceIndices.count {
-                continue
-            }
-            var color = self.deltaColors.first
-            if i < self.deltaColors.count {
-                color = self.deltaColors[i]
-            }
-            attString.addAttribute(NSAttributedString.Key.foregroundColor, value: color as Any, range: NSRange(location: spaceIndices[i], length: spaceIndices[i + 1] - spaceIndices[i]))
-        }
-        
-        attString.mutableString.replaceOccurrences(of: "✔", with: "", options: NSString.CompareOptions.literal, range: NSRange(location: 0, length: attString.string.count))
-        
-        return attString
-    }
-    
-    public var deltaColors: [UIColor] {
-        // yaw (number): Good side of the road (+1/-1 = above/below)
-    
-        return self.yaw == 1 ? deltaColorsWhenAboveIsGoodSide : deltaColorsWhenBelowIsGoodSide
-    }
-    
-    public var deltaColorsWhenBelowIsGoodSide: [UIColor] {
-        return [UIColor.beeminder.green, UIColor.beeminder.blue, UIColor.beeminder.orange]
-    }
-    
-    public var deltaColorsWhenAboveIsGoodSide: [UIColor] {
-        return deltaColorsWhenBelowIsGoodSide.reversed()
     }
 
     public func hideDataEntry() -> Bool {

--- a/BeeSwift/GoalViewController.swift
+++ b/BeeSwift/GoalViewController.swift
@@ -35,7 +35,6 @@ class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTabl
     fileprivate var goalImageScrollView = UIScrollView()
     fileprivate var pollTimer : Timer?
     fileprivate var countdownLabel = BSLabel()
-    fileprivate var deltasLabel = BSLabel()
     fileprivate var scrollView = UIScrollView()
     fileprivate var submitButton = BSButton()
     fileprivate let headerWidth = Double(1.0/3.0)
@@ -116,20 +115,11 @@ class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTabl
         }
         self.goalImageView.goal = self.goal
 
-        self.scrollView.addSubview(self.deltasLabel)
-        self.deltasLabel.snp.makeConstraints { (make) in
-            make.top.equalTo(self.goalImageScrollView.snp.bottom)
-            make.left.right.equalTo(0)
-        }
-        self.deltasLabel.font = UIFont.beeminder.defaultBoldFont.withSize(Constants.defaultFontSize)
-        self.deltasLabel.textAlignment = .center
-
-
         self.addChild(self.datapointTableController)
         self.scrollView.addSubview(self.datapointTableController.view)
         self.datapointTableController.delegate = self
         self.datapointTableController.view.snp.makeConstraints { (make) -> Void in
-            make.top.equalTo(self.deltasLabel.snp.bottom).offset(elementSpacing)
+            make.top.equalTo(self.goalImageScrollView.snp.bottom).offset(elementSpacing)
             make.left.equalTo(self.goalImageScrollView).offset(sideMargin)
             make.right.equalTo(self.goalImageScrollView).offset(-sideMargin)
         }
@@ -318,13 +308,6 @@ class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTabl
 
     @objc func onGoalsUpdatedNotification() {
         updateInterfaceToMatchGoal()
-    }
-
-    override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
-        if (!ServiceLocator.currentUserManager.signedIn()) { return }
-        if keyPath == "delta_text" || keyPath == "safebump" || keyPath == "safesum" {
-            self.refreshCountdown()
-        }
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -535,7 +518,6 @@ class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTabl
         }
 
         self.refreshCountdown()
-        self.deltasLabel.attributedText = self.goal!.attributedDeltaText
     }
 
     func viewForZooming(in scrollView: UIScrollView) -> UIView? {

--- a/BeeSwiftTests/GoalTests.swift
+++ b/BeeSwiftTests/GoalTests.swift
@@ -27,11 +27,8 @@ final class GoalTests: XCTestCase {
           "use_defaults": true,
           "id": "737aaa34f0118a330852e4bd",
           "queued": false,
-          "yaw": 1,
           "limsum": "100 in 200 days",
           "won": false,
-          "delta_text": "✔ ✔ ✔",
-          "safebump": 3828,
           "safesum": "safe for 200 days",
           "lasttouch": "2022-12-07T03:21:40.000Z",
           "safebuf": 3583,
@@ -40,7 +37,6 @@ final class GoalTests: XCTestCase {
           "hhmmformat": false,
           "yaxis": "cumulative total test-goal",
           "initday": 1668963600,
-          "curval": 4000,
           "pledge": 0,
           "recent_data": [
             {
@@ -99,11 +95,8 @@ final class GoalTests: XCTestCase {
         XCTAssertEqual(goal.use_defaults, true)
         XCTAssertEqual(goal.id, "737aaa34f0118a330852e4bd")
         XCTAssertEqual(goal.queued, false)
-        XCTAssertEqual(goal.yaw, 1)
         XCTAssertEqual(goal.limsum, "100 in 200 days")
         XCTAssertEqual(goal.won, false)
-        XCTAssertEqual(goal.delta_text, "✔ ✔ ✔")
-        XCTAssertEqual(goal.safebump, 3828)
         XCTAssertEqual(goal.safesum, "safe for 200 days")
         XCTAssertEqual(goal.lasttouch, 1670383300)
         XCTAssertEqual(goal.safebuf, 3583)
@@ -112,7 +105,6 @@ final class GoalTests: XCTestCase {
         XCTAssertEqual(goal.hhmmformat, false)
         XCTAssertEqual(goal.yaxis, "cumulative total test-goal")
         XCTAssertEqual(goal.initday, 1668963600)
-        XCTAssertEqual(goal.curval, 4000)
         XCTAssertEqual(goal.pledge, 0)
         XCTAssertEqual(goal.recent_data!.count, 5)
 
@@ -167,7 +159,6 @@ final class GoalTests: XCTestCase {
             "yaxis": "cumulative total test-goal",
             "won": false,
             "safebuf": 1,
-            "yaw": 1,
             "use_defaults": true,
             "pledge": 0,
             "hhmmformat": false,


### PR DESCRIPTION
The app previously showed a section of numbers below the graph, e.g. (+1 +1 +2). These were from a time when "lanes" and "road" were part of the beeminder vocabulary and were pretty hard to understand, especially for do less goals.

We may wish to replace them with a table of what is due when, but for now just remove them.

Testing
Loaded the app and looked at a goal.