### PR TITLE
Rename Goal to BeeGoal to make room for CoreData type

### DIFF
--- a/BeeKit/BeeDataPoint.swift
+++ b/BeeKit/BeeDataPoint.swift
@@ -3,7 +3,7 @@
 import Foundation
 import SwiftyJSON
 
-public protocol DataPoint {
+public protocol BeeDataPoint {
     var requestid: String { get }
     var daystamp: Daystamp { get }
     var value: NSNumber { get }
@@ -11,7 +11,7 @@ public protocol DataPoint {
 }
 
 /// A data point received from the server. This will have had an ID allocated
-public struct ExistingDataPoint : DataPoint {
+public struct ExistingDataPoint : BeeDataPoint {
     public let id: String
     public let requestid: String
     public let daystamp: Daystamp
@@ -34,7 +34,7 @@ public struct ExistingDataPoint : DataPoint {
 }
 
 /// A data point we have created locally (e.g. from user input, or HealthKit)
-public struct NewDataPoint : DataPoint {
+public struct NewDataPoint : BeeDataPoint {
     public let requestid: String
     public let daystamp: Daystamp
     public let value: NSNumber

--- a/BeeKit/BeeGoal.swift
+++ b/BeeKit/BeeGoal.swift
@@ -13,7 +13,7 @@ import OSLog
 import UserNotifications
 import UIKit
 
-public class Goal {
+public class BeeGoal {
     private let logger = Logger(subsystem: "com.beeminder.beeminder", category: "Goal")
 
     // Ignore automatic datapoint updates where the difference is a smaller fraction than this. This
@@ -340,7 +340,7 @@ public class Goal {
     }
 }
 
-public extension Goal {
+public extension BeeGoal {
     var cacheBustingThumbUrl: String {
         let thumbUrlStr = self.thumb_url!
         return cacheBuster(thumbUrlStr)
@@ -352,7 +352,7 @@ public extension Goal {
     }
 }
 
-private extension Goal {
+private extension BeeGoal {
     func cacheBuster(_ originUrlStr: String) -> String {
         guard let lastTouch = self.lasttouch else {
             return originUrlStr

--- a/BeeKit/BeeGoal.swift
+++ b/BeeKit/BeeGoal.swift
@@ -273,7 +273,7 @@ public class BeeGoal {
         return fetchedDatapoints.filter { point in point.daystamp >= daystamp }
     }
 
-    func updateToMatchDataPoints(healthKitDataPoints : [DataPoint]) async throws {
+    func updateToMatchDataPoints(healthKitDataPoints : [BeeDataPoint]) async throws {
         guard let firstDaystamp = healthKitDataPoints.map({ point in point.daystamp }).min() else { return }
 
         let datapoints = try await datapointsSince(daystamp: try! Daystamp(fromString: firstDaystamp.description))
@@ -283,7 +283,7 @@ public class BeeGoal {
         }
     }
 
-    private func updateToMatchDataPoint(newDataPoint : DataPoint, recentDatapoints: [ExistingDataPoint]) async throws {
+    private func updateToMatchDataPoint(newDataPoint : BeeDataPoint, recentDatapoints: [ExistingDataPoint]) async throws {
         var matchingDatapoints = datapointsMatchingDaystamp(datapoints: recentDatapoints, daystamp: newDataPoint.daystamp)
         if matchingDatapoints.count == 0 {
             // If there are not already data points for this day, do not add points

--- a/BeeKit/HeathKit/CategoryHealthKitMetric.swift
+++ b/BeeKit/HeathKit/CategoryHealthKitMetric.swift
@@ -31,11 +31,11 @@ class CategoryHealthKitMetric : HealthKitMetric {
         return hkSampleType
     }
 
-    func recentDataPoints(days : Int, deadline : Int, healthStore : HKHealthStore) async throws -> [DataPoint] {
+    func recentDataPoints(days : Int, deadline : Int, healthStore : HKHealthStore) async throws -> [BeeDataPoint] {
         let today = Daystamp.now(deadline: deadline)
         let startDate = today - days
 
-        var results : [DataPoint] = []
+        var results : [BeeDataPoint] = []
         for date in (startDate...today) {
             results.append(try await self.getDataPoint(date: date, deadline: deadline, healthStore: healthStore))
         }
@@ -46,7 +46,7 @@ class CategoryHealthKitMetric : HealthKitMetric {
         return HKUnit.count()
     }
 
-    private func getDataPoint(date : Daystamp, deadline : Int, healthStore : HKHealthStore) async throws -> DataPoint {
+    private func getDataPoint(date : Daystamp, deadline : Int, healthStore : HKHealthStore) async throws -> BeeDataPoint {
 
         let samples = try await withCheckedThrowingContinuation({ (continuation: CheckedContinuation<[HKSample], Error>) in
             let query = HKSampleQuery.init(

--- a/BeeKit/HeathKit/GoalHealthKitConnection.swift
+++ b/BeeKit/HeathKit/GoalHealthKitConnection.swift
@@ -22,13 +22,13 @@ class GoalHealthKitConnection {
 
     private let logger = Logger(subsystem: "com.beeminder.beeminder", category: "GoalHealthKitConnection")
     private let healthStore: HKHealthStore
-    private let goal : Goal
+    private let goal : BeeGoal
     private var observerQuery : HKObserverQuery? = nil
     private var lastObserverUpdate : Date? = nil
 
     public let metric : HealthKitMetric
 
-    init(goal: Goal, metric : HealthKitMetric, healthStore: HKHealthStore) {
+    init(goal: BeeGoal, metric : HealthKitMetric, healthStore: HKHealthStore) {
         self.goal = goal
         self.metric = metric
         self.healthStore = healthStore

--- a/BeeKit/HeathKit/HealthKitMetric.swift
+++ b/BeeKit/HeathKit/HealthKitMetric.swift
@@ -35,7 +35,7 @@ public protocol HealthKitMetric {
     ///   - healthStore: A HKHealthStore instance to use for querying data
     ///
     /// - Returns: A list of DataPoint objects containing values for the provided date range. May or may not include 0 values if there is no data. Values are not guaranteed to be in order.
-    func recentDataPoints(days : Int, deadline : Int, healthStore : HKHealthStore) async throws -> [DataPoint]
+    func recentDataPoints(days : Int, deadline : Int, healthStore : HKHealthStore) async throws -> [BeeDataPoint]
 
     /// The units this metric returns its datapoint values in
     func units(healthStore : HKHealthStore) async throws -> HKUnit

--- a/BeeKit/HeathKit/QuantityHealthKitMetric.swift
+++ b/BeeKit/HeathKit/QuantityHealthKitMetric.swift
@@ -33,7 +33,7 @@ class QuantityHealthKitMetric : HealthKitMetric {
         return HKObjectType.quantityType(forIdentifier: self.hkQuantityTypeIdentifier)!
     }
 
-    func recentDataPoints(days : Int, deadline : Int, healthStore : HKHealthStore) async throws -> [DataPoint] {
+    func recentDataPoints(days : Int, deadline : Int, healthStore : HKHealthStore) async throws -> [BeeDataPoint] {
         guard let quantityType = HKObjectType.quantityType(forIdentifier: self.hkQuantityTypeIdentifier) else {
             throw HealthKitError("Unable to look up a quantityType")
         }
@@ -75,9 +75,9 @@ class QuantityHealthKitMetric : HealthKitMetric {
         return unit
     }
     
-    private func datapointsForCollection(collection : HKStatisticsCollection, startDate: Daystamp, endDate: Daystamp, deadline : Int, healthStore: HKHealthStore) async throws -> [DataPoint] {
+    private func datapointsForCollection(collection : HKStatisticsCollection, startDate: Daystamp, endDate: Daystamp, deadline : Int, healthStore: HKHealthStore) async throws -> [BeeDataPoint] {
 
-        var results : [DataPoint] = []
+        var results : [BeeDataPoint] = []
 
         for statistics in collection.statistics() {
             // Use the midpoint of the interval to determine the daystamp. Theoretically using the startDate

--- a/BeeKit/Managers/HealthStoreManager.swift
+++ b/BeeKit/Managers/HealthStoreManager.swift
@@ -35,7 +35,7 @@ public class HealthStoreManager :NSObject {
     }
 
     /// Start listening for background updates to the supplied goal if we are not already doing so
-    public func ensureUpdatesRegularly(goal: Goal) async throws {
+    public func ensureUpdatesRegularly(goal: BeeGoal) async throws {
         try await self.ensureUpdatesRegularly(goals: [goal])
     }
 
@@ -44,7 +44,7 @@ public class HealthStoreManager :NSObject {
     ///
     /// It is safe to pass the same goal or set of goals to this function multiple times, this function
     /// will ensure duplicate observers are not installed.
-    public func ensureUpdatesRegularly(goals: [Goal]) async throws {
+    public func ensureUpdatesRegularly(goals: [BeeGoal]) async throws {
         let goalConnections = goals.compactMap { self.connectionFor(goal:$0) }
 
         var permissions = Set<HKObjectType>()
@@ -69,7 +69,7 @@ public class HealthStoreManager :NSObject {
     ///
     /// This function will never show a permissions dialog - instead it will not update for
     /// metrics where we do not have permission.
-    public func silentlyInstallObservers(goals: [Goal]) {
+    public func silentlyInstallObservers(goals: [BeeGoal]) {
         logger.notice("Silently installing observer queries")
 
         let goalConnections = goals.compactMap { self.connectionFor(goal:$0) }
@@ -84,7 +84,7 @@ public class HealthStoreManager :NSObject {
     /// - Parameters:
     ///   - goal: The healthkit-connected goal to be updated
     ///   - days: How many days of history to update. Supplying 1 will update the current day.
-    public func updateWithRecentData(goal: Goal, days: Int) async throws {
+    public func updateWithRecentData(goal: BeeGoal, days: Int) async throws {
         logger.notice("Updating \(goal.healthKitMetric ?? "nil", privacy: .public) goal with recent day for last \(days, privacy: .public) days")
         guard let connection = self.connectionFor(goal: goal) else {
             throw HealthKitError("Failed to find connection for goal")
@@ -107,7 +107,7 @@ public class HealthStoreManager :NSObject {
     }
 
     /// Gets or creates an appropriate connection object for the supplied goal
-    private func connectionFor(goal: Goal) -> GoalHealthKitConnection? {
+    private func connectionFor(goal: BeeGoal) -> GoalHealthKitConnection? {
         connectionsSemaphore.wait()
 
         if (goal.healthKitMetric ?? "") == "" {

--- a/BeeSwift.xcodeproj/project.pbxproj
+++ b/BeeSwift.xcodeproj/project.pbxproj
@@ -66,7 +66,7 @@
 		E458C8042AD11BC3000DCA5C /* SignedRequestManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A142492C1FD079B4007736B3 /* SignedRequestManager.swift */; };
 		E458C8052AD11BC8000DCA5C /* VersionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C161932423CE9F0045C90D /* VersionManager.swift */; };
 		E458C8062AD11BCD000DCA5C /* GoalManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E44CE782299338C500394E87 /* GoalManager.swift */; };
-		E458C8072AD11BDB000DCA5C /* Goal.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1F8F07A232C05410060B83E /* Goal.swift */; };
+		E458C8072AD11BDB000DCA5C /* BeeGoal.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1F8F07A232C05410060B83E /* BeeGoal.swift */; };
 		E458C8082AD11BFB000DCA5C /* DataPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4B0833C293810EB00A71564 /* DataPoint.swift */; };
 		E458C8092AD11C13000DCA5C /* SynchronizedBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = E462BA2D29A31C3B00E80EF0 /* SynchronizedBox.swift */; };
 		E458C80A2AD11C1C000DCA5C /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1C11B471B06F5D100D22871 /* Constants.swift */; };
@@ -311,7 +311,7 @@
 		A1E618E31E7934C700D8ED93 /* HealthKitConfigTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HealthKitConfigTableViewCell.swift; sourceTree = "<group>"; };
 		A1E618FF1E86980900D8ED93 /* HealthKitConfig.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HealthKitConfig.swift; sourceTree = "<group>"; };
 		A1EA154C1B01E6EC0052A6E6 /* DatapointTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatapointTableViewCell.swift; sourceTree = "<group>"; };
-		A1F8F07A232C05410060B83E /* Goal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Goal.swift; sourceTree = "<group>"; };
+		A1F8F07A232C05410060B83E /* BeeGoal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeeGoal.swift; sourceTree = "<group>"; };
 		A1F9D1E9211B9B7600E2BC93 /* EditDatapointViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditDatapointViewController.swift; sourceTree = "<group>"; };
 		E4040D732A7B5F0E008E7D0E /* WorkoutMinutesHealthKitMetric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutMinutesHealthKitMetric.swift; sourceTree = "<group>"; };
 		E41286ED2A62DF330093D598 /* BeeminderModel.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = BeeminderModel.xcdatamodel; sourceTree = "<group>"; };
@@ -720,7 +720,7 @@
 				E4B0833C293810EB00A71564 /* DataPoint.swift */,
 				E46FF15A2984C522009F8C7A /* DateUtils.swift */,
 				E45470272B60E24500EE648B /* Daystamp.swift */,
-				A1F8F07A232C05410060B83E /* Goal.swift */,
+				A1F8F07A232C05410060B83E /* BeeGoal.swift */,
 				E57BE6E32655EBDA00BA540B /* Info.plist */,
 				E44CE7722993317B00394E87 /* ServiceLocator.swift */,
 			);
@@ -1229,7 +1229,7 @@
 				E458C81D2AD11CEC000DCA5C /* UIDevice.swift in Sources */,
 				E458C8172AD11CA7000DCA5C /* TotalSleepMinutes.swift in Sources */,
 				E46071012B451FA400305DB4 /* BeeminderModel.xcdatamodeld in Sources */,
-				E458C8072AD11BDB000DCA5C /* Goal.swift in Sources */,
+				E458C8072AD11BDB000DCA5C /* BeeGoal.swift in Sources */,
 				E458C80D2AD11C64000DCA5C /* Crypto.swift in Sources */,
 				E458C8012AD11BB3000DCA5C /* RequestManager.swift in Sources */,
 			);

--- a/BeeSwift.xcodeproj/project.pbxproj
+++ b/BeeSwift.xcodeproj/project.pbxproj
@@ -67,7 +67,7 @@
 		E458C8052AD11BC8000DCA5C /* VersionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C161932423CE9F0045C90D /* VersionManager.swift */; };
 		E458C8062AD11BCD000DCA5C /* GoalManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E44CE782299338C500394E87 /* GoalManager.swift */; };
 		E458C8072AD11BDB000DCA5C /* BeeGoal.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1F8F07A232C05410060B83E /* BeeGoal.swift */; };
-		E458C8082AD11BFB000DCA5C /* DataPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4B0833C293810EB00A71564 /* DataPoint.swift */; };
+		E458C8082AD11BFB000DCA5C /* BeeDataPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4B0833C293810EB00A71564 /* BeeDataPoint.swift */; };
 		E458C8092AD11C13000DCA5C /* SynchronizedBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = E462BA2D29A31C3B00E80EF0 /* SynchronizedBox.swift */; };
 		E458C80A2AD11C1C000DCA5C /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1C11B471B06F5D100D22871 /* Constants.swift */; };
 		E458C80B2AD11C2B000DCA5C /* ServiceLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E44CE7722993317B00394E87 /* ServiceLocator.swift */; };
@@ -341,7 +341,7 @@
 		E48E271F2973261F008013C0 /* BackgroundUpdates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundUpdates.swift; sourceTree = "<group>"; };
 		E4B083382932F90400A71564 /* ConfigureHKMetricViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigureHKMetricViewController.swift; sourceTree = "<group>"; };
 		E4B0833A2934620500A71564 /* DatapointTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatapointTableViewController.swift; sourceTree = "<group>"; };
-		E4B0833C293810EB00A71564 /* DataPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataPoint.swift; sourceTree = "<group>"; };
+		E4B0833C293810EB00A71564 /* BeeDataPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeeDataPoint.swift; sourceTree = "<group>"; };
 		E4B6FEC52A776A2900690376 /* GoalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalTests.swift; sourceTree = "<group>"; };
 		E4E43D8729F39CE800697116 /* LogsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogsViewController.swift; sourceTree = "<group>"; };
 		E4E6427B2910C3AB004F3EA9 /* HealthKitMetric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthKitMetric.swift; sourceTree = "<group>"; };
@@ -717,7 +717,7 @@
 				E57BE6E22655EBDA00BA540B /* BeeKit.h */,
 				E55FEE6A23FF7552007C20B2 /* Config.swift */,
 				E5DF493624DC69A200260560 /* Config.swift.sample */,
-				E4B0833C293810EB00A71564 /* DataPoint.swift */,
+				E4B0833C293810EB00A71564 /* BeeDataPoint.swift */,
 				E46FF15A2984C522009F8C7A /* DateUtils.swift */,
 				E45470272B60E24500EE648B /* Daystamp.swift */,
 				A1F8F07A232C05410060B83E /* BeeGoal.swift */,
@@ -1213,7 +1213,7 @@
 				E458C8182AD11CAC000DCA5C /* TimeAsleepHealthKitMetric.swift in Sources */,
 				E458C80B2AD11C2B000DCA5C /* ServiceLocator.swift in Sources */,
 				E458C81B2AD11CD8000DCA5C /* UIColorExtension.swift in Sources */,
-				E458C8082AD11BFB000DCA5C /* DataPoint.swift in Sources */,
+				E458C8082AD11BFB000DCA5C /* BeeDataPoint.swift in Sources */,
 				E458C81C2AD11CDE000DCA5C /* UIFontExtension.swift in Sources */,
 				E458C81A2AD11CB5000DCA5C /* WorkoutMinutesHealthKitMetric.swift in Sources */,
 				E458C8112AD11C8B000DCA5C /* MindfulSessionHealthKitMetric.swift in Sources */,

--- a/BeeSwift/AppDelegate.swift
+++ b/BeeSwift/AppDelegate.swift
@@ -135,7 +135,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         logger.notice("Updating badge count")
 
         guard let goals = ServiceLocator.goalManager.staleGoals() else { return }
-        let beemergencyCount = goals.filter({ (goal: Goal) -> Bool in
+        let beemergencyCount = goals.filter({ (goal: BeeGoal) -> Bool in
             return goal.safebuf.intValue < 1
         }).count
         logger.notice("Beemergency count is \(beemergencyCount, privacy: .public)")

--- a/BeeSwift/Components/DatapointTableViewController.swift
+++ b/BeeSwift/Components/DatapointTableViewController.swift
@@ -12,7 +12,7 @@ import UIKit
 import BeeKit
 
 protocol DatapointTableViewControllerDelegate {
-    func datapointTableViewController(_ datapointTableViewController: DatapointTableViewController, didSelectDatapoint datapoint: DataPoint)
+    func datapointTableViewController(_ datapointTableViewController: DatapointTableViewController, didSelectDatapoint datapoint: BeeDataPoint)
 }
 
 class DatapointTableViewController : UIViewController, UITableViewDelegate, UITableViewDataSource {
@@ -22,7 +22,7 @@ class DatapointTableViewController : UIViewController, UITableViewDelegate, UITa
 
     public var delegate : DatapointTableViewControllerDelegate?
 
-    public var datapoints : [DataPoint] = [] {
+    public var datapoints : [BeeDataPoint] = [] {
         didSet {
             // Cause the table to re-render to pick up the change to rows
             self.datapointsTableView.reloadData()
@@ -83,7 +83,7 @@ class DatapointTableViewController : UIViewController, UITableViewDelegate, UITa
         self.delegate?.datapointTableViewController(self, didSelectDatapoint: datapoint)
     }
 
-    func displayText(datapoint: DataPoint) -> String {
+    func displayText(datapoint: BeeDataPoint) -> String {
         let day = datapoint.daystamp.day
 
         var formattedValue: String

--- a/BeeSwift/Components/GoalImageView.swift
+++ b/BeeSwift/Components/GoalImageView.swift
@@ -21,7 +21,7 @@ class GoalImageView : UIView {
 
     public let isThumbnail: Bool
 
-    public var goal: Goal? {
+    public var goal: BeeGoal? {
         didSet {
             // If changed to a different goal, remove any current state
             if goal !== oldValue {

--- a/BeeSwift/EditDatapointViewController.swift
+++ b/BeeSwift/EditDatapointViewController.swift
@@ -19,12 +19,12 @@ class EditDatapointViewController: UIViewController, UITextFieldDelegate {
     private let margin = 10
     
     var datapoint : ExistingDataPoint
-    var goal : Goal!
+    var goal : BeeGoal!
     fileprivate var datePicker = InlineDatePicker()
     fileprivate var valueField = UITextField()
     fileprivate var commentField = UITextField()
 
-    init(goal: Goal, datapoint: ExistingDataPoint) {
+    init(goal: BeeGoal, datapoint: ExistingDataPoint) {
         self.goal = goal
         self.datapoint = datapoint
         super.init(nibName: nil, bundle: nil)

--- a/BeeSwift/Gallery/GalleryViewController.swift
+++ b/BeeSwift/Gallery/GalleryViewController.swift
@@ -33,8 +33,8 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
     var lastUpdated: Date?
     let maxSearchBarHeight: Int = 50
     
-    var goals : Array<Goal> = []
-    var filteredGoals : Array<Goal> = []
+    var goals : Array<BeeGoal> = []
+    var filteredGoals : Array<BeeGoal> = []
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -474,7 +474,7 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell:GoalCollectionViewCell = self.collectionView!.dequeueReusableCell(withReuseIdentifier: self.cellReuseIdentifier, for: indexPath) as! GoalCollectionViewCell
         
-        let goal:Goal = self.filteredGoals[(indexPath as NSIndexPath).row]
+        let goal:BeeGoal = self.filteredGoals[(indexPath as NSIndexPath).row]
         
         cell.goal = goal
         
@@ -509,7 +509,7 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
         }
     }
     
-    func openGoal(_ goal: Goal) {
+    func openGoal(_ goal: BeeGoal) {
         let goalViewController = GoalViewController()
         goalViewController.goal = goal
         self.navigationController?.pushViewController(goalViewController, animated: true)

--- a/BeeSwift/GoalCollectionViewCell.swift
+++ b/BeeSwift/GoalCollectionViewCell.swift
@@ -18,7 +18,7 @@ class GoalCollectionViewCell: UICollectionViewCell {
     let safesumLabel :BSLabel = BSLabel()
     let margin = 8
     
-    var goal: Goal? {
+    var goal: BeeGoal? {
         didSet {
             self.thumbnailImageView.goal = goal
             self.titleLabel.text = goal?.title

--- a/BeeSwift/GoalViewController.swift
+++ b/BeeSwift/GoalViewController.swift
@@ -22,7 +22,7 @@ class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTabl
 
     private let logger = Logger(subsystem: "com.beeminder.com", category: "GoalViewController")
 
-    var goal : Goal!
+    var goal : BeeGoal!
 
     fileprivate var goalImageView = GoalImageView(isThumbnail: false)
     fileprivate var datapointTableController = DatapointTableViewController()

--- a/BeeSwift/GoalViewController.swift
+++ b/BeeSwift/GoalViewController.swift
@@ -382,7 +382,7 @@ class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTabl
         self.goalImageScrollView.setZoomScale(self.goalImageScrollView.zoomScale == 1.0 ? 2.0 : 1.0, animated: true)
     }
 
-    func datapointTableViewController(_ datapointTableViewController: DatapointTableViewController, didSelectDatapoint datapoint: DataPoint) {
+    func datapointTableViewController(_ datapointTableViewController: DatapointTableViewController, didSelectDatapoint datapoint: BeeDataPoint) {
         guard !self.goal.hideDataEntry() else { return }
         guard let existingDatapoint = datapoint as? ExistingDataPoint else { return }
 

--- a/BeeSwift/HealthKitConfigTableViewCell.swift
+++ b/BeeSwift/HealthKitConfigTableViewCell.swift
@@ -12,7 +12,7 @@ import BeeKit
 
 class HealthKitConfigTableViewCell: UITableViewCell {
 
-    var goal : Goal? {
+    var goal : BeeGoal? {
         didSet {
             self.goalnameLabel.text = self.goal?.slug
             self.autodataNameLabel.text = self.goal?.humanizedAutodata

--- a/BeeSwift/Settings/ChooseHKMetricViewController.swift
+++ b/BeeSwift/Settings/ChooseHKMetricViewController.swift
@@ -17,7 +17,7 @@ class ChooseHKMetricViewController: UIViewController {
     fileprivate let cellReuseIdentifier = "hkMetricTableViewCell"
     fileprivate let headerReusedIdentifier = "hkMetricTableHeader"
     fileprivate var tableView = UITableView()
-    var goal : Goal!
+    var goal : BeeGoal!
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/BeeSwift/Settings/ConfigureHKMetricViewController.swift
+++ b/BeeSwift/Settings/ConfigureHKMetricViewController.swift
@@ -12,7 +12,7 @@ class ConfigureHKMetricViewController : UIViewController {
 
     let componentMargin = 10
 
-    private let goal: Goal
+    private let goal: BeeGoal
     private let metric: HealthKitMetric
 
     let previewDescriptionLabel = BSLabel()
@@ -20,7 +20,7 @@ class ConfigureHKMetricViewController : UIViewController {
     fileprivate let noDataFoundLabel = BSLabel()
     let saveButton = BSButton()
 
-    init(goal: Goal, metric : HealthKitMetric) {
+    init(goal: BeeGoal, metric : HealthKitMetric) {
         self.goal = goal
         self.metric = metric
         super.init(nibName: nil, bundle: nil)

--- a/BeeSwift/Settings/ConfigureNotificationsViewController.swift
+++ b/BeeSwift/Settings/ConfigureNotificationsViewController.swift
@@ -15,7 +15,7 @@ import BeeKit
 class ConfigureNotificationsViewController: UIViewController {
     private let logger = Logger(subsystem: "com.beeminder.beeminder", category: "ConfigureNotificationsViewController")
     
-    fileprivate var goals : [Goal] = []
+    fileprivate var goals : [BeeGoal] = []
     fileprivate var cellReuseIdentifier = "configureNotificationsTableViewCell"
     fileprivate var tableView = UITableView()
     fileprivate let settingsButton = BSButton()

--- a/BeeSwift/Settings/EditGoalNotificationsViewController.swift
+++ b/BeeSwift/Settings/EditGoalNotificationsViewController.swift
@@ -15,14 +15,14 @@ import BeeKit
 class EditGoalNotificationsViewController : EditNotificationsViewController {
     private let logger = Logger(subsystem: "com.beeminder.beeminder", category: "EditGoalNotificationsViewController")
 
-    var goal : Goal? {
+    var goal : BeeGoal? {
         didSet {
 
         }
     }
     fileprivate var useDefaultsSwitch = UISwitch()
     
-    init(goal : Goal) {
+    init(goal : BeeGoal) {
         super.init()
         self.goal = goal
         self.leadTimeStepper.value = goal.leadtime!.doubleValue

--- a/BeeSwift/Settings/HealthKitConfigViewController.swift
+++ b/BeeSwift/Settings/HealthKitConfigViewController.swift
@@ -18,7 +18,7 @@ class HealthKitConfigViewController: UIViewController {
     private let logger = Logger(subsystem: "com.beeminder.beeminder", category: "HealthKitConfigViewController")
     
     var tableView = UITableView()
-    var goals : [Goal] = []
+    var goals : [BeeGoal] = []
     let cellReuseIdentifier = "healthKitConfigTableViewCell"
     let margin = 12
     
@@ -131,7 +131,7 @@ extension HealthKitConfigViewController: UITableViewDelegate, UITableViewDataSou
         }
     }
     
-    private func goalAt(_ indexPath: IndexPath) -> Goal {
+    private func goalAt(_ indexPath: IndexPath) -> BeeGoal {
         if indexPath.section == 0 {
             return self.manualSourced[indexPath.row]
         } else if indexPath.section == 1 {
@@ -164,21 +164,21 @@ extension HealthKitConfigViewController: UITableViewDelegate, UITableViewDataSou
 }
 
 extension HealthKitConfigViewController {
-    var autoSourced: [Goal] {
+    var autoSourced: [BeeGoal] {
         return self.goals.filter { $0.isDataProvidedAutomatically }
     }
     
-    var manualSourced: [Goal] {
+    var manualSourced: [BeeGoal] {
         return self.goals.filter { !$0.isDataProvidedAutomatically }
     }
     
-    var autoSourcedModifiable: [Goal] {
+    var autoSourcedModifiable: [BeeGoal] {
         return self.autoSourced.filter { goal -> Bool in
             return "Apple".localizedCaseInsensitiveCompare(goal.autodata) == ComparisonResult.orderedSame
         }
     }
     
-    var autoSourcedUnmodifiable: [Goal] {
+    var autoSourcedUnmodifiable: [BeeGoal] {
         return self.autoSourced.filter { goal -> Bool in
             return "Apple".localizedCaseInsensitiveCompare(goal.autodata) != ComparisonResult.orderedSame
         }

--- a/BeeSwift/Settings/RemoveHKMetricViewController.swift
+++ b/BeeSwift/Settings/RemoveHKMetricViewController.swift
@@ -15,7 +15,7 @@ import BeeKit
 class RemoveHKMetricViewController: UIViewController {
     private let logger = Logger(subsystem: "com.beeminder.beeminder", category: "RemoveHKMetricViewController")
     
-    var goal : Goal!
+    var goal : BeeGoal!
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -77,7 +77,7 @@ class RemoveHKMetricViewController: UIViewController {
             do {
                 let responseObject = try await ServiceLocator.requestManager.put(url: "api/v1/users/{username}/goals/\(self.goal!.slug).json", parameters: params)
 
-                self.goal = Goal(json: JSON(responseObject!))
+                self.goal = BeeGoal(json: JSON(responseObject!))
 
                 hud.mode = .customView
                 hud.customView = UIImageView(image: UIImage(named: "BasicCheckmark"))

--- a/BeeSwift/TimerViewController.swift
+++ b/BeeSwift/TimerViewController.swift
@@ -16,7 +16,7 @@ class TimerViewController: UIViewController {
     
     let timerLabel = BSLabel()
     let startStopButton = BSButton()
-    var goal : Goal?
+    var goal : BeeGoal?
     var timingSince: Date?
     var timer: Timer?
     var slug: String?

--- a/BeeSwiftTests/GoalTests.swift
+++ b/BeeSwiftTests/GoalTests.swift
@@ -83,7 +83,7 @@ final class GoalTests: XCTestCase {
         }
         """)
 
-        let goal = Goal(json: testJSON)
+        let goal = BeeGoal(json: testJSON)
 
         XCTAssertEqual(goal.slug, "test-goal")
         XCTAssertEqual(goal.title, "Goal for Testing Purposes")
@@ -117,7 +117,7 @@ final class GoalTests: XCTestCase {
             ["value": 2, "daystamp": "20221126"],
             ["value": 3.5, "daystamp": "20221125"],
         ]
-        let goal = Goal(json: testJSON)
+        let goal = BeeGoal(json: testJSON)
 
         XCTAssertEqual(goal.suggestedNextValue, 1)
     }
@@ -125,7 +125,7 @@ final class GoalTests: XCTestCase {
     func testSuggestedNextValueEmptyIfNoData() throws {
         var testJSON = requiredGoalJson()
         testJSON["recent_data"] = []
-        let goal = Goal(json: testJSON)
+        let goal = BeeGoal(json: testJSON)
 
         XCTAssertEqual(goal.suggestedNextValue, nil)
     }
@@ -140,7 +140,7 @@ final class GoalTests: XCTestCase {
             ["value": 2, "daystamp": "20221126"],
             ["value": 3.5, "daystamp": "20221125"],
         ]
-        let goal = Goal(json: testJSON)
+        let goal = BeeGoal(json: testJSON)
 
         XCTAssertEqual(goal.suggestedNextValue, 2)
     }


### PR DESCRIPTION
As part of changing the underlying local cache from memory to CoreData we will be introducing new Goal and DataPoint types. These are difficult to rename after creation, so to make room for them rename the existing memory backed types.

Testing:
Verify the code still compiles