### PR TITLE
timer screen figures out its own units

### DIFF
--- a/BeeSwift/GoalViewController.swift
+++ b/BeeSwift/GoalViewController.swift
@@ -332,18 +332,6 @@ class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTabl
     @objc func timerButtonPressed() {
         let controller = TimerViewController(goal: self.goal)
         controller.modalPresentationStyle = .fullScreen
-        do {
-            let hoursRegex = try NSRegularExpression(pattern: "(hr|hour)s?")
-            let minutesRegex = try NSRegularExpression(pattern: "(min|minute)s?")
-            if hoursRegex.firstMatch(in: self.goal.yAxis, options: [], range: NSMakeRange(0, self.goal.yAxis.count)) != nil {
-                controller.units = "hours"
-            }
-            if minutesRegex.firstMatch(in: self.goal.yAxis, options: [], range: NSMakeRange(0, self.goal.yAxis.count)) != nil {
-                controller.units = "minutes"
-            }
-        } catch {
-            //
-        }
         self.present(controller, animated: true, completion: nil)
     }
 

--- a/BeeSwift/TimerViewController.swift
+++ b/BeeSwift/TimerViewController.swift
@@ -14,7 +14,7 @@ import BeeKit
 
 class TimerViewController: UIViewController {
     private enum TimerUnit {
-        case hours, minutes, other
+        case hours, minutes
     }
 
     let timerLabel = BSLabel()
@@ -28,7 +28,7 @@ class TimerViewController: UIViewController {
     
     init(goal: Goal) {
         self.goal = goal
-        self.units = Self.timerUnit(goal: goal)
+        self.units = Self.timerUnit(goal: goal) ?? .hours
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -176,7 +176,7 @@ class TimerViewController: UIViewController {
         switch self.units {
         case .minutes:
             value = self.totalSeconds()/60.0
-        case .hours, .other:
+        case .hours:
             value = self.totalSeconds()/3600.0
         }
         
@@ -213,17 +213,17 @@ class TimerViewController: UIViewController {
 }
 
 private extension TimerViewController {
-    static private func timerUnit(goal: Goal) -> TimerUnit {
-        guard let hoursRegex = try? NSRegularExpression(pattern: "(hr|hour)s?") else { return .other }
+    static private func timerUnit(goal: Goal) -> TimerUnit? {
+        guard let hoursRegex = try? NSRegularExpression(pattern: "(hr|hour)s?") else { return nil }
         if hoursRegex.firstMatch(in: goal.yAxis, options: [], range: NSMakeRange(0, goal.yAxis.count)) != nil {
             return .hours
         }
         
-        guard let minutesRegex = try? NSRegularExpression(pattern: "(min|minute)s?") else { return .other }
+        guard let minutesRegex = try? NSRegularExpression(pattern: "(min|minute)s?") else { return nil }
         if minutesRegex.firstMatch(in: goal.yAxis, options: [], range: NSMakeRange(0, goal.yAxis.count)) != nil {
             return .minutes
         }
         
-        return .other
+        return nil
     }
 }

--- a/BeeSwift/TimerViewController.swift
+++ b/BeeSwift/TimerViewController.swift
@@ -13,28 +13,22 @@ import MBProgressHUD
 import BeeKit
 
 class TimerViewController: UIViewController {
+    private enum TimerUnit {
+        case hours, minutes, other
+    }
+
     let timerLabel = BSLabel()
     let startStopButton = BSButton(type: .system)
     let goal: Goal
     var timingSince: Date?
     var timer: Timer?
-    private var units: String? {
-        guard let hoursRegex = try? NSRegularExpression(pattern: "(hr|hour)s?") else { return nil }
-        if hoursRegex.firstMatch(in: self.goal.yAxis, options: [], range: NSMakeRange(0, self.goal.yAxis.count)) != nil {
-            return "hours"
-        }
-        
-        guard let minutesRegex = try? NSRegularExpression(pattern: "(min|minute)s?") else { return nil }
-        if minutesRegex.firstMatch(in: self.goal.yAxis, options: [], range: NSMakeRange(0, self.goal.yAxis.count)) != nil {
-            return "minutes"
-        }
-        
-        return nil
-    }
-    var accumulatedSeconds = 0
+    private let units: TimerUnit
 
+    var accumulatedSeconds = 0
+    
     init(goal: Goal) {
         self.goal = goal
+        self.units = Self.timerUnit(goal: goal)
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -177,8 +171,14 @@ class TimerViewController: UIViewController {
         formatter.locale = Locale(identifier: "en_US")
         formatter.dateFormat = "d"
         
-        var value = self.totalSeconds()/3600.0
-        if self.units == "minutes" { value = self.totalSeconds()/60.0 }
+        let value: Double
+
+        switch self.units {
+        case .minutes:
+            value = self.totalSeconds()/60.0
+        case .hours, .other:
+            value = self.totalSeconds()/3600.0
+        }
         
         let comment = "Automatically entered from iOS timer interface"
         
@@ -209,5 +209,21 @@ class TimerViewController: UIViewController {
                 self.present(alertController, animated: true)
             }
         }
+    }
+}
+
+private extension TimerViewController {
+    static private func timerUnit(goal: Goal) -> TimerUnit {
+        guard let hoursRegex = try? NSRegularExpression(pattern: "(hr|hour)s?") else { return .other }
+        if hoursRegex.firstMatch(in: goal.yAxis, options: [], range: NSMakeRange(0, goal.yAxis.count)) != nil {
+            return .hours
+        }
+        
+        guard let minutesRegex = try? NSRegularExpression(pattern: "(min|minute)s?") else { return .other }
+        if minutesRegex.firstMatch(in: goal.yAxis, options: [], range: NSMakeRange(0, goal.yAxis.count)) != nil {
+            return .minutes
+        }
+        
+        return .other
     }
 }

--- a/BeeSwift/TimerViewController.swift
+++ b/BeeSwift/TimerViewController.swift
@@ -18,7 +18,19 @@ class TimerViewController: UIViewController {
     let goal: Goal
     var timingSince: Date?
     var timer: Timer?
-    var units: String?
+    private var units: String? {
+        guard let hoursRegex = try? NSRegularExpression(pattern: "(hr|hour)s?") else { return nil }
+        if hoursRegex.firstMatch(in: self.goal.yAxis, options: [], range: NSMakeRange(0, self.goal.yAxis.count)) != nil {
+            return "hours"
+        }
+        
+        guard let minutesRegex = try? NSRegularExpression(pattern: "(min|minute)s?") else { return nil }
+        if minutesRegex.firstMatch(in: self.goal.yAxis, options: [], range: NSMakeRange(0, self.goal.yAxis.count)) != nil {
+            return "minutes"
+        }
+        
+        return nil
+    }
     var accumulatedSeconds = 0
 
     init(goal: Goal) {


### PR DESCRIPTION
The Timer Screen has special logic for interpreting the accumulated seconds, dividing the value by 60 when the goal's unit is (perhaps, probably) in minutes

Previously the goal screen included the logic for figuring out which units the timer screen should use.
