### PR TITLE
using ``Daystamp`` when considering deadline

### DIFF
--- a/BeeKit/Daystamp.swift
+++ b/BeeKit/Daystamp.swift
@@ -41,7 +41,7 @@ public struct Daystamp: CustomStringConvertible, Strideable, Comparable, Equatab
         self.init(year: year, month: month, day: day)
     }
 
-    init(fromDate date: Date, deadline: Int) {
+    public init(fromDate date: Date, deadline: Int) {
         let secondsAfterMidnight =
             Daystamp.calendar.component(.hour, from: date) * 60 * 60
             + Daystamp.calendar.component(.minute, from: date) * 60

--- a/BeeKit/Daystamp.swift
+++ b/BeeKit/Daystamp.swift
@@ -109,6 +109,7 @@ public struct Daystamp: CustomStringConvertible, Strideable, Comparable, Equatab
 
     // Trait: CustomStringConvertible
 
+    /// Daystamp formatted as a YYYYMMdd string
     public var description: String {
         return String(format: "%04d%02d%02d", year, month, day)
     }

--- a/BeeKit/Daystamp.swift
+++ b/BeeKit/Daystamp.swift
@@ -40,7 +40,12 @@ public struct Daystamp: CustomStringConvertible, Strideable, Comparable, Equatab
 
         self.init(year: year, month: month, day: day)
     }
-
+    
+    /// Creates a Daystamp of having submitted a datapoint on a particular date given the goal's deadline
+    ///
+    /// - Parameters:
+    ///   - date: a calendar date
+    ///   - deadline: a ``Goal/deadline``
     public init(fromDate date: Date, deadline: Int) {
         let secondsAfterMidnight =
             Daystamp.calendar.component(.hour, from: date) * 60 * 60

--- a/BeeKit/Daystamp.swift
+++ b/BeeKit/Daystamp.swift
@@ -156,4 +156,20 @@ public struct Daystamp: CustomStringConvertible, Strideable, Comparable, Equatab
 
     // Trait: Hashable
     // This is generated automatically for structs by the compiler
+    
+    
+    /// generates the daystamp as a string for use in urtext, considering both the submission date and goal's deadline
+    /// - Parameters:
+    ///   - submissionDate: calendar date on which the datapoint would be submitted
+    ///   - goal: the goal for which the urtext is to be created
+    /// - Returns: string of the daystamp, suitable for use in urtext
+    public static func makeUrtextDaystamp(submissionDate: Date = Date(), goal: Goal) -> String {
+        let daystamp = Daystamp(fromDate: submissionDate,
+                                deadline: goal.deadline)
+        
+        return String(format: "%04d %02d %02d",
+                      daystamp.year,
+                      daystamp.month,
+                      daystamp.day)
+    }
 }

--- a/BeeKit/Daystamp.swift
+++ b/BeeKit/Daystamp.swift
@@ -115,6 +115,9 @@ public struct Daystamp: CustomStringConvertible, Strideable, Comparable, Equatab
 
     // Trait: Strideable
 
+    /// how many days apart two daystamps are
+    /// - Parameter other: another daystamp
+    /// - Returns: number of days as distance between the daystamps
     public func distance(to other: Daystamp) -> Int {
         let selfDate = Daystamp.calendar.date(from: DateComponents(calendar: Daystamp.calendar, year: year, month: month, day: day))!
         let otherDate = Daystamp.calendar.date(from: DateComponents(calendar: Daystamp.calendar, year: other.year, month: other.month, day: other.day))!

--- a/BeeSwift/GoalViewController.swift
+++ b/BeeSwift/GoalViewController.swift
@@ -209,15 +209,7 @@ class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTabl
         self.dateStepper.tintColor = UIColor.Beeminder.gray
         dataEntryView.addSubview(self.dateStepper)
         self.dateStepper.addTarget(self, action: #selector(GoalViewController.dateStepperValueChanged), for: .valueChanged)
-        self.dateStepper.value = {
-            let now = Date()
-            let daystampAccountingForTheGoalsDeadline = Daystamp(fromDate: now,
-                                                                 deadline: goal.deadline)
-            let daystampAssumingMidnightDeadline = Daystamp(fromDate: now,
-                                                            deadline: 0)
-            
-            return Double(daystampAccountingForTheGoalsDeadline.distance(to: daystampAssumingMidnightDeadline))
-        }()
+        self.dateStepper.value = Self.makeInitialDateStepperValue(for: goal)
 
         self.dateStepper.snp.makeConstraints { (make) -> Void in
             make.top.equalTo(self.dateTextField.snp.bottom).offset(elementSpacing)
@@ -497,6 +489,15 @@ class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTabl
 
     func viewForZooming(in scrollView: UIScrollView) -> UIView? {
         return self.goalImageView
+    }
+    
+    private static func makeInitialDateStepperValue(date: Date = Date(), for goal: Goal) -> Double {
+        let daystampAccountingForTheGoalsDeadline = Daystamp(fromDate: date,
+                                                             deadline: goal.deadline)
+        let daystampAssumingMidnightDeadline = Daystamp(fromDate: date,
+                                                        deadline: 0)
+        
+        return Double(daystampAccountingForTheGoalsDeadline.distance(to: daystampAssumingMidnightDeadline))
     }
 
     // MARK: - SFSafariViewControllerDelegate

--- a/BeeSwift/TimerViewController.swift
+++ b/BeeSwift/TimerViewController.swift
@@ -143,11 +143,7 @@ class TimerViewController: UIViewController {
     }
     
     func urtext() -> String {
-        let urtextDaystamp: String = {
-            let daystamp = Daystamp(fromDate: Date(), deadline: goal.deadline)
-            
-            return String(format: "%04d %02d %02d", daystamp.year, daystamp.month, daystamp.day)
-        }()
+        let urtextDaystamp = Daystamp.makeUrtextDaystamp(submissionDate: Date(), goal: goal)
         
         let value: Double
 

--- a/BeeSwift/TimerViewController.swift
+++ b/BeeSwift/TimerViewController.swift
@@ -143,7 +143,11 @@ class TimerViewController: UIViewController {
     }
     
     func urtext() -> String {
-        let day = Daystamp(fromDate: Date(), deadline: goal.deadline).day
+        let urtextDaystamp: String = {
+            let daystamp = Daystamp(fromDate: Date(), deadline: goal.deadline)
+            
+            return String(format: "%04d %02d %02d", daystamp.year, daystamp.month, daystamp.day)
+        }()
         
         let value: Double
 
@@ -156,7 +160,7 @@ class TimerViewController: UIViewController {
         
         let comment = "Automatically entered from iOS timer interface"
         
-        return "\(day) \(value) \"\(comment)\""
+        return "\(urtextDaystamp) \(value) \"\(comment)\""
     }
     
     @objc func addDatapointButtonPressed() {

--- a/BeeSwift/TimerViewController.swift
+++ b/BeeSwift/TimerViewController.swift
@@ -143,33 +143,7 @@ class TimerViewController: UIViewController {
     }
     
     func urtext() -> String {
-        // if the goal's deadline is after midnight, and it's after midnight,
-        // but before the deadline,
-        // default to entering data for the "previous" day.
-        let now = Date()
-        var offset: Double = 0
-        let calendar = Calendar.current
-        let components = (calendar as NSCalendar).components([.hour, .minute], from: now)
-        let currentHour = components.hour
-        if self.goal.deadline > 0 && currentHour! < 6 && self.goal.deadline/3600 < currentHour! {
-            offset = -1
-        }
-        
-        // if the goal's deadline is before midnight and has already passed for this calendar day, default to entering data for the "next" day
-        if self.goal.deadline < 0 {
-            let deadlineSecondsAfterMidnight = 24*3600 + self.goal.deadline
-            let deadlineHour = deadlineSecondsAfterMidnight/3600
-            let deadlineMinute = (deadlineSecondsAfterMidnight % 3600)/60
-            let currentMinute = components.minute
-            if deadlineHour < currentHour! ||
-                (deadlineHour == currentHour! && deadlineMinute < currentMinute!) {
-                offset = 1
-            }
-        }
-        
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US")
-        formatter.dateFormat = "d"
+        let day = Daystamp(fromDate: Date(), deadline: goal.deadline).day
         
         let value: Double
 
@@ -182,7 +156,7 @@ class TimerViewController: UIViewController {
         
         let comment = "Automatically entered from iOS timer interface"
         
-        return "\(formatter.string(from: Date(timeIntervalSinceNow: offset*24*3600))) \(value) \"\(comment)\""
+        return "\(day) \(value) \"\(comment)\""
     }
     
     @objc func addDatapointButtonPressed() {

--- a/BeeSwiftToday/TodayTableViewCell.swift
+++ b/BeeSwiftToday/TodayTableViewCell.swift
@@ -125,36 +125,13 @@ class TodayTableViewCell: UITableViewCell {
         hud.mode = .indeterminate
         self.addDataButton.isUserInteractionEnabled = false
         
-        // if the goal's deadline is after midnight, and it's after midnight,
-        // but before the deadline,
-        // default to entering data for the "previous" day.
-        let now = Date()
-        var offset: Double = 0
-        let calendar = Calendar.current
-        let components = (calendar as NSCalendar).components([.hour, .minute], from: now)
-        let currentHour = components.hour
-        let goalDeadline = goal.deadline
-        if goalDeadline > 0 && currentHour! < 6 && goalDeadline/3600 < currentHour! {
-            offset = -1
-        }
+        let urtextDaystamp: String = {
+            let daystamp = Daystamp(fromDate: Date(), deadline: goal.deadline)
+            
+            return String(format: "%04d %02d %02d", daystamp.year, daystamp.month, daystamp.day)
+        }()
         
-        // if the goal's deadline is before midnight and has already passed for this calendar day, default to entering data for the "next" day
-        if goalDeadline < 0 {
-            let deadlineSecondsAfterMidnight = 24*3600 + goalDeadline
-            let deadlineHour = deadlineSecondsAfterMidnight/3600
-            let deadlineMinute = (deadlineSecondsAfterMidnight % 3600)/60
-            let currentMinute = components.minute
-            if deadlineHour < currentHour! ||
-                (deadlineHour == currentHour! && deadlineMinute < currentMinute!) {
-                offset = 1
-            }
-        }
-        
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US")
-        formatter.dateFormat = "d"
-        
-        let params = ["urtext": "\(formatter.string(from: Date(timeIntervalSinceNow: offset*24*3600))) \(Int(self.valueStepper.value)) \"Added via iOS widget\"", "requestid": UUID().uuidString]
+        let params = ["urtext": "\(urtextDaystamp) \(Int(self.valueStepper.value)) \"Added via iOS widget\"", "requestid": UUID().uuidString]
         let slug = goal.slug
 
         Task { @MainActor in

--- a/BeeSwiftToday/TodayTableViewCell.swift
+++ b/BeeSwiftToday/TodayTableViewCell.swift
@@ -125,13 +125,11 @@ class TodayTableViewCell: UITableViewCell {
         hud.mode = .indeterminate
         self.addDataButton.isUserInteractionEnabled = false
         
-        let urtextDaystamp: String = {
-            let daystamp = Daystamp(fromDate: Date(), deadline: goal.deadline)
-            
-            return String(format: "%04d %02d %02d", daystamp.year, daystamp.month, daystamp.day)
-        }()
+        let urtextDaystamp = Daystamp.makeUrtextDaystamp(submissionDate: Date(), goal: goal)
+        let value = Int(self.valueStepper.value)
+        let comment = "Added via iOS widget"
         
-        let params = ["urtext": "\(urtextDaystamp) \(Int(self.valueStepper.value)) \"Added via iOS widget\"", "requestid": UUID().uuidString]
+        let params = ["urtext": "\(urtextDaystamp) \(value) \"\(comment)\"", "requestid": UUID().uuidString]
         let slug = goal.slug
 
         Task { @MainActor in


### PR DESCRIPTION
``Daystamp`` contains the logic for calculating the date (all of year, month, and day) that should be reported as the daystamp of a newly created datapoint, including accounting for the goal's deadline.

This merge request uses Daystamp and this feature of it to replace the three instances of other areas in the app tackling this same calculation: in Today View extension, in Goal / add datapoint, and in Timer.

Furthermore, three places with their own implementations all suffered the same logic error of not accounting for certain deadlines correctly - in particular deadlines just after midnight (midnight until 1 in the morning):

```swift
 if self.goal.deadline > 0 && currentHour! < 6 && currentHour! < self.goal.deadline/3600 {
            self.dateStepper.value = -1
        }
```
If there was not a whole hour of difference, then the deadline was effectively ignored. 

Fixes #17 
Fixes #228 

--
There have been many reports of the app not handling deadlines well or properly. Commit 5f3278c6f9a2d6fef21d63d7288739d31c81d1d3 introduces logic for handling the deadline in the Goal/add and Timer screens.
Other, possibly related issues: #17, #35, #228, #450