### PR TITLE
Fix most common CoreData errors

### DIFF
--- a/BeeKit/Managers/GoalManager.swift
+++ b/BeeKit/Managers/GoalManager.swift
@@ -158,7 +158,6 @@ public actor GoalManager {
                 try await withThrowingTaskGroup(of: Void.self) { group in
                     for goal in queuedGoals {
                         group.addTask {
-                            // TODO: We don't really need to reload the goal in a new context here
                             try await self.refreshGoal(goal.objectID)
                         }
                     }

--- a/BeeKit/Managers/GoalManager.swift
+++ b/BeeKit/Managers/GoalManager.swift
@@ -71,9 +71,11 @@ public actor GoalManager {
         let responseObject = try await requestManager.get(url: "/api/v1/users/\(currentUserManager.username!)/goals/\(goal.slug)?datapoints_count=5", parameters: nil)
         let goalJSON = JSON(responseObject!)
 
+        // The goal may have changed during the network operation, reload latest version
+        context.refresh(goal, mergeChanges: false)
         goal.updateToMatch(json: goalJSON)
-        try context.save()
 
+        try context.save()
         await performPostGoalUpdateBookkeeping()
     }
 

--- a/BeeKit/Managers/HealthStoreManager.swift
+++ b/BeeKit/Managers/HealthStoreManager.swift
@@ -111,6 +111,7 @@ public class HealthStoreManager {
                     let goalID = goal.objectID
                     group.addTask {
                         // This is a new thread, so we are not allowed to use the goal object from CoreData
+                        // TODO: This will generate lots of unneccesary reloads
                         try await self.updateWithRecentData(goalID: goalID, days: days)
                     }
                 }

--- a/BeeKit/Model/BeeminderModel.xcdatamodeld/BeeminderModel.xcdatamodel/contents
+++ b/BeeKit/Model/BeeminderModel.xcdatamodeld/BeeminderModel.xcdatamodel/contents
@@ -7,7 +7,7 @@
         <attribute name="requestid" optional="YES" attributeType="String"/>
         <attribute name="updatedAt" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="value" attributeType="Decimal" defaultValueString="0.0"/>
-        <relationship name="goal" maxCount="1" deletionRule="Nullify" destinationEntity="Goal"/>
+        <relationship name="goal" maxCount="1" deletionRule="Nullify" destinationEntity="Goal" inverseName="data" inverseEntity="Goal"/>
     </entity>
     <entity name="Goal" representedClassName="Goal" syncable="YES">
         <attribute name="alertStart" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
@@ -33,6 +33,7 @@
         <attribute name="useDefaults" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="won" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="yAxis" attributeType="String"/>
+        <relationship name="data" toMany="YES" deletionRule="Cascade" destinationEntity="DataPoint" inverseName="goal" inverseEntity="DataPoint"/>
         <relationship name="owner" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User" inverseName="goals" inverseEntity="User"/>
         <relationship name="recentData" toMany="YES" deletionRule="Nullify" destinationEntity="DataPoint"/>
     </entity>


### PR DESCRIPTION
Addresses the most common CoreData related crashes I have observed. This includes
* Using contexts across threads
* Keeping versions of goals before writing, leading to conflicts
* Fix cascading deletion

Testing:
Run app on device