### PR TITLE
using alamofireimage for transitions when loading thumbnails and graphs

### DIFF
--- a/BeeSwift/Components/GoalImageView.swift
+++ b/BeeSwift/Components/GoalImageView.swift
@@ -35,16 +35,16 @@ class GoalImageView : UIView {
     init(isThumbnail: Bool) {
         self.isThumbnail = isThumbnail
         super.init(frame: CGRect(x: 0, y: 0, width: 0, height: 0))
-        setupView()
+        setUpView()
     }
 
     required init?(coder: NSCoder) {
         self.isThumbnail = false
         super.init(coder: coder)
-        setupView()
+        setUpView()
     }
 
-    private func setupView() {
+    private func setUpView() {
         self.addSubview(imageView)
         imageView.snp.makeConstraints { (make) in
             make.edges.equalToSuperview()


### PR DESCRIPTION
It was already being used in the Today Extension view but not for the graphs and graph thumbnails elsewhere in the app. Using it simplifies the code and allows for easily adding transitions. When scrolling the gallery or loading a goal, the user experience is enhanced by using smooth rather than jarring animations and transitions.