### PR TITLE
CoreData objects track when last written to

### DIFF
--- a/BeeKit/Model/BeeminderModel.xcdatamodeld/BeeminderModel.xcdatamodel/contents
+++ b/BeeKit/Model/BeeminderModel.xcdatamodeld/BeeminderModel.xcdatamodel/contents
@@ -19,7 +19,7 @@
         <attribute name="hhmmFormat" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="id" attributeType="String"/>
         <attribute name="initDay" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
-        <attribute name="lastModifiedLocal" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="lastModifiedLocal" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="lastTouch" attributeType="String"/>
         <attribute name="leadTime" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="limSum" attributeType="String"/>

--- a/BeeKit/Model/BeeminderModel.xcdatamodeld/BeeminderModel.xcdatamodel/contents
+++ b/BeeKit/Model/BeeminderModel.xcdatamodeld/BeeminderModel.xcdatamodel/contents
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22758" systemVersion="23F79" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22758" systemVersion="23G93" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="DataPoint" representedClassName="DataPoint" syncable="YES">
         <attribute name="comment" optional="YES" attributeType="String"/>
         <attribute name="daystampRaw" attributeType="String"/>
         <attribute name="id" attributeType="String"/>
+        <attribute name="lastModifiedLocal" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="requestid" optional="YES" attributeType="String"/>
         <attribute name="updatedAt" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="value" attributeType="Decimal" defaultValueString="0.0"/>
@@ -18,6 +19,7 @@
         <attribute name="hhmmFormat" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="id" attributeType="String"/>
         <attribute name="initDay" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="lastModifiedLocal" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="lastTouch" attributeType="String"/>
         <attribute name="leadTime" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="limSum" attributeType="String"/>
@@ -42,6 +44,7 @@
         <attribute name="defaultAlertStart" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="defaultDeadline" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="defaultLeadTime" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="lastModifiedLocal" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="timezone" attributeType="String"/>
         <attribute name="username" attributeType="String"/>
         <relationship name="goals" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Goal" inverseName="owner" inverseEntity="Goal"/>

--- a/BeeKit/Model/DataPoint.swift
+++ b/BeeKit/Model/DataPoint.swift
@@ -22,6 +22,9 @@ public class DataPoint: NSManagedObject, BeeDataPoint {
 
     @NSManaged public var updatedAt: Int
 
+    /// The last time this record in the CoreData store was updated
+    @NSManaged public var lastModifiedLocal: Date
+
     public init(context: NSManagedObjectContext, goal: Goal, id: String, comment: String, daystamp: Daystamp, requestid: String, value: NSNumber, updatedAt: Int) {
         let entity = NSEntityDescription.entity(forEntityName: "DataPoint", in: context)!
         super.init(entity: entity, insertInto: context)
@@ -32,6 +35,7 @@ public class DataPoint: NSManagedObject, BeeDataPoint {
         self.requestid = requestid
         self.value = value
         self.updatedAt = updatedAt
+        lastModifiedLocal = Date()
     }
 
     @available(*, unavailable)
@@ -79,6 +83,7 @@ public class DataPoint: NSManagedObject, BeeDataPoint {
         comment = json["comment"].stringValue
         requestid = json["requestid"].stringValue
         updatedAt = json["updated_at"].intValue
+        lastModifiedLocal = Date()
     }
 
     public var daystamp: Daystamp {

--- a/BeeKit/Model/Goal.swift
+++ b/BeeKit/Model/Goal.swift
@@ -63,6 +63,9 @@ public class Goal: NSManagedObject {
     @objc(removeRecentData:)
     @NSManaged public func removeFromRecentData(_ values: Set<DataPoint>)
 
+    /// The last time this record in the CoreData store was updated
+    @NSManaged public var lastModifiedLocal: Date
+
     public init(
         context: NSManagedObjectContext,
         owner: User,
@@ -116,6 +119,8 @@ public class Goal: NSManagedObject {
         self.useDefaults = useDefaults
         self.won = won
         self.yAxis = yAxis
+
+        lastModifiedLocal = Date()
     }
 
     public init(context: NSManagedObjectContext, owner: User, json: JSON) {
@@ -175,5 +180,7 @@ public class Goal: NSManagedObject {
 
         removeFromRecentData(recentData)
         addToRecentData(newRecentData)
+
+        lastModifiedLocal = Date()
     }
 }

--- a/BeeKit/Model/User.swift
+++ b/BeeKit/Model/User.swift
@@ -16,6 +16,9 @@ public class User: NSManagedObject {
     @NSManaged func addGoals(value: Set<Goal>)
     @NSManaged func removeGoals(value: Set<Goal>)
 
+    /// The last time this record in the CoreData store was updated
+    @NSManaged public var lastModifiedLocal: Date
+
     public init(context: NSManagedObjectContext,
                 username: String,
                 deadbeat: Bool,
@@ -32,6 +35,8 @@ public class User: NSManagedObject {
         self.defaultAlertStart = defaultAlertStart
         self.defaultDeadline = defaultDeadline
         self.defaultLeadTime = defaultLeadTime
+
+        lastModifiedLocal = Date()
     }
 
     @available(*, unavailable)


### PR DESCRIPTION
Adds lastModifiedLocal to all core data objects, which tracks when they were last modified. This is only a last local update, and does not e.g. correspond to when the server last changed.

This ensures that any write to these objects causes a change, making it easier to e.g. ensure we update Spotlight each time we write to the object, even if there are no property changes.