### PR TITLE
fancy swift filter and sorted(using:)

### DIFF
--- a/BeeKit/GoalExtensions.swift
+++ b/BeeKit/GoalExtensions.swift
@@ -80,13 +80,10 @@ extension Goal {
 
     /// A hint for the value the user is likely to enter, based on past data points
     public var suggestedNextValue: NSNumber? {
-        let recentData = self.recentData
-        for dataPoint in recentData.sorted(by: { $0.updatedAt > $1.updatedAt }) {
-            if dataPoint.isMeta() {
-                continue
-            }
-            return dataPoint.value
-        }
-        return nil
+        let candidateDatapoints = self.recentData
+            .filter { !$0.isMeta() }
+            .sorted(using: [SortDescriptor(\.updatedAt, order: .reverse)])
+        
+        return candidateDatapoints.first?.value
     }
 }


### PR DESCRIPTION
Using `.filter` for increased legibility. And using `.sorted(using:)` to as a cleaner way to achieve the same result as the manual closure-based sorting, since the manual closure-based sort was only checking one keypath item anyway.