### PR TITLE
blemish in BSButton's corners

### DIFF
--- a/BeeKit/UI/BSButton.swift
+++ b/BeeKit/UI/BSButton.swift
@@ -29,6 +29,7 @@ public class BSButton : UIButton {
         
         self.layer.borderColor = UIColor.Beeminder.yellow.cgColor
         self.layer.borderWidth = 1
+        self.layer.cornerRadius = 4
     }
     
 }


### PR DESCRIPTION
This addresses the blemish as seen in the screenshot in https://github.com/beeminder/BeeSwift/pull/483#issuecomment-2395234709. A square border is drawn around an otherwise rounded button. Now the border is also rounded.



### Dark
##### Before
![Simulator Screenshot - Test-iPhone - 2024-10-06 at 13 48 52](https://github.com/user-attachments/assets/36ad0c77-7e1c-4412-8b56-52edf115250e)

##### After
![Simulator Screenshot - Test-iPhone - 2024-10-06 at 14 09 05](https://github.com/user-attachments/assets/3204fe11-0732-4959-acdf-9eb409949e7e)


### Light
##### Before
![Simulator Screenshot - Test-iPhone - 2024-10-06 at 13 48 47](https://github.com/user-attachments/assets/a1453acb-147b-4180-8be2-486fb02e501f)

##### After
![Simulator Screenshot - Test-iPhone - 2024-10-06 at 14 09 30](https://github.com/user-attachments/assets/c9255edc-b806-480a-9e60-bd1259cab5d7)

