### PR TITLE
image link download from App Store is broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Using Apple Health as a source, data can be syncronized from the Apple Health ap
 
 ## Download Beeminder for iOS
 
-[![Download on the App Store](https://linkmaker.itunes.apple.com/en-us/badge-lrg.svg?releaseDate=2012-08-30&kind=iossoftware&bubble=ios_apps)](https://apps.apple.com/us/app/beeminder/id551869729?mt=8)
+[![Download on the App Store](https://toolbox.marketingtools.apple.com/api/v2/badges/download-on-the-app-store/black/en-us?releaseDate=1346284800)](https://apps.apple.com/us/app/beeminder/id551869729?itscg=30200&itsct=apps_box_badge&mttnsubad=551869729)
 
 
 ## Contributing


### PR DESCRIPTION
The image for the download link was no longer available. iTunes Linkmaker was no longer providing it. That service's replacement appears to be Apple's Marketing Tools Toolbox.

generated at https://toolbox.marketingtools.apple.com/en-us/app-store/us/app/551869729