### PR TITLE
letting RelativeFormatter work its magic

### DIFF
--- a/BeeSwift/Gallery/GalleryViewController.swift
+++ b/BeeSwift/Gallery/GalleryViewController.swift
@@ -314,11 +314,8 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
     @objc func updateLastUpdatedLabel() {
         let lastUpdated = self.lastUpdated ?? .distantPast
         
-        let backgroundColor = lastUpdated.timeIntervalSinceNow < -3600 ? UIColor.Beeminder.red : UIColor.Beeminder.gray
-        let lastTextString = "Last updated: " + lastUpdatedDF.localizedString(for: lastUpdated, relativeTo: Date())
-        
-        self.lastUpdatedView.backgroundColor = backgroundColor
-        self.lastUpdatedLabel.text = lastTextString
+        self.lastUpdatedView.backgroundColor = lastUpdated.timeIntervalSinceNow < -3600 ? UIColor.Beeminder.red : UIColor.Beeminder.gray
+        self.lastUpdatedLabel.text = "Last updated: " + lastUpdatedDF.localizedString(for: lastUpdated, relativeTo: Date())
     }
 
     

--- a/BeeSwift/Gallery/GalleryViewController.swift
+++ b/BeeSwift/Gallery/GalleryViewController.swift
@@ -65,7 +65,7 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
         }
         
         self.lastUpdatedView.addSubview(self.lastUpdatedLabel)
-        self.lastUpdatedLabel.text = "Last updated:"
+        self.lastUpdatedLabel.text = nil
         self.lastUpdatedLabel.font = UIFont.beeminder.defaultFontPlain.withSize(Constants.defaultFontSize)
         self.lastUpdatedLabel.textAlignment = NSTextAlignment.center
         self.lastUpdatedLabel.snp.makeConstraints { (make) -> Void in
@@ -306,34 +306,20 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
         }
     }
     
+    private let lastUpdatedDF: RelativeDateTimeFormatter = {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.dateTimeStyle = .named
+        return formatter
+    }()
+    
     @objc func updateLastUpdatedLabel() {
-        var lastTextString = ""
-        var color = UIColor.black
-        if let lastUpdated = self.lastUpdated {
-            if lastUpdated.timeIntervalSinceNow < -3600 {
-                color = UIColor.Beeminder.red
-                lastTextString = "Last updated: a long time ago..."
-            }
-            else if lastUpdated.timeIntervalSinceNow < -120 {
-                color = UIColor.black
-                lastTextString = "Last updated: \(-1 * Int(lastUpdated.timeIntervalSinceNow / 60)) minutes ago"
-            }
-            else if lastUpdated.timeIntervalSinceNow < -60 {
-                color = UIColor.black
-                lastTextString = "Last updated: 1 minute ago"
-            }
-            else {
-                color = UIColor.black
-                lastTextString = "Last updated: less than a minute ago"
-            }
-        }
-        else {
-            color = UIColor.Beeminder.red
-            lastTextString = "Last updated: a long time ago..."
-        }
-        let lastText: NSMutableAttributedString = NSMutableAttributedString(string: lastTextString)
-        lastText.addAttribute(NSAttributedString.Key.foregroundColor, value: color, range: NSRange(location: 0, length: lastText.string.count))
-        self.lastUpdatedLabel.attributedText = lastText
+        let lastUpdated = self.lastUpdated ?? .distantPast
+        
+        let backgroundColor = lastUpdated.timeIntervalSinceNow < -3600 ? UIColor.Beeminder.red : UIColor.Beeminder.gray
+        let lastTextString = "Last updated: " + lastUpdatedDF.localizedString(for: lastUpdated, relativeTo: Date())
+        
+        self.lastUpdatedView.backgroundColor = backgroundColor
+        self.lastUpdatedLabel.text = lastTextString
     }
 
     

--- a/BeeSwift/Gallery/GalleryViewController.swift
+++ b/BeeSwift/Gallery/GalleryViewController.swift
@@ -65,7 +65,6 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
         }
         
         self.lastUpdatedView.addSubview(self.lastUpdatedLabel)
-        self.lastUpdatedLabel.text = nil
         self.lastUpdatedLabel.font = UIFont.beeminder.defaultFontPlain.withSize(Constants.defaultFontSize)
         self.lastUpdatedLabel.textAlignment = NSTextAlignment.center
         self.lastUpdatedLabel.snp.makeConstraints { (make) -> Void in

--- a/BeeSwift/Gallery/GalleryViewController.swift
+++ b/BeeSwift/Gallery/GalleryViewController.swift
@@ -305,7 +305,7 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
         }
     }
     
-    private let lastUpdatedDF: RelativeDateTimeFormatter = {
+    private let lastUpdatedDateFormatter: RelativeDateTimeFormatter = {
         let formatter = RelativeDateTimeFormatter()
         formatter.dateTimeStyle = .named
         return formatter
@@ -315,7 +315,7 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
         let lastUpdated = self.lastUpdated ?? .distantPast
         
         self.lastUpdatedView.backgroundColor = lastUpdated.timeIntervalSinceNow < -3600 ? UIColor.Beeminder.red : UIColor.Beeminder.gray
-        self.lastUpdatedLabel.text = "Last updated: " + lastUpdatedDF.localizedString(for: lastUpdated, relativeTo: Date())
+        self.lastUpdatedLabel.text = "Last updated: " + lastUpdatedDateFormatter.localizedString(for: lastUpdated, relativeTo: Date())
     }
 
     


### PR DESCRIPTION
also replaces the low contrast red on light grey with black on red

### before

![red on gray](https://github.com/user-attachments/assets/46898ba8-e2a6-4d87-b4b5-1242aece4708)

### after

![black on red](https://github.com/user-attachments/assets/0bd5f1d0-16cd-4a63-bd0f-1fd43441e99c)
