### PR TITLE
Target iOS 17

### DIFF
--- a/BeeKit/HeathKit/TotalSleepMinutes.swift
+++ b/BeeKit/HeathKit/TotalSleepMinutes.swift
@@ -26,7 +26,7 @@ func isRelevantToSleep(_ sample: HKCategorySample) -> Bool {
             HKCategoryValueSleepAnalysis.asleepREM,
             HKCategoryValueSleepAnalysis.asleepDeep,
             HKCategoryValueSleepAnalysis.asleepCore,
-            HKCategoryValueSleepAnalysis.asleep
+            HKCategoryValueSleepAnalysis.asleepUnspecified
         ]
     } else {
         // Fallback on earlier versions

--- a/BeeSwift.xcodeproj/project.pbxproj
+++ b/BeeSwift.xcodeproj/project.pbxproj
@@ -1369,7 +1369,7 @@
 				EXCLUDED_ARCHS = "";
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = BeeSwiftToday/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1396,7 +1396,7 @@
 				EXCLUDED_ARCHS = "";
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = BeeSwiftToday/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1555,7 +1555,7 @@
 				);
 				INFOPLIST_FILE = BeeSwift/Info.plist;
 				INTENTS_CODEGEN_LANGUAGE = Swift;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1592,7 +1592,7 @@
 				GCC_OPTIMIZATION_LEVEL = s;
 				INFOPLIST_FILE = BeeSwift/Info.plist;
 				INTENTS_CODEGEN_LANGUAGE = Swift;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1623,6 +1623,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = BeeSwiftTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1645,6 +1646,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = BeeSwiftTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1683,7 +1685,7 @@
 				INFOPLIST_FILE = BeeKit/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				INTENTS_CODEGEN_LANGUAGE = Swift;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1730,7 +1732,7 @@
 				INFOPLIST_FILE = BeeKit/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				INTENTS_CODEGEN_LANGUAGE = Swift;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1765,7 +1767,7 @@
 				DEVELOPMENT_TEAM = 8TW9V9HVES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = BeeKitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1795,7 +1797,7 @@
 				DEVELOPMENT_TEAM = 8TW9V9HVES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = BeeKitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1829,7 +1831,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = BeeSwiftIntents/Info.plist;
 				INTENTS_CODEGEN_LANGUAGE = Swift;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1864,7 +1866,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = BeeSwiftIntents/Info.plist;
 				INTENTS_CODEGEN_LANGUAGE = Swift;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1893,7 +1895,7 @@
 				DEVELOPMENT_TEAM = 8TW9V9HVES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = BeeSwiftUITests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1923,7 +1925,7 @@
 				DEVELOPMENT_TEAM = 8TW9V9HVES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = BeeSwiftUITests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/BeeSwift/AppDelegate.swift
+++ b/BeeSwift/AppDelegate.swift
@@ -140,7 +140,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         }).count
         logger.notice("Beemergency count is \(beemergencyCount, privacy: .public)")
 
-        UIApplication.shared.applicationIconBadgeNumber = beemergencyCount
+        UNUserNotificationCenter.current().setBadgeCount(beemergencyCount)
     }
 
     private func refreshGoalsAndLogErrors() {

--- a/BeeSwift/Components/DatapointValueAccessory.swift
+++ b/BeeSwift/Components/DatapointValueAccessory.swift
@@ -69,11 +69,11 @@ class DatapointValueAccessory : UIInputView {
         colonButton.layer.shadowOpacity = 0.5
 
         updateColorsToMatchMode()
-    }
 
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        updateColorsToMatchMode()
+        registerForTraitChanges([UITraitUserInterfaceStyle.self]) {
+            (self: Self, previousTraitCollection: UITraitCollection) in
+            self.updateColorsToMatchMode()
+        }
     }
 
     private func updateColorsToMatchMode() {

--- a/BeeSwift/Components/InlineDatePicker.swift
+++ b/BeeSwift/Components/InlineDatePicker.swift
@@ -15,6 +15,12 @@ class InlineDatePicker : UIDatePicker {
         super.init(frame: .zero)
         self.preferredDatePickerStyle = .compact
 
+        registerForTraitChanges(
+            [UITraitUserInterfaceStyle.self, UITraitUserInterfaceLevel.self, UITraitUserInterfaceIdiom.self]) {
+            (self: Self, previousTraitCollection: UITraitCollection) in
+            self.resetStyle()
+        }
+
         resetStyle()
     }
 
@@ -29,11 +35,6 @@ class InlineDatePicker : UIDatePicker {
 
     override func layoutSubviews() {
         super.layoutSubviews()
-        resetStyle()
-    }
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
         resetStyle()
     }
 


### PR DESCRIPTION
This increases the minimum iOS version for BeeSwift to iOS17. Analytics data suggests that <2% of users are on iOS 16 or below. It also addresses the deprecation warnings associated with this new version.

Testing:
Confirmed it compiles