### PR TITLE
Store goal information in CoreData

### DIFF
--- a/BeeKit/Managers/CurrentUserManager.swift
+++ b/BeeKit/Managers/CurrentUserManager.swift
@@ -9,6 +9,7 @@
 import CoreData
 import Foundation
 import KeychainSwift
+import OSLog
 import SwiftyJSON
 
 public class CurrentUserManager {
@@ -82,7 +83,7 @@ public class CurrentUserManager {
             let request = NSFetchRequest<User>(entityName: "User")
             let requestContext = context ?? container.newBackgroundContext()
             let users = try requestContext.fetch(request)
-            return users?.first
+            return users.first
         } catch {
             logger.error("Unable to fetch users \(error)")
             return nil

--- a/BeeKit/Managers/CurrentUserManager.swift
+++ b/BeeKit/Managers/CurrentUserManager.swift
@@ -75,7 +75,7 @@ public class CurrentUserManager {
     }
 
 
-    private func user(context: NSManagedObjectContext? = nil) -> User? {
+    func user(context: NSManagedObjectContext? = nil) -> User? {
         // Fetch a user from the persistent store
         let request = NSFetchRequest<User>(entityName: "User")
         // TODO: Handle (or at least log) an error here

--- a/BeeKit/Managers/CurrentUserManager.swift
+++ b/BeeKit/Managers/CurrentUserManager.swift
@@ -12,6 +12,8 @@ import KeychainSwift
 import SwiftyJSON
 
 public class CurrentUserManager {
+    let logger = Logger(subsystem: "com.beeminder.beeminder", category: "CurrentUserManager")
+
     public static let signedInNotificationName     = "com.beeminder.signedInNotification"
     public static let willSignOutNotificationName  = "com.beeminder.willSignOutNotification"
     public static let failedSignInNotificationName = "com.beeminder.failedSignInNotification"
@@ -76,11 +78,15 @@ public class CurrentUserManager {
 
 
     func user(context: NSManagedObjectContext? = nil) -> User? {
-        // Fetch a user from the persistent store
-        let request = NSFetchRequest<User>(entityName: "User")
-        // TODO: Handle (or at least log) an error here
-        let users = try? (context ?? container.newBackgroundContext()).fetch(request)
-        return users?.first
+        do {
+            let request = NSFetchRequest<User>(entityName: "User")
+            let requestContext = context ?? container.newBackgroundContext()
+            let users = try requestContext.fetch(request)
+            return users?.first
+        } catch {
+            logger.error("Unable to fetch users \(error)")
+            return nil
+        }
     }
 
     private func modifyUser(_ callback: (User)->()) throws {

--- a/BeeKit/Managers/GoalManager.swift
+++ b/BeeKit/Managers/GoalManager.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import CoreData
 import SwiftyJSON
 import OSLog
 import OrderedCollections
@@ -22,6 +23,7 @@ public actor GoalManager {
 
     private let requestManager: RequestManager
     private let currentUserManager: CurrentUserManager
+    private let container: BeeminderPersistentContainer
 
     /// The known set of goals
     /// Has two slightly differenty empty states. If nil, it means we have not fetched goals. If an empty dictionary, means we have
@@ -33,9 +35,10 @@ public actor GoalManager {
 
     private var queuedGoalsBackgroundTaskRunning : Bool = false
 
-    init(requestManager: RequestManager, currentUserManager: CurrentUserManager) {
+    init(requestManager: RequestManager, currentUserManager: CurrentUserManager, container: BeeminderPersistentContainer) {
         self.requestManager = requestManager
         self.currentUserManager = currentUserManager
+        self.container = container
 
         // Load any cached goals from previous app invocation
         if let goalJSON = self.cachedLastFetchedGoals() {
@@ -99,6 +102,7 @@ public actor GoalManager {
             return nil
         }
 
+        // Update memory goals representation
         let existingGoals = self.goalsBox.get() ?? OrderedDictionary()
 
         for goalJSON in responseGoals {
@@ -113,6 +117,35 @@ public actor GoalManager {
         }
 
         self.goalsBox.set(updatedGoals)
+
+        //  Update CoreData representation
+        let context = container.newBackgroundContext()
+        // TODO: Better error handling of null here?
+        let user = self.currentUserManager.user(context: context)!
+
+        // Create and update existing goals
+        for goalJSON in responseGoals {
+            let goalId = goalJSON["id"].stringValue
+            let request = NSFetchRequest<Goal>(entityName: "Goal")
+            request.predicate = NSPredicate(format: "id == %@", goalId)
+            // TODO: Better error handling of failure here?
+            if let existingGoal = try! context.fetch(request).first {
+                existingGoal.updateToMatch(json: goalJSON)
+            } else {
+                let _ = Goal(context: context, owner: user, json: goalJSON)
+            }
+        }
+
+        // Remove any deleted goals
+        let allGoalIds = Set(responseGoals.map { $0["id"].stringValue })
+        let goalsToDelete = user.goals.filter { !allGoalIds.contains($0.id) }
+        for goal in goalsToDelete {
+            context.delete(goal)
+        }
+
+        // TODO: Better error handling here?
+        try! context.save()
+
         return updatedGoals
     }
 

--- a/BeeKit/Model/BeeminderModel.xcdatamodeld/BeeminderModel.xcdatamodel/contents
+++ b/BeeKit/Model/BeeminderModel.xcdatamodeld/BeeminderModel.xcdatamodel/contents
@@ -15,6 +15,6 @@
         <attribute name="defaultLeadTime" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO"/>
         <attribute name="timezone" attributeType="String"/>
         <attribute name="username" attributeType="String"/>
-        <relationship name="goals" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Goal" inverseName="owner" inverseEntity="Goal"/>
+        <relationship name="goals" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Goal" inverseName="owner" inverseEntity="Goal"/>
     </entity>
 </model>

--- a/BeeKit/Model/BeeminderModel.xcdatamodeld/BeeminderModel.xcdatamodel/contents
+++ b/BeeKit/Model/BeeminderModel.xcdatamodeld/BeeminderModel.xcdatamodel/contents
@@ -1,16 +1,32 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22757" systemVersion="23E224" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22758" systemVersion="23E224" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="DataPoint" representedClassName="DataPoint" syncable="YES">
         <attribute name="id" optional="YES" attributeType="String"/>
     </entity>
     <entity name="Goal" representedClassName="Goal" syncable="YES">
+        <attribute name="alertStart" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="autodata" optional="YES" attributeType="String"/>
-        <attribute name="deadline" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="deadline" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="graphUrl" attributeType="String"/>
+        <attribute name="healthKitMetric" optional="YES" attributeType="String"/>
+        <attribute name="hhmmFormat" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="id" attributeType="String"/>
+        <attribute name="initDay" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="lastTouch" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="leadTime" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="limSum" attributeType="String"/>
+        <attribute name="pledge" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="queued" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="safeBuf" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="safeSum" attributeType="String"/>
         <attribute name="slug" attributeType="String"/>
         <attribute name="thumbUrl" attributeType="String"/>
+        <attribute name="title" attributeType="String"/>
+        <attribute name="todayta" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="urgencyKey" attributeType="String"/>
+        <attribute name="useDefaults" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="won" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="yAxis" attributeType="String"/>
         <relationship name="owner" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User" inverseName="goals" inverseEntity="User"/>
     </entity>
     <entity name="User" representedClassName=".User" syncable="YES">

--- a/BeeKit/Model/BeeminderModel.xcdatamodeld/BeeminderModel.xcdatamodel/contents
+++ b/BeeKit/Model/BeeminderModel.xcdatamodeld/BeeminderModel.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22758" systemVersion="23E224" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22758" systemVersion="23F79" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="DataPoint" representedClassName="DataPoint" syncable="YES">
         <attribute name="id" optional="YES" attributeType="String"/>
     </entity>
@@ -36,6 +36,6 @@
         <attribute name="defaultLeadTime" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO"/>
         <attribute name="timezone" attributeType="String"/>
         <attribute name="username" attributeType="String"/>
-        <relationship name="goals" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Goal" inverseName="owner" inverseEntity="Goal"/>
+        <relationship name="goals" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Goal" inverseName="owner" inverseEntity="Goal"/>
     </entity>
 </model>

--- a/BeeKit/Model/BeeminderModel.xcdatamodeld/BeeminderModel.xcdatamodel/contents
+++ b/BeeKit/Model/BeeminderModel.xcdatamodeld/BeeminderModel.xcdatamodel/contents
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22757" systemVersion="23E224" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
-    <entity name="DataPoint" representedClassName="DataPoint" syncable="YES" codeGenerationType="class"/>
+    <entity name="DataPoint" representedClassName="DataPoint" syncable="YES">
+        <attribute name="id" optional="YES" attributeType="String"/>
+    </entity>
     <entity name="Goal" representedClassName="Goal" syncable="YES">
         <attribute name="id" attributeType="String"/>
         <attribute name="slug" attributeType="String"/>

--- a/BeeKit/Model/BeeminderModel.xcdatamodeld/BeeminderModel.xcdatamodel/contents
+++ b/BeeKit/Model/BeeminderModel.xcdatamodeld/BeeminderModel.xcdatamodel/contents
@@ -4,8 +4,13 @@
         <attribute name="id" optional="YES" attributeType="String"/>
     </entity>
     <entity name="Goal" representedClassName="Goal" syncable="YES">
+        <attribute name="autodata" optional="YES" attributeType="String"/>
+        <attribute name="deadline" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="id" attributeType="String"/>
+        <attribute name="limSum" attributeType="String"/>
         <attribute name="slug" attributeType="String"/>
+        <attribute name="thumbUrl" attributeType="String"/>
+        <attribute name="won" attributeType="Boolean" usesScalarValueType="YES"/>
         <relationship name="owner" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User" inverseName="goals" inverseEntity="User"/>
     </entity>
     <entity name="User" representedClassName=".User" syncable="YES">

--- a/BeeKit/Model/BeeminderModel.xcdatamodeld/BeeminderModel.xcdatamodel/contents
+++ b/BeeKit/Model/BeeminderModel.xcdatamodeld/BeeminderModel.xcdatamodel/contents
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22757" systemVersion="23D60" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22757" systemVersion="23E224" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="DataPoint" representedClassName="DataPoint" syncable="YES" codeGenerationType="class"/>
-    <entity name="Goal" representedClassName="Goal" syncable="YES" codeGenerationType="class">
+    <entity name="Goal" representedClassName="Goal" syncable="YES">
+        <attribute name="id" attributeType="String"/>
+        <attribute name="slug" attributeType="String"/>
         <relationship name="owner" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User" inverseName="goals" inverseEntity="User"/>
     </entity>
     <entity name="User" representedClassName=".User" syncable="YES">

--- a/BeeKit/Model/BeeminderModel.xcdatamodeld/BeeminderModel.xcdatamodel/contents
+++ b/BeeKit/Model/BeeminderModel.xcdatamodeld/BeeminderModel.xcdatamodel/contents
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22522" systemVersion="23C71" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22757" systemVersion="23D60" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="DataPoint" representedClassName="DataPoint" syncable="YES" codeGenerationType="class"/>
+    <entity name="Goal" representedClassName="Goal" syncable="YES" codeGenerationType="class">
+        <relationship name="owner" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User" inverseName="goals" inverseEntity="User"/>
+    </entity>
     <entity name="User" representedClassName=".User" syncable="YES">
         <attribute name="deadbeat" attributeType="Boolean" usesScalarValueType="NO"/>
         <attribute name="defaultAlertStart" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO"/>
@@ -7,5 +11,6 @@
         <attribute name="defaultLeadTime" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO"/>
         <attribute name="timezone" attributeType="String"/>
         <attribute name="username" attributeType="String"/>
+        <relationship name="goals" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Goal" inverseName="owner" inverseEntity="Goal"/>
     </entity>
 </model>

--- a/BeeKit/Model/DataPoint.swift
+++ b/BeeKit/Model/DataPoint.swift
@@ -1,6 +1,7 @@
 import Foundation
 import CoreData
 
+@objc(DataPoint)
 public class DataPoint: NSManagedObject {
     @NSManaged public var id: String
 

--- a/BeeKit/Model/DataPoint.swift
+++ b/BeeKit/Model/DataPoint.swift
@@ -1,0 +1,27 @@
+import Foundation
+import CoreData
+
+public class DataPoint: NSManagedObject {
+    @NSManaged public var id: String
+
+    public init(context: NSManagedObjectContext, id: String) {
+        let entity = NSEntityDescription.entity(forEntityName: "DataPoint", in: context)!
+        super.init(entity: entity, insertInto: context)
+        self.id = id
+    }
+
+    @available(*, unavailable)
+    public init() {
+        fatalError()
+    }
+
+    @available(*, unavailable)
+    public init(context: NSManagedObjectContext) {
+        fatalError()
+    }
+
+    public override init(entity: NSEntityDescription, insertInto: NSManagedObjectContext?) {
+        super.init(entity: entity, insertInto: insertInto)
+    }
+
+}

--- a/BeeKit/Model/Goal.swift
+++ b/BeeKit/Model/Goal.swift
@@ -3,6 +3,7 @@ import CoreData
 
 import SwiftyJSON
 
+@objc(Goal)
 public class Goal: NSManagedObject {
     @NSManaged public var owner: User
     @NSManaged public var id: String
@@ -22,7 +23,7 @@ public class Goal: NSManagedObject {
         super.init(entity: entity, insertInto: context)
         self.owner = owner
         self.id = json["id"].stringValue
-        
+
         self.updateToMatch(json: json)
     }
 

--- a/BeeKit/Model/Goal.swift
+++ b/BeeKit/Model/Goal.swift
@@ -1,6 +1,8 @@
 import Foundation
 import CoreData
 
+import SwiftyJSON
+
 public class Goal: NSManagedObject {
     @NSManaged public var owner: User
     @NSManaged public var id: String
@@ -12,6 +14,16 @@ public class Goal: NSManagedObject {
         self.owner = owner
         self.id = id
         self.slug = slug
+    }
+
+    // Question: Should this type know about JSON, or should there be an adapter / extension?
+    public init(context: NSManagedObjectContext, owner: User, json: JSON) {
+        let entity = NSEntityDescription.entity(forEntityName: "Goal", in: context)!
+        super.init(entity: entity, insertInto: context)
+        self.owner = owner
+        self.id = json["id"].stringValue
+        
+        self.updateToMatch(json: json)
     }
 
     @available(*, unavailable)
@@ -26,5 +38,9 @@ public class Goal: NSManagedObject {
 
     public override init(entity: NSEntityDescription, insertInto: NSManagedObjectContext?) {
         super.init(entity: entity, insertInto: insertInto)
+    }
+
+    public func updateToMatch(json: JSON) {
+        self.slug = json["slug"].stringValue
     }
 }

--- a/BeeKit/Model/Goal.swift
+++ b/BeeKit/Model/Goal.swift
@@ -50,6 +50,12 @@ public class Goal: NSManagedObject {
     // Question: Should this type know about JSON, or should there be an adapter / extension?
     public func updateToMatch(json: JSON) {
         self.slug = json["slug"].stringValue
+
+        self.autodata = json["autodata"].string
+        self.deadline = json["deadline"].intValue
+        self.limSum = json["limsum"].stringValue
+        self.thumbUrl = json["thumb_url"].stringValue
+        self.won = json["won"].boolValue
     }
 
     public var isDataProvidedAutomatically: Bool {

--- a/BeeKit/Model/Goal.swift
+++ b/BeeKit/Model/Goal.swift
@@ -1,0 +1,28 @@
+import Foundation
+import CoreData
+
+public class Goal: NSManagedObject {
+    @NSManaged public var id: String
+    @NSManaged public var slug: String
+
+    public init(context: NSManagedObjectContext, id: String, slug: String) {
+        let entity = NSEntityDescription.entity(forEntityName: "Goal", in: context)!
+        super.init(entity: entity, insertInto: context)
+        self.id = id
+        self.slug = slug
+    }
+
+    @available(*, unavailable)
+    public init() {
+        fatalError()
+    }
+
+    @available(*, unavailable)
+    public init(context: NSManagedObjectContext) {
+        fatalError()
+    }
+
+    public override init(entity: NSEntityDescription, insertInto: NSManagedObjectContext?) {
+        super.init(entity: entity, insertInto: insertInto)
+    }
+}

--- a/BeeKit/Model/Goal.swift
+++ b/BeeKit/Model/Goal.swift
@@ -40,7 +40,8 @@ public class Goal: NSManagedObject {
     public override init(entity: NSEntityDescription, insertInto: NSManagedObjectContext?) {
         super.init(entity: entity, insertInto: insertInto)
     }
-
+    
+    // Question: Should this type know about JSON, or should there be an adapter / extension?
     public func updateToMatch(json: JSON) {
         self.slug = json["slug"].stringValue
     }

--- a/BeeKit/Model/Goal.swift
+++ b/BeeKit/Model/Goal.swift
@@ -9,6 +9,12 @@ public class Goal: NSManagedObject {
     @NSManaged public var id: String
     @NSManaged public var slug: String
 
+    @NSManaged public var autodata: String?
+    @NSManaged public var deadline: Int
+    @NSManaged public var limSum: String
+    @NSManaged public var thumbUrl: String
+    @NSManaged public var won: Bool
+
     public init(context: NSManagedObjectContext, owner: User, id: String, slug: String) {
         let entity = NSEntityDescription.entity(forEntityName: "Goal", in: context)!
         super.init(entity: entity, insertInto: context)
@@ -44,5 +50,17 @@ public class Goal: NSManagedObject {
     // Question: Should this type know about JSON, or should there be an adapter / extension?
     public func updateToMatch(json: JSON) {
         self.slug = json["slug"].stringValue
+    }
+
+    public var isDataProvidedAutomatically: Bool {
+        guard let autodata = self.autodata else {
+            return false
+        }
+        return !autodata.isEmpty
+    }
+
+    public var hideDataEntry: Bool {
+        // TODO: Implement this
+        return isDataProvidedAutomatically || won
     }
 }

--- a/BeeKit/Model/Goal.swift
+++ b/BeeKit/Model/Goal.swift
@@ -9,18 +9,102 @@ public class Goal: NSManagedObject {
     @NSManaged public var id: String
     @NSManaged public var slug: String
 
+    /// Seconds after midnight that we start sending you reminders (on the day that you're scheduled to start getting them).
+    @NSManaged public var alertStart: Int64
+    /// The name of automatic data source, if this goal has one. Will be null for manual goals.
     @NSManaged public var autodata: String?
+    /// Seconds by which your deadline differs from midnight. Negative is before midnight, positive is after midnight. Allowed range is -17*3600 to 6*3600 (7am to 6am).
     @NSManaged public var deadline: Int
+    /// URL for the goal's graph image. E.g., "http://static.beeminder.com/alice/weight.png".
+    @NSManaged public var graphUrl: String
+    /// The internal app identifier for the healthkit metric to sync to this goal
+    @NSManaged public var healthKitMetric: String
+    /// Whether to show data in a "timey" way, with colons. For example, this would make a 1.5 show up as 1:30.
+    @NSManaged public var hhmmFormat: Bool
+    /// Unix timestamp (in seconds) of the start of the bright red line.
+    @NSManaged public var initDay: Int64
+    /// Undocumented.
+    @NSManaged public var lastTouch: Int64
+    /// Summary of what you need to do to eke by, e.g., "+2 within 1 day".
     @NSManaged public var limSum: String
+    /// Days before derailing we start sending you reminders. Zero means we start sending them on the beemergency day, when you will derail later that day.
+    @NSManaged public var leadTime: Int64
+    /// Amount pledged (USD) on the goal.
+    @NSManaged public var pledge: Int64
+    /// Whether the graph is currently being updated to reflect new data.
+    @NSManaged public var queued: Bool
+    /// The integer number of safe days. If it's a beemergency this will be zero.
+    @NSManaged public var safeBuf: Int64
+    /// Undocumented
+    @NSManaged public var safeSum: String
+    /// URL for the goal's graph thumbnail image. E.g., "http://static.beeminder.com/alice/weight-thumb.png".
     @NSManaged public var thumbUrl: String
+    /// The title that the user specified for the goal. E.g., "Weight Loss".
+    @NSManaged public var title: String
+    /// Whether there are any datapoints for today.
+    @NSManaged public var todayta: Bool
+    /// Sort by this key to put the goals in order of decreasing urgency. (Case-sensitive ascii or unicode sorting is assumed).
+    @NSManaged public var urgencyKey: String
+    /// Undocumented
+    @NSManaged public var useDefaults: Bool
+    /// Whether the goal has been successfully completed.
     @NSManaged public var won: Bool
+    /// The label for the y-axis of the graph. E.g., "Cumulative total hours".
+    @NSManaged public var yAxis: String
 
-    public init(context: NSManagedObjectContext, owner: User, id: String, slug: String) {
+    public init(
+        context: NSManagedObjectContext,
+        owner: User,
+        id: String,
+        slug: String,
+        alertStart: Int64,
+        autodata: String?,
+        deadline: Int,
+        graphUrl: String,
+        healthKitMetric: String,
+        hhmmFormat: Bool,
+        initDay: Int64,
+        lastTouch: Int64,
+        limSum: String,
+        leadTime: Int64,
+        pledge: Int64,
+        queued: Bool,
+        safeBuf: Int64,
+        safeSum: String,
+        thumbUrl: String,
+        title: String,
+        todayta: Bool,
+        urgencyKey: String,
+        useDefaults: Bool,
+        won: Bool,
+        yAxis: String
+    ) {
         let entity = NSEntityDescription.entity(forEntityName: "Goal", in: context)!
         super.init(entity: entity, insertInto: context)
         self.owner = owner
         self.id = id
         self.slug = slug
+        self.alertStart = alertStart
+        self.autodata = autodata
+        self.deadline = deadline
+        self.graphUrl = graphUrl
+        self.healthKitMetric = healthKitMetric
+        self.hhmmFormat = hhmmFormat
+        self.initDay = initDay
+        self.lastTouch = lastTouch
+        self.limSum = limSum
+        self.leadTime = leadTime
+        self.pledge = pledge
+        self.queued = queued
+        self.safeBuf = safeBuf
+        self.safeSum = safeSum
+        self.thumbUrl = thumbUrl
+        self.title = title
+        self.todayta = todayta
+        self.urgencyKey = urgencyKey
+        self.useDefaults = useDefaults
+        self.won = won
+        self.yAxis = yAxis
     }
 
     // Question: Should this type know about JSON, or should there be an adapter / extension?
@@ -51,11 +135,27 @@ public class Goal: NSManagedObject {
     public func updateToMatch(json: JSON) {
         self.slug = json["slug"].stringValue
 
+        self.alertStart = json["alertstart"].int64Value
         self.autodata = json["autodata"].string
         self.deadline = json["deadline"].intValue
+        self.graphUrl = json["graph_url"].stringValue
+        self.healthKitMetric = json["healthkitmetric"].stringValue
+        self.hhmmFormat = json["hhmmformat"].boolValue
+        self.initDay = json["initday"].int64Value
+        self.lastTouch = json["updated_at"].int64Value
         self.limSum = json["limsum"].stringValue
+        self.leadTime = json["leadtime"].int64Value
+        self.pledge = json["pledge"].int64Value
+        self.queued = json["queued"].boolValue
+        self.safeBuf = json["safebuf"].int64Value
+        self.safeSum = json["safesum"].stringValue
         self.thumbUrl = json["thumb_url"].stringValue
+        self.title = json["title"].stringValue
+        self.todayta = json["todayta"].boolValue
+        self.urgencyKey = json["urgencykey"].stringValue
+        self.useDefaults = json["use_defaults"].boolValue
         self.won = json["won"].boolValue
+        self.yAxis = json["yaxis"].stringValue
     }
 
     public var isDataProvidedAutomatically: Bool {

--- a/BeeKit/Model/Goal.swift
+++ b/BeeKit/Model/Goal.swift
@@ -2,12 +2,14 @@ import Foundation
 import CoreData
 
 public class Goal: NSManagedObject {
+    @NSManaged public var owner: User
     @NSManaged public var id: String
     @NSManaged public var slug: String
 
-    public init(context: NSManagedObjectContext, id: String, slug: String) {
+    public init(context: NSManagedObjectContext, owner: User, id: String, slug: String) {
         let entity = NSEntityDescription.entity(forEntityName: "Goal", in: context)!
         super.init(entity: entity, insertInto: context)
+        self.owner = owner
         self.id = id
         self.slug = slug
     }

--- a/BeeKit/Model/Goal.swift
+++ b/BeeKit/Model/Goal.swift
@@ -166,7 +166,6 @@ public class Goal: NSManagedObject {
     }
 
     public var hideDataEntry: Bool {
-        // TODO: Implement this
         return isDataProvidedAutomatically || won
     }
 }

--- a/BeeKit/Model/User.swift
+++ b/BeeKit/Model/User.swift
@@ -1,6 +1,7 @@
 import Foundation
 import CoreData
 
+@objc(User)
 public class User: NSManagedObject {
     @NSManaged public var username: String
     @NSManaged public var deadbeat: Bool

--- a/BeeKit/Model/User.swift
+++ b/BeeKit/Model/User.swift
@@ -9,6 +9,12 @@ public class User: NSManagedObject {
     @NSManaged public var defaultDeadline: Int32
     @NSManaged public var defaultLeadTime: Int32
 
+    @NSManaged public var goals: Set<Goal>
+    @NSManaged func addGoalsObject(value: Goal)
+    @NSManaged func removeGoalsObject(value: Goal)
+    @NSManaged func addGoals(value: Set<Goal>)
+    @NSManaged func removeGoals(value: Set<Goal>)
+
     public init(context: NSManagedObjectContext,
                 username: String,
                 deadbeat: Bool,

--- a/BeeKit/Model/User.swift
+++ b/BeeKit/Model/User.swift
@@ -40,6 +40,4 @@ public class User: NSManagedObject {
     public override init(entity: NSEntityDescription, insertInto: NSManagedObjectContext?) {
         super.init(entity: entity, insertInto: insertInto)
     }
-
-
 }

--- a/BeeKit/ServiceLocator.swift
+++ b/BeeKit/ServiceLocator.swift
@@ -13,7 +13,13 @@ public class ServiceLocator {
         let container = BeeminderPersistentContainer(name: "BeeminderModel")
         container.loadPersistentStores { description, error in
             if let error = error {
-                fatalError("Unable to load persistent stores: \(error)")
+                // TODO: We probably can't ship with this. Will need to be careful with migrations
+                try! FileManager.default.removeItem(at: BeeminderPersistentContainer.defaultDirectoryURL())
+                container.loadPersistentStores { description, error in
+                    if let error = error {
+                        fatalError("Unable to load persistent stores: \(error)")
+                    }
+                }
             }
         }
         return container

--- a/BeeKit/ServiceLocator.swift
+++ b/BeeKit/ServiceLocator.swift
@@ -7,17 +7,21 @@
 //
 
 import Foundation
+import OSLog
 
 public class ServiceLocator {
+    private static let logger = Logger(subsystem: "com.beeminder.beeminder", category: "ServiceLocationm")
+
     static let persistentContainer: BeeminderPersistentContainer = {
         let container = BeeminderPersistentContainer(name: "BeeminderModel")
         container.loadPersistentStores { description, error in
             if let error = error {
-                // TODO: We probably can't ship with this. Will need to be careful with migrations
+                logger.error("Unable to load persistent stores: \(error, privacy: .public)")
+                // TODO: Reconsider this approach after we use this data for real
                 try! FileManager.default.removeItem(at: BeeminderPersistentContainer.defaultDirectoryURL())
                 container.loadPersistentStores { description, error in
                     if let error = error {
-                        fatalError("Unable to load persistent stores: \(error)")
+                        fatalError("Unable to load persistent stores on retry: \(error)")
                     }
                 }
             }

--- a/BeeKit/ServiceLocator.swift
+++ b/BeeKit/ServiceLocator.swift
@@ -22,7 +22,7 @@ public class ServiceLocator {
     public static let requestManager = RequestManager()
     public static let signedRequestManager = SignedRequestManager(requestManager: requestManager)
     public static let currentUserManager = CurrentUserManager(requestManager: requestManager, container: persistentContainer)
-    public static let goalManager = GoalManager(requestManager: requestManager, currentUserManager: currentUserManager)
+    public static let goalManager = GoalManager(requestManager: requestManager, currentUserManager: currentUserManager, container: persistentContainer)
     public static let healthStoreManager = HealthStoreManager()
     public static let versionManager = VersionManager(requestManager: requestManager)
 }

--- a/BeeSwift.xcodeproj/project.pbxproj
+++ b/BeeSwift.xcodeproj/project.pbxproj
@@ -131,6 +131,7 @@
 		E4B0A33228C194CA00055EA7 /* AddDataIntents.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = E540953B260FB6A100C30784 /* AddDataIntents.intentdefinition */; };
 		E4B6FEC62A776A2900690376 /* GoalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4B6FEC52A776A2900690376 /* GoalTests.swift */; };
 		E4E43D8829F39CE800697116 /* LogsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E43D8729F39CE800697116 /* LogsViewController.swift */; };
+		E4E8DD3B2BE87F890059C64F /* Goal.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E8DD3A2BE87F890059C64F /* Goal.swift */; };
 		E55760F526549D310076B95A /* AddDataIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = E55760F426549D310076B95A /* AddDataIntentHandler.swift */; };
 		E557610026549DD10076B95A /* AddDataIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = E55760F426549D310076B95A /* AddDataIntentHandler.swift */; };
 		E57BE6E92655EBE000BA540B /* BeeKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E57BE6E02655EBD900BA540B /* BeeKit.framework */; };
@@ -349,6 +350,7 @@
 		E4E642832910C442004F3EA9 /* CategoryHealthKitMetric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryHealthKitMetric.swift; sourceTree = "<group>"; };
 		E4E642872910D055004F3EA9 /* MindfulSessionHealthKitMetric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MindfulSessionHealthKitMetric.swift; sourceTree = "<group>"; };
 		E4E6428F2910D327004F3EA9 /* TimeInBedHealthKitMetric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeInBedHealthKitMetric.swift; sourceTree = "<group>"; };
+		E4E8DD3A2BE87F890059C64F /* Goal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Goal.swift; sourceTree = "<group>"; };
 		E52094FD2741D72300CB766F /* GoalHealthKitConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalHealthKitConnection.swift; sourceTree = "<group>"; };
 		E540953B260FB6A100C30784 /* AddDataIntents.intentdefinition */ = {isa = PBXFileReference; lastKnownFileType = file.intentdefinition; path = AddDataIntents.intentdefinition; sourceTree = "<group>"; };
 		E55760F426549D310076B95A /* AddDataIntentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddDataIntentHandler.swift; sourceTree = "<group>"; };
@@ -632,6 +634,7 @@
 				E41286EC2A62DF330093D598 /* BeeminderModel.xcdatamodeld */,
 				E46070F72B3FEFD400305DB4 /* BeeminderPersistantContainer.swift */,
 				E46070EE2B36A4D900305DB4 /* User.swift */,
+				E4E8DD3A2BE87F890059C64F /* Goal.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -1228,6 +1231,7 @@
 				E458C8252AD11E01000DCA5C /* BSButton.swift in Sources */,
 				E458C81D2AD11CEC000DCA5C /* UIDevice.swift in Sources */,
 				E458C8172AD11CA7000DCA5C /* TotalSleepMinutes.swift in Sources */,
+				E4E8DD3B2BE87F890059C64F /* Goal.swift in Sources */,
 				E46071012B451FA400305DB4 /* BeeminderModel.xcdatamodeld in Sources */,
 				E458C8072AD11BDB000DCA5C /* BeeGoal.swift in Sources */,
 				E458C80D2AD11C64000DCA5C /* Crypto.swift in Sources */,

--- a/BeeSwift.xcodeproj/project.pbxproj
+++ b/BeeSwift.xcodeproj/project.pbxproj
@@ -132,6 +132,7 @@
 		E4B6FEC62A776A2900690376 /* GoalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4B6FEC52A776A2900690376 /* GoalTests.swift */; };
 		E4E43D8829F39CE800697116 /* LogsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E43D8729F39CE800697116 /* LogsViewController.swift */; };
 		E4E8DD3B2BE87F890059C64F /* Goal.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E8DD3A2BE87F890059C64F /* Goal.swift */; };
+		E4E8DD3D2BE881440059C64F /* DataPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E8DD3C2BE881440059C64F /* DataPoint.swift */; };
 		E55760F526549D310076B95A /* AddDataIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = E55760F426549D310076B95A /* AddDataIntentHandler.swift */; };
 		E557610026549DD10076B95A /* AddDataIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = E55760F426549D310076B95A /* AddDataIntentHandler.swift */; };
 		E57BE6E92655EBE000BA540B /* BeeKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E57BE6E02655EBD900BA540B /* BeeKit.framework */; };
@@ -351,6 +352,7 @@
 		E4E642872910D055004F3EA9 /* MindfulSessionHealthKitMetric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MindfulSessionHealthKitMetric.swift; sourceTree = "<group>"; };
 		E4E6428F2910D327004F3EA9 /* TimeInBedHealthKitMetric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeInBedHealthKitMetric.swift; sourceTree = "<group>"; };
 		E4E8DD3A2BE87F890059C64F /* Goal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Goal.swift; sourceTree = "<group>"; };
+		E4E8DD3C2BE881440059C64F /* DataPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataPoint.swift; sourceTree = "<group>"; };
 		E52094FD2741D72300CB766F /* GoalHealthKitConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalHealthKitConnection.swift; sourceTree = "<group>"; };
 		E540953B260FB6A100C30784 /* AddDataIntents.intentdefinition */ = {isa = PBXFileReference; lastKnownFileType = file.intentdefinition; path = AddDataIntents.intentdefinition; sourceTree = "<group>"; };
 		E55760F426549D310076B95A /* AddDataIntentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddDataIntentHandler.swift; sourceTree = "<group>"; };
@@ -635,6 +637,7 @@
 				E46070F72B3FEFD400305DB4 /* BeeminderPersistantContainer.swift */,
 				E46070EE2B36A4D900305DB4 /* User.swift */,
 				E4E8DD3A2BE87F890059C64F /* Goal.swift */,
+				E4E8DD3C2BE881440059C64F /* DataPoint.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -1219,6 +1222,7 @@
 				E458C8082AD11BFB000DCA5C /* BeeDataPoint.swift in Sources */,
 				E458C81C2AD11CDE000DCA5C /* UIFontExtension.swift in Sources */,
 				E458C81A2AD11CB5000DCA5C /* WorkoutMinutesHealthKitMetric.swift in Sources */,
+				E4E8DD3D2BE881440059C64F /* DataPoint.swift in Sources */,
 				E458C8112AD11C8B000DCA5C /* MindfulSessionHealthKitMetric.swift in Sources */,
 				E458C80A2AD11C1C000DCA5C /* Constants.swift in Sources */,
 				E46071032B451FB100305DB4 /* User.swift in Sources */,

--- a/BeeSwift/BeeSwift.entitlements
+++ b/BeeSwift/BeeSwift.entitlements
@@ -17,6 +17,8 @@
 	<true/>
 	<key>com.apple.developer.siri</key>
 	<true/>
+	<key>com.apple.developer.usernotifications.time-sensitive</key>
+	<true/>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.beeminder.beeminder</string>


### PR DESCRIPTION
Introduce a new Goal type in CoreData. Update the goal fetching code to also write all fetched goal data to this store, along side the in memory store. At present app functionality is still reading from the in memory store rather than core data.

Testing:
Make sure the app still launches, can show the goal list, and view individual goals