### PR TITLE
Migrate TodayView widget to use CoreData

### DIFF
--- a/BeeKit/Managers/CurrentUserManager.swift
+++ b/BeeKit/Managers/CurrentUserManager.swift
@@ -78,7 +78,7 @@ public class CurrentUserManager {
     }
 
 
-    func user(context: NSManagedObjectContext? = nil) -> User? {
+    public func user(context: NSManagedObjectContext? = nil) -> User? {
         do {
             let request = NSFetchRequest<User>(entityName: "User")
             let requestContext = context ?? container.newBackgroundContext()

--- a/BeeKit/Model/BeeminderPersistantContainer.swift
+++ b/BeeKit/Model/BeeminderPersistantContainer.swift
@@ -1,7 +1,7 @@
 import UIKit
 import CoreData
 
-class BeeminderPersistentContainer: NSPersistentContainer {
+public class BeeminderPersistentContainer: NSPersistentContainer {
 
     override open class func defaultDirectoryURL() -> URL {
         let storeURL = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: "group.beeminder.beeminder")

--- a/BeeKit/Model/Goal.swift
+++ b/BeeKit/Model/Goal.swift
@@ -168,16 +168,4 @@ public class Goal: NSManagedObject {
     public var hideDataEntry: Bool {
         return isDataProvidedAutomatically || won
     }
-
-    public var isDataProvidedAutomatically: Bool {
-        guard let autodata = self.autodata else {
-            return false
-        }
-        return !autodata.isEmpty
-    }
-
-    public var hideDataEntry: Bool {
-        // TODO: Implement this
-        return isDataProvidedAutomatically || won
-    }
 }

--- a/BeeKit/Model/Goal.swift
+++ b/BeeKit/Model/Goal.swift
@@ -168,4 +168,16 @@ public class Goal: NSManagedObject {
     public var hideDataEntry: Bool {
         return isDataProvidedAutomatically || won
     }
+
+    public var isDataProvidedAutomatically: Bool {
+        guard let autodata = self.autodata else {
+            return false
+        }
+        return !autodata.isEmpty
+    }
+
+    public var hideDataEntry: Bool {
+        // TODO: Implement this
+        return isDataProvidedAutomatically || won
+    }
 }

--- a/BeeKit/ServiceLocator.swift
+++ b/BeeKit/ServiceLocator.swift
@@ -12,7 +12,7 @@ import OSLog
 public class ServiceLocator {
     private static let logger = Logger(subsystem: "com.beeminder.beeminder", category: "ServiceLocationm")
 
-    static let persistentContainer: BeeminderPersistentContainer = {
+    public static let persistentContainer: BeeminderPersistentContainer = {
         let container = BeeminderPersistentContainer(name: "BeeminderModel")
         container.loadPersistentStores { description, error in
             if let error = error {

--- a/BeeSwiftToday/TodayTableViewCell.swift
+++ b/BeeSwiftToday/TodayTableViewCell.swift
@@ -60,7 +60,7 @@ class TodayTableViewCell: UITableViewCell {
 
         self.addSubview(self.limitLabel)
         self.limitLabel.numberOfLines = 0
-        self.limitLabel.text = goal.limSum
+        self.limitLabel.text = "\(goal.slug.prefix(20)): \(goal.limSum)"
         self.limitLabel.font = UIFont.systemFont(ofSize: 14)
         
         self.limitLabel.snp.makeConstraints({ (make) -> Void in

--- a/BeeSwiftToday/TodayTableViewCell.swift
+++ b/BeeSwiftToday/TodayTableViewCell.swift
@@ -16,12 +16,12 @@ import SwiftyJSON
 import BeeKit
 
 class TodayTableViewCell: UITableViewCell {
-    var goalDictionary:NSDictionary = [:] {
+    var goal: Goal? {
         didSet {
             self.configureCell()
         }
     }
-    
+
     let valueLabel = BSLabel()
     let valueStepper = UIStepper()
     let limitLabel = BSLabel()
@@ -43,6 +43,8 @@ class TodayTableViewCell: UITableViewCell {
     }
     
     fileprivate func configureCell() {
+        guard let goal = self.goal else { return }
+
         self.selectionStyle = .none
         
         self.addSubview(self.graphImageView)
@@ -54,11 +56,11 @@ class TodayTableViewCell: UITableViewCell {
             make.bottom.equalTo(-20)
         })
         self.graphImageView.image = self.thumbnailPlaceholder
-        self.setGraphImage(urlStr: self.goalDictionary["thumbUrl"] as? String)
-        
+        self.setGraphImage(urlStr: goal.thumbUrl)
+
         self.addSubview(self.limitLabel)
         self.limitLabel.numberOfLines = 0
-        self.limitLabel.text = self.goalDictionary["limSum"] as? String
+        self.limitLabel.text = goal.limSum
         self.limitLabel.font = UIFont.systemFont(ofSize: 14)
         
         self.limitLabel.snp.makeConstraints({ (make) -> Void in
@@ -67,7 +69,7 @@ class TodayTableViewCell: UITableViewCell {
             make.right.equalTo(-10)
         })
         
-        if self.goalDictionary["hideDataEntry"] as! Bool {
+        if goal.hideDataEntry {
             self.limitLabel.snp.remakeConstraints({ (make) in
                 make.left.equalTo(self.graphImageView.snp.right).offset(10)
                 make.centerY.equalTo(self.graphImageView)
@@ -117,6 +119,8 @@ class TodayTableViewCell: UITableViewCell {
     }
     
     @objc func addDataButtonPressed() {
+        guard let goal = self.goal else { return }
+
         let hud = MBProgressHUD.showAdded(to: self, animated: true)
         hud.mode = .indeterminate
         self.addDataButton.isUserInteractionEnabled = false
@@ -129,7 +133,7 @@ class TodayTableViewCell: UITableViewCell {
         let calendar = Calendar.current
         let components = (calendar as NSCalendar).components([.hour, .minute], from: now)
         let currentHour = components.hour
-        guard let goalDeadline = self.goalDictionary["deadline"] as? Int else { return }
+        let goalDeadline = goal.deadline
         if goalDeadline > 0 && currentHour! < 6 && goalDeadline/3600 < currentHour! {
             offset = -1
         }
@@ -151,7 +155,7 @@ class TodayTableViewCell: UITableViewCell {
         formatter.dateFormat = "d"
         
         let params = ["urtext": "\(formatter.string(from: Date(timeIntervalSinceNow: offset*24*3600))) \(Int(self.valueStepper.value)) \"Added via iOS widget\"", "requestid": UUID().uuidString]
-        guard let slug = self.goalDictionary["slug"] as? String else { return }
+        let slug = goal.slug
 
         Task { @MainActor in
             do {
@@ -172,7 +176,8 @@ class TodayTableViewCell: UITableViewCell {
     
     @objc func refreshGoal() {
         Task { @MainActor in
-            guard let slug = self.goalDictionary["slug"] as? String else { return }
+            guard let goal = self.goal else { return }
+            let slug = goal.slug
 
             do {
                 let responseObject = try await ServiceLocator.requestManager.get(url: "api/v1/users/me/goals/\(slug)", parameters: [:])

--- a/BeeSwiftToday/TodayViewController.swift
+++ b/BeeSwiftToday/TodayViewController.swift
@@ -46,7 +46,7 @@ class TodayViewController: UIViewController {
     }
     
     @objc func updateDataSource() {
-        self.goals = Array(ServiceLocator.currentUserManager.user()?.goals ?? [])
+        self.goals = Array(ServiceLocator.currentUserManager.user(context: ServiceLocator.persistentContainer.viewContext)?.goals ?? [])
     }
 }
 

--- a/BeeSwiftToday/TodayViewController.swift
+++ b/BeeSwiftToday/TodayViewController.swift
@@ -14,9 +14,9 @@ import NotificationCenter
 import BeeKit
 
 class TodayViewController: UIViewController {
-    var goalDictionaries: [NSDictionary] = [] {
+    var goals: [Goal] = [] {
         didSet {
-            self.extensionContext?.widgetLargestAvailableDisplayMode = self.goalDictionaries.count > 1 ? .expanded : .compact
+            self.extensionContext?.widgetLargestAvailableDisplayMode = self.goals.count > 1 ? .expanded : .compact
         }
     }
     var tableView = UITableView()
@@ -46,16 +46,14 @@ class TodayViewController: UIViewController {
     }
     
     @objc func updateDataSource() {
-        let defaults = UserDefaults(suiteName: Constants.appGroupIdentifier)
-        // Goal dictionaries will not be available if the user is logged out or has never fetched goals
-        self.goalDictionaries = defaults?.object(forKey: "todayGoalDictionaries") as? Array<NSDictionary> ?? Array()
+        self.goals = Array(ServiceLocator.currentUserManager.user()?.goals ?? [])
     }
 }
 
 extension TodayViewController : NCWidgetProviding {
     func widgetActiveDisplayModeDidChange(_ activeDisplayMode: NCWidgetDisplayMode, withMaximumSize maxSize: CGSize) {
         if activeDisplayMode == .expanded {
-            self.preferredContentSize = CGSize.init(width: 0, height: self.rowHeight * self.goalDictionaries.count)
+            self.preferredContentSize = CGSize.init(width: 0, height: self.rowHeight * self.goals.count)
         }
         else if activeDisplayMode == .compact {
             self.preferredContentSize = CGSize.init(width: 0, height: self.rowHeight)
@@ -65,7 +63,7 @@ extension TodayViewController : NCWidgetProviding {
 
 extension TodayViewController : UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        guard let slug = self.goalDictionaries[indexPath.row]["slug"] as? String else { return }
+        let slug = self.goals[indexPath.row].slug
         self.extensionContext?.open(URL(string: "beeminder://?slug=\(slug)")!, completionHandler: nil)
     }
 }
@@ -76,7 +74,7 @@ extension TodayViewController : UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return self.goalDictionaries.count
+        return self.goals.count
     }
     
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
@@ -86,8 +84,8 @@ extension TodayViewController : UITableViewDataSource {
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = self.tableView.dequeueReusableCell(withIdentifier: self.cellReuseIdentifier, for: indexPath) as! TodayTableViewCell
         
-        cell.goalDictionary = self.goalDictionaries[indexPath.row]
-        
+        cell.goal = self.goals[indexPath.row]
+
         return cell
     }
 }


### PR DESCRIPTION
Update the TodayView widget to use CoreData to read goals. While this widget is largely deprecated, it seems a good initial test case for the CoreData store.

Testing:
Verify the today widget shows correct data