### PR TITLE
Add #THISWILLSELFDESTRUCT to list of ignored points

### DIFF
--- a/BeeKit/Goal.swift
+++ b/BeeKit/Goal.swift
@@ -145,7 +145,7 @@ public class Goal {
         for dataPoint in recentData.reversed() {
             let comment = dataPoint.comment
             // Ignore data points with comments suggesting they aren't a real value
-            if comment.contains("#DERAIL") || comment.contains("#SELFDESTRUCT") || comment.contains("#RESTART") || comment.contains("#TARE") {
+            if comment.contains("#DERAIL") || comment.contains("#SELFDESTRUCT") || comment.contains("#THISWILLSELFDESTRUCT") || comment.contains("#RESTART") || comment.contains("#TARE") {
                 continue
             }
             return dataPoint.value

--- a/BeeSwiftTests/GoalTests.swift
+++ b/BeeSwiftTests/GoalTests.swift
@@ -135,6 +135,7 @@ final class GoalTests: XCTestCase {
         testJSON["recent_data"] = [
             ["value": 0, "daystamp": "20221131", "comment": "Goal #RESTART Point"],
             ["value": 0, "daystamp": "20221131", "comment": "This will #SELFDESTRUCT"],
+            ["value": 0, "daystamp": "20221131", "comment": "PESSIMISTIC PRESUMPTION #THISWILLSELFDESTRUCT"],
             ["value": 0, "daystamp": "20221130", "comment": "#DERAIL ON THE 1st"],
             ["value": 2, "daystamp": "20221126"],
             ["value": 3.5, "daystamp": "20221125"],


### PR DESCRIPTION
Apparently pessimistic presumptive data points now look like `PESSIMISTIC PRESUMPTION #THISWILLSELFDESTRUCT` which means the app was not ignoring them. Add to the list of ignored strings to include these.

Testing:
Updated the unit tests to include this case.