### PR TITLE
Introduce CoreData version of DataPoint

### DIFF
--- a/BeeKit/Model/BeeminderModel.xcdatamodeld/BeeminderModel.xcdatamodel/contents
+++ b/BeeKit/Model/BeeminderModel.xcdatamodeld/BeeminderModel.xcdatamodel/contents
@@ -1,7 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22758" systemVersion="23F79" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="DataPoint" representedClassName="DataPoint" syncable="YES">
+        <attribute name="comment" optional="YES" attributeType="String"/>
+        <attribute name="daystampRaw" attributeType="String"/>
         <attribute name="id" optional="YES" attributeType="String"/>
+        <attribute name="requestid" optional="YES" attributeType="String"/>
+        <attribute name="value" attributeType="Decimal" defaultValueString="0.0"/>
+        <relationship name="goal" maxCount="1" deletionRule="Nullify" destinationEntity="Goal"/>
     </entity>
     <entity name="Goal" representedClassName="Goal" syncable="YES">
         <attribute name="alertStart" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>

--- a/BeeKit/Model/BeeminderModel.xcdatamodeld/BeeminderModel.xcdatamodel/contents
+++ b/BeeKit/Model/BeeminderModel.xcdatamodeld/BeeminderModel.xcdatamodel/contents
@@ -33,6 +33,7 @@
         <attribute name="won" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="yAxis" attributeType="String"/>
         <relationship name="owner" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User" inverseName="goals" inverseEntity="User"/>
+        <relationship name="recentData" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="DataPoint"/>
     </entity>
     <entity name="User" representedClassName=".User" syncable="YES">
         <attribute name="deadbeat" attributeType="Boolean" usesScalarValueType="NO"/>

--- a/BeeKit/Model/DataPoint.swift
+++ b/BeeKit/Model/DataPoint.swift
@@ -3,12 +3,23 @@ import CoreData
 
 @objc(DataPoint)
 public class DataPoint: NSManagedObject {
-    @NSManaged public var id: String
+    @NSManaged public var id: String?
+    @NSManaged public var goal: Goal
 
-    public init(context: NSManagedObjectContext, id: String) {
+    @NSManaged public var comment: String
+    @NSManaged private var daystampRaw: String
+    @NSManaged public var requestid: String?
+    @NSManaged public var value: NSNumber
+
+    public init(context: NSManagedObjectContext, goal: Goal, id: String?, comment: String, daystamp: Daystamp, requestid: String?, value: NSNumber) {
         let entity = NSEntityDescription.entity(forEntityName: "DataPoint", in: context)!
         super.init(entity: entity, insertInto: context)
+        self.goal = goal
         self.id = id
+        self.comment = comment
+        self.daystamp = daystamp
+        self.requestid = requestid
+        self.value = value
     }
 
     @available(*, unavailable)
@@ -25,4 +36,12 @@ public class DataPoint: NSManagedObject {
         super.init(entity: entity, insertInto: insertInto)
     }
 
+    public var daystamp: Daystamp {
+        get {
+            return try! Daystamp(fromString: daystampRaw)
+        }
+        set {
+            daystampRaw = newValue.description
+        }
+    }
 }

--- a/BeeKit/Model/DataPoint.swift
+++ b/BeeKit/Model/DataPoint.swift
@@ -3,12 +3,19 @@ import CoreData
 
 @objc(DataPoint)
 public class DataPoint: NSManagedObject {
+    // Server identified for the datapoint, globally unique.
     @NSManaged public var id: String?
+    // Goal this datapoint is associated with
     @NSManaged public var goal: Goal
 
+    // An optional comment about the datapoint.
+    // TODO: Check if this can be null
     @NSManaged public var comment: String
+    // The date of the datapoint (e.g., "20150831"). Raw value in the datastore
     @NSManaged private var daystampRaw: String
+    // If a datapoint was created via the API and this parameter was included, it will be echoed back.
     @NSManaged public var requestid: String?
+    // The value, e.g., how much you weighed on the day indicated by the timestamp.
     @NSManaged public var value: NSNumber
 
     public init(context: NSManagedObjectContext, goal: Goal, id: String?, comment: String, daystamp: Daystamp, requestid: String?, value: NSNumber) {


### PR DESCRIPTION
This sets up all the attributes of the DataPoint type in CoreData and arranges for relevant objects to be created as part of loading a goal. It continues to not be used in the UI

Testing:
Loaded the app, verified in the debugger that data points were being created.