### PR TITLE
Remove migration of user preferences to new store

### DIFF
--- a/BeeSwiftTests/CurrentUserManagerTests.swift
+++ b/BeeSwiftTests/CurrentUserManagerTests.swift
@@ -14,15 +14,4 @@ final class CurrentUserManagerTests: XCTestCase {
         currentUserManager.setAccessToken("test_access_token")
         XCTAssertEqual(currentUserManager.accessToken, "test_access_token")
     }
-
-    func testCanMigrateAccessToken() throws {
-        let userDefaults = UserDefaults(suiteName: Constants.appGroupIdentifier)!
-        userDefaults.set("migrated_access_token", forKey: CurrentUserManager.accessTokenKey)
-
-        let currentUserManager = CurrentUserManager(requestManager: ServiceLocator.requestManager, container: ServiceLocator.persistentContainer)
-        XCTAssertEqual(currentUserManager.accessToken, "migrated_access_token")
-
-        // The value should also have been removed from UserDefaults
-        XCTAssertNil(userDefaults.object(forKey: CurrentUserManager.accessTokenKey))
-    }
 }


### PR DESCRIPTION
A long time ago we migrated from using an app only preference store to one shared with extensions and other app components. This has been released long enough that we can remove support for upgrading from the old format.

Testing:
None