### PR TITLE
Crash if failing to load core data

### DIFF
--- a/BeeKit/Model/BeeminderPersistantContainer.swift
+++ b/BeeKit/Model/BeeminderPersistantContainer.swift
@@ -24,20 +24,7 @@ public class BeeminderPersistentContainer: NSPersistentContainer {
 
         container.loadPersistentStores { description, error in
             if let error = error {
-                logger.error("Unable to load persistent stores: \(error, privacy: .public)")
-                // TODO: Reconsider this approach after we use this data for real
-                for storeDescription in container.persistentStoreDescriptions {
-                    if let url = storeDescription.url {
-                        try! FileManager.default.removeItem(at: url)
-                    } else {
-                        logger.warning("No URL for store description: \(storeDescription, privacy: .public)")
-                    }
-                }
-                container.loadPersistentStores { description, error in
-                    if let error = error {
-                        fatalError("Unable to load persistent stores on retry: \(error)")
-                    }
-                }
+                fatalError("Unable to load persistent stores: \(error)")
             }
         }
 


### PR DESCRIPTION
Previously if there was an error loading core data (for example an incompatible schema) the app would wipe the db and retry. This was convenient for iteration, and might be good for robustness in production. But in beta/Testflight we want to catch and report errors, so we should just crash.

Testing
* [ ] Install the current release build, confirm we can upgrade to this build without crashing
* [ ] Install the current testflight build, confirm we can upgrade to this build without crashing