### PR TITLE
Lighter button fill in light mode

### DIFF
--- a/BeeKit/UI/BSButton.swift
+++ b/BeeKit/UI/BSButton.swift
@@ -13,11 +13,25 @@ public class BSButton : UIButton {
     
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
+        
+        registerForTraitChanges(
+            [UITraitUserInterfaceStyle.self]) {
+                (self: Self, previousTraitCollection: UITraitCollection) in
+                self.resetStyle()
+            }
+        
         self.setUp()
     }
     
     override init(frame: CGRect) {
         super.init(frame: frame)
+        
+        registerForTraitChanges(
+            [UITraitUserInterfaceStyle.self]) {
+                (self: Self, previousTraitCollection: UITraitCollection) in
+                self.resetStyle()
+            }
+        
         self.setUp()
     }
     
@@ -30,6 +44,10 @@ public class BSButton : UIButton {
         self.layer.borderColor = UIColor.Beeminder.yellow.cgColor
         self.layer.borderWidth = 1
         self.layer.cornerRadius = 4
+    }
+    
+    private func resetStyle() {
+        self.tintColor = dynamicTintFillColor
     }
     
     private let dynamicTintFillColor = UIColor { traitCollection in

--- a/BeeKit/UI/BSButton.swift
+++ b/BeeKit/UI/BSButton.swift
@@ -24,7 +24,7 @@ public class BSButton : UIButton {
     private func setUp() {
         self.titleLabel?.font = UIFont.beeminder.defaultBoldFont
         self.setTitleColor(UIColor.Beeminder.yellow, for: UIControl.State())
-        self.tintColor = .black
+        self.tintColor = dynamicTintFillColor
         self.configuration = .filled()
         
         self.layer.borderColor = UIColor.Beeminder.yellow.cgColor
@@ -32,4 +32,15 @@ public class BSButton : UIButton {
         self.layer.cornerRadius = 4
     }
     
+    private let dynamicTintFillColor = UIColor { traitCollection in
+        switch traitCollection.userInterfaceStyle {
+        case .dark:
+            return UIColor.black
+        default:
+            return UIColor(red: 59.0/255.0,
+                           green: 59.0/255.0,
+                           blue: 59.0/255.0,
+                           alpha: 0.5)
+        }
+    }
 }

--- a/BeeKit/UI/BSButton.swift
+++ b/BeeKit/UI/BSButton.swift
@@ -37,7 +37,7 @@ public class BSButton : UIButton {
     
     private func setUp() {
         self.titleLabel?.font = UIFont.beeminder.defaultBoldFont
-        self.setTitleColor(UIColor.Beeminder.yellow, for: UIControl.State())
+        self.setTitleColor(dynamicTitleColor, for: UIControl.State())
         self.tintColor = dynamicTintFillColor
         self.configuration = .filled()
         
@@ -48,6 +48,7 @@ public class BSButton : UIButton {
     
     private func resetStyle() {
         self.tintColor = dynamicTintFillColor
+        self.setTitleColor(dynamicTitleColor, for: UIControl.State())
     }
     
     private let dynamicTintFillColor = UIColor { traitCollection in
@@ -55,10 +56,19 @@ public class BSButton : UIButton {
         case .dark:
             return UIColor.black
         default:
-            return UIColor(red: 59.0/255.0,
-                           green: 59.0/255.0,
-                           blue: 59.0/255.0,
-                           alpha: 0.5)
+            return UIColor(red: 235.0/255.0,
+                           green: 235.0/255.0,
+                           blue: 235.0/255.0,
+                           alpha: 1.0)
+        }
+    }
+    
+    private let dynamicTitleColor = UIColor { traitCollection in
+        switch traitCollection.userInterfaceStyle {
+        case .dark:
+            return UIColor.Beeminder.yellow
+        default:
+            return UIColor.black
         }
     }
 }


### PR DESCRIPTION
Provides a lighter fill color for the button when in light mode and handles updating it dynamically as the appearance changes.

Examples:

### Light
![Simulator Screenshot - Test-iPhone - 2024-10-06 at 14 09 30](https://github.com/user-attachments/assets/2f3cdd72-7b11-4031-8fa5-40262f86dda7)

### Dark
![Simulator Screenshot - Test-iPhone - 2024-10-06 at 14 09 05](https://github.com/user-attachments/assets/3a77aff9-2136-4c12-a0ce-da2bf93c699b)
