### PR TITLE
date picker wraps around to 1 for the first of the current month

### DIFF
--- a/BeeSwift/GoalViewController.swift
+++ b/BeeSwift/GoalViewController.swift
@@ -457,14 +457,7 @@ class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTabl
     }
     
     private var urtext: String {
-        let urtextDateFormatter: DateFormatter = {
-            let formatter = DateFormatter()
-            formatter.locale = Locale(identifier: "en_US")
-            formatter.dateFormat = "yyyy MM dd"
-            return formatter
-        }()
-        
-        return "\(urtextDateFormatter.string(from: self.date)) \(self.valueTextField.text!) \"\(self.commentTextField.text!)\""
+        return "\(DateFormatter.urtextDateString(from: self.date)) \(self.valueTextField.text!) \"\(self.commentTextField.text!)\""
     }
 
     @objc func submitDatapoint() {
@@ -530,5 +523,19 @@ class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTabl
 
     func safariViewControllerDidFinish(_ controller: SFSafariViewController) {
         controller.dismiss(animated: true, completion: nil)
+    }
+}
+
+
+private extension DateFormatter {
+    private static let urtextDateFormatter: DateFormatter = {
+            let formatter = DateFormatter()
+            formatter.locale = Locale(identifier: "en_US")
+            formatter.dateFormat = "yyyy MM dd"
+            return formatter
+        }()
+    
+    static func urtextDateString(from date: Date) -> String {
+        urtextDateFormatter.string(from: date)
     }
 }

--- a/BeeSwift/GoalViewController.swift
+++ b/BeeSwift/GoalViewController.swift
@@ -275,7 +275,7 @@ class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTabl
         }
 
         self.navigationItem.rightBarButtonItems = [UIBarButtonItem(barButtonSystemItem: .action, target: self, action: #selector(self.actionButtonPressed))]
-        if (!self.goal.hideDataEntry) {
+        if !self.goal.hideDataEntry {
             self.navigationItem.rightBarButtonItems?.append(UIBarButtonItem(image: UIImage(named: "Timer"), style: .plain, target: self, action: #selector(self.timerButtonPressed)))
         }
 
@@ -422,12 +422,12 @@ class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTabl
     }
 
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
-        if (textField.isEqual(self.valueTextField)) {
+        if textField.isEqual(self.valueTextField) {
             // Only allow a single decimal separator (, or .)
             if textField.text!.components(separatedBy: ".").count > 1 {
                 if string == "." || string == "," { return false }
             }
-            if (string == ",") {
+            if string == "," {
                 textField.text = textField.text! + "."
                 return false
             }

--- a/BeeSwift/GoalViewController.swift
+++ b/BeeSwift/GoalViewController.swift
@@ -377,22 +377,8 @@ class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTabl
         
         let isDifferentYear = calendar.component(.year, from: now) != calendar.component(.year, from: date)
         let isDifferentMonth = calendar.component(.month, from: now) != calendar.component(.month, from: date)
-        
-        let formatter: DateFormatter = {
-            let formatter = DateFormatter()
-            formatter.locale = Locale(identifier: "en_US")
 
-            if isDifferentYear {
-                formatter.dateFormat = "yyyy-MM-dd"
-            } else if isDifferentMonth {
-                formatter.dateFormat = "MMM d"
-            } else {
-                formatter.dateFormat = "d"
-            }
-            return formatter
-        }()
-        
-        self.dateTextField.text = formatter.string(from: self.date)
+        self.dateTextField.text = DateFormatter.dateTextFieldString(from: self.date, isDifferentYear: isDifferentYear, isDifferentMonth: isDifferentMonth)
     }
 
     func setValueTextField() {
@@ -537,5 +523,38 @@ private extension DateFormatter {
     
     static func urtextDateString(from date: Date) -> String {
         urtextDateFormatter.string(from: date)
+    }
+}
+
+private extension DateFormatter {
+    private static let newDatapointDateDifferentYearDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US")
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter
+    }()
+    
+    private static let newDatapointDateDifferentMonthDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US")
+        formatter.dateFormat = "MMM d"
+        return formatter
+    }()
+    
+    private static let newDatapointDateWithinSameMonthDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US")
+        formatter.dateFormat = "d"
+        return formatter
+    }()
+    
+    static func dateTextFieldString(from date: Date, isDifferentYear: Bool, isDifferentMonth: Bool) -> String {
+        if isDifferentYear {
+            return newDatapointDateDifferentYearDateFormatter.string(from: date)
+        } else if isDifferentMonth {
+            return newDatapointDateDifferentMonthDateFormatter.string(from: date)
+        } else {
+            return newDatapointDateWithinSameMonthDateFormatter.string(from: date)
+        }
     }
 }

--- a/BeeSwift/GoalViewController.swift
+++ b/BeeSwift/GoalViewController.swift
@@ -368,7 +368,7 @@ class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTabl
         var components = DateComponents()
         components.day = Int(self.dateStepper.value)
 
-        let newDate = (calendar as NSCalendar?)?.date(byAdding: components, to: Date(), options: [])
+        let newDate = calendar.date(byAdding: components, to: Date())
 
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "en_US")


### PR DESCRIPTION
The Edit Datapoint screen contains a date picker. The Add Datapoint screen, the lower part of the goal screen, did not contain a date picker. Instead it contained a single digit to represent the date of the to-be-created datapoint and furthermore sent this single digit to the backend as part of `urtext`. The backend itself then interpreted the values sent and really had no way to accurately map the "day of the month" number to any particular year or month.

With this merge request, the Add Datapoint section has been given its own date which is then sent to the backend when adding the new datapoint. Since the app now provides all of year, month, and day, there is less ambiguity related to the daystamp for the datapoint.

Furthermore, similar to how the [Android app / Beedroid](https://github.com/beeminder/BeeSwift/issues/386#issuecomment-1574351335) handles this, the format shown varies: the (date) value shown is either a simple single number (the day) when within the same month, the month and day when no longer in the same month but still the same year, and all three components when the point is for a different calendar year.

example, stepping through dates on 2024-Oct-21:

https://github.com/user-attachments/assets/fb4f0d23-6880-4e8d-97a9-4ed38dff4185




Fixes #386