### PR TITLE
HKCategoryValueSleepAnalysis.asleep deprecated on ios16

### DIFF
--- a/BeeSwiftTests/TotalSleepMinutesTests.swift
+++ b/BeeSwiftTests/TotalSleepMinutesTests.swift
@@ -32,76 +32,76 @@ final class TotalSleepMinutesTests: XCTestCase {
 
     func testCountsAnyMinuteContainingSleep() throws {
         XCTAssertEqual(totalSleepMinutes(samples: [
-            sample(value: .asleep, start: "6:00:59", end: "6:01:01")
+            sample(value: .asleepUnspecified, start: "6:00:59", end: "6:01:01")
         ]), 2)
     }
 
     func testCountsAllMinutesWithinRange() throws {
         XCTAssertEqual(totalSleepMinutes(samples: [
-            sample(value: .asleep, start: "6:00:59", end: "6:02:01")
+            sample(value: .asleepUnspecified, start: "6:00:59", end: "6:02:01")
         ]), 3)
     }
 
     func testEndTimeIsExclusive() throws {
         XCTAssertEqual(totalSleepMinutes(samples: [
-            sample(value: .asleep, start: "6:00:00", end: "6:01:00")
+            sample(value: .asleepUnspecified, start: "6:00:00", end: "6:01:00")
         ]), 1)
     }
 
     func testSeparateDataPointsAreAdded() throws {
         XCTAssertEqual(totalSleepMinutes(samples: [
-            sample(value: .asleep, start: "6:00:59", end: "6:01:01"),
-            sample(value: .asleep, start: "7:00:59", end: "7:01:01")
+            sample(value: .asleepUnspecified, start: "6:00:59", end: "6:01:01"),
+            sample(value: .asleepUnspecified, start: "7:00:59", end: "7:01:01")
         ]), 4)
     }
 
     func testAdjacentDataPointsAreCombined() throws {
         XCTAssertEqual(totalSleepMinutes(samples: [
-            sample(value: .asleep, start: "6:00:30", end: "6:01:30"),
-            sample(value: .asleep, start: "6:01:30", end: "6:02:30")
+            sample(value: .asleepUnspecified, start: "6:00:30", end: "6:01:30"),
+            sample(value: .asleepUnspecified, start: "6:01:30", end: "6:02:30")
         ]), 3)
     }
 
     func testMinuteIsOnlyCountedOnce() throws {
         XCTAssertEqual(totalSleepMinutes(samples: [
-            sample(value: .asleep, start: "6:00:59", end: "6:01:01"),
-            sample(value: .asleep, start: "6:01:59", end: "6:02:01")
+            sample(value: .asleepUnspecified, start: "6:00:59", end: "6:01:01"),
+            sample(value: .asleepUnspecified, start: "6:01:59", end: "6:02:01")
         ]), 3)
     }
 
     func testMinuteNotCountedIfMoreAwakeThanAsleep() throws {
         XCTAssertEqual(totalSleepMinutes(samples: [
-            sample(value: .asleep, start: "6:00:01", end: "6:00:02"),
+            sample(value: .asleepUnspecified, start: "6:00:01", end: "6:00:02"),
             sample(value: .awake, start: "6:00:01", end: "6:00:30")
         ]), 0)
     }
 
     func testMinuteCountedAsAsleepIfThereIsATie() throws {
         XCTAssertEqual(totalSleepMinutes(samples: [
-            sample(value: .asleep, start: "6:00:01", end: "6:00:02"),
+            sample(value: .asleepUnspecified, start: "6:00:01", end: "6:00:02"),
             sample(value: .awake, start: "6:00:01", end: "6:00:02")
         ]), 1)
     }
 
     func testLongOverlappingAwakeBasedOnFirstMinute() throws {
         XCTAssertEqual(totalSleepMinutes(samples: [
-            sample(value: .asleep, start: "6:00:30", end: "6:05:59"),
+            sample(value: .asleepUnspecified, start: "6:00:30", end: "6:05:59"),
             sample(value: .awake, start: "6:00:01", end: "6:05:59")
         ]), 0)
     }
 
     func testLongOverlappingAsleepBasedOnFirstMinute() throws {
         XCTAssertEqual(totalSleepMinutes(samples: [
-            sample(value: .asleep, start: "6:00:01", end: "6:05:59"),
+            sample(value: .asleepUnspecified, start: "6:00:01", end: "6:05:59"),
             sample(value: .awake, start: "6:00:30", end: "6:05:59")
         ]), 6)
     }
 
     func testPreceedingMinuteHasNoEffectIfSamplesDoNotOverlap() throws {
         XCTAssertEqual(totalSleepMinutes(samples: [
-            sample(value: .asleep, start: "6:00:01", end: "6:00:02"),
+            sample(value: .asleepUnspecified, start: "6:00:01", end: "6:00:02"),
             sample(value: .awake, start: "6:00:01", end: "6:00:03"),
-            sample(value: .asleep, start: "6:01:01", end: "6:01:02"),
+            sample(value: .asleepUnspecified, start: "6:01:01", end: "6:01:02"),
             sample(value: .awake, start: "6:01:01", end: "6:01:02")
         ]), 1)
     }


### PR DESCRIPTION
This is a follow-up to Commit e5ef0f / MR #484.

It replaces uses of `asleep` with `asleepUnspecified` in the other targets (tests).
```diff
-  HKCategoryValueSleepAnalysis.asleep
+  HKCategoryValueSleepAnalysis.asleepUnspecified
```