### PR TITLE
HealthKit should not remove metadata datapoints

### DIFF
--- a/BeeKit/GoalExtensions.swift
+++ b/BeeKit/GoalExtensions.swift
@@ -82,9 +82,7 @@ extension Goal {
     public var suggestedNextValue: NSNumber? {
         let recentData = self.recentData
         for dataPoint in recentData.sorted(by: { $0.updatedAt > $1.updatedAt }) {
-            let comment = dataPoint.comment
-            // Ignore data points with comments suggesting they aren't a real value
-            if comment.contains("#DERAIL") || comment.contains("#SELFDESTRUCT") || comment.contains("#THISWILLSELFDESTRUCT") || comment.contains("#RESTART") || comment.contains("#TARE") {
+            if dataPoint.isMetaPoint() {
                 continue
             }
             return dataPoint.value

--- a/BeeKit/GoalExtensions.swift
+++ b/BeeKit/GoalExtensions.swift
@@ -82,7 +82,7 @@ extension Goal {
     public var suggestedNextValue: NSNumber? {
         let recentData = self.recentData
         for dataPoint in recentData.sorted(by: { $0.updatedAt > $1.updatedAt }) {
-            if dataPoint.isMetaPoint() {
+            if dataPoint.isMeta() {
                 continue
             }
             return dataPoint.value

--- a/BeeKit/Managers/DataPointManager.swift
+++ b/BeeKit/Managers/DataPointManager.swift
@@ -95,9 +95,10 @@ public class DataPointManager {
         guard let firstDaystamp = healthKitDataPoints.map({ point in point.daystamp }).min() else { return }
 
         let datapoints = try await datapointsSince(goal: goal, daystamp: try! Daystamp(fromString: firstDaystamp.description))
+        let realDatapoints = datapoints.filter{ !$0.isMeta() }
 
         for newDataPoint in healthKitDataPoints {
-            try await self.updateToMatchDataPoint(goal: goal, newDataPoint: newDataPoint, recentDatapoints: datapoints)
+            try await self.updateToMatchDataPoint(goal: goal, newDataPoint: newDataPoint, recentDatapoints: realDatapoints)
         }
     }
 

--- a/BeeKit/Model/DataPoint.swift
+++ b/BeeKit/Model/DataPoint.swift
@@ -97,7 +97,7 @@ extension DataPoint {
     /// Is this a DataPoint containing metadata, rather than a real value
     /// DataPoints are used to track certain events, like automatic pessimistic values, goal restarts, derailments, etc. These should sometimes
     /// be treated differently, e.g. not deleted as part of syncing with HealthKit
-    public func isMetaPoint() -> Bool {
+    public func isMeta() -> Bool {
         for tag in DataPoint.metaPointHashtags {
             if comment.contains(tag) {
                 return true

--- a/BeeKit/Model/DataPoint.swift
+++ b/BeeKit/Model/DataPoint.swift
@@ -90,3 +90,19 @@ public class DataPoint: NSManagedObject, BeeDataPoint {
         }
     }
 }
+
+extension DataPoint {
+    private static var metaPointHashtags = Set(["#DERAIL", "#SELFDESTRUCT", "#THISWILLSELFDESTRUCT", "#RESTART", "#TARE"])
+
+    /// Is this a DataPoint containing metadata, rather than a real value
+    /// DataPoints are used to track certain events, like automatic pessimistic values, goal restarts, derailments, etc. These should sometimes
+    /// be treated differently, e.g. not deleted as part of syncing with HealthKit
+    public func isMetaPoint() -> Bool {
+        for tag in DataPoint.metaPointHashtags {
+            if comment.contains(tag) {
+                return true
+            }
+        }
+        return false
+    }
+}


### PR DESCRIPTION
The HealthKit integration deletes all points which do not correspond to HealthKit entries. In the past this resulted in deleting points used for metadata tracking, e.g. derailments or restarts. This was confusing for support.

Resolve this by ignoring those points when syncing with HealthKit, so they are neither updated nor deleted.

Fixes #456