### PR TITLE
Introduce CoreDataEvolution library

### DIFF
--- a/.github/workflows/fastlane-tests.yml
+++ b/.github/workflows/fastlane-tests.yml
@@ -23,6 +23,8 @@ jobs:
       with:
         ruby-version: '3.3.5'
         bundler-cache: true
+    - name: Enable Macros
+      run: defaults write com.apple.dt.Xcode IDESkipMacroFingerprintValidation -bool YES
     - name: Run tests
       run: bundle exec fastlane ci
     - name: Upload report

--- a/BeeSwift.xcodeproj/project.pbxproj
+++ b/BeeSwift.xcodeproj/project.pbxproj
@@ -101,6 +101,7 @@
 		E46DC80F2AA58DF20059FDFE /* PullToRefreshHint.swift in Sources */ = {isa = PBXBuildFile; fileRef = E46DC80E2AA58DF20059FDFE /* PullToRefreshHint.swift */; };
 		E486DE2629B0403700F338B2 /* OrderedCollections in Frameworks */ = {isa = PBXBuildFile; productRef = E486DE2529B0403700F338B2 /* OrderedCollections */; };
 		E486DE2A29B0410A00F338B2 /* OrderedCollections in Frameworks */ = {isa = PBXBuildFile; productRef = E486DE2929B0410A00F338B2 /* OrderedCollections */; };
+		E48D9F0E2CE9A3A80041957F /* CoreDataEvolution in Frameworks */ = {isa = PBXBuildFile; productRef = E48D9F0D2CE9A3A80041957F /* CoreDataEvolution */; };
 		E48E2714296B75E4008013C0 /* TotalSleepMinutesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E48E2713296B75E4008013C0 /* TotalSleepMinutesTests.swift */; };
 		E48E27202973261F008013C0 /* BackgroundUpdates.swift in Sources */ = {isa = PBXBuildFile; fileRef = E48E271F2973261F008013C0 /* BackgroundUpdates.swift */; };
 		E4B083392932F90400A71564 /* ConfigureHKMetricViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4B083382932F90400A71564 /* ConfigureHKMetricViewController.swift */; };
@@ -378,6 +379,7 @@
 				E458C8242AD11D7F000DCA5C /* KeychainSwift in Frameworks */,
 				E458C8202AD11D35000DCA5C /* SwiftyJSON in Frameworks */,
 				E458C8292AD12057000DCA5C /* OrderedCollections in Frameworks */,
+				E48D9F0E2CE9A3A80041957F /* CoreDataEvolution in Frameworks */,
 				E458C8222AD11D40000DCA5C /* Alamofire in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -790,6 +792,7 @@
 				E458C8212AD11D40000DCA5C /* Alamofire */,
 				E458C8232AD11D7F000DCA5C /* KeychainSwift */,
 				E458C8282AD12057000DCA5C /* OrderedCollections */,
+				E48D9F0D2CE9A3A80041957F /* CoreDataEvolution */,
 			);
 			productName = BeeKit;
 			productReference = E57BE6E02655EBD900BA540B /* BeeKit.framework */;
@@ -942,6 +945,7 @@
 				E462BA5829AEF02500E80EF0 /* XCRemoteSwiftPackageReference "IQKeyboardManager" */,
 				E486DE2429B0403700F338B2 /* XCRemoteSwiftPackageReference "swift-collections" */,
 				E41286EF2A62E6840093D598 /* XCRemoteSwiftPackageReference "keychain-swift" */,
+				E48D9F0C2CE9A3A80041957F /* XCRemoteSwiftPackageReference "CoreDataEvolution" */,
 			);
 			productRefGroup = A196CB151AE4142E00B90A3E /* Products */;
 			projectDirPath = "";
@@ -1867,6 +1871,14 @@
 				minimumVersion = 1.0.0;
 			};
 		};
+		E48D9F0C2CE9A3A80041957F /* XCRemoteSwiftPackageReference "CoreDataEvolution" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/fatbobman/CoreDataEvolution.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.4.1;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -1964,6 +1976,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = E486DE2429B0403700F338B2 /* XCRemoteSwiftPackageReference "swift-collections" */;
 			productName = OrderedCollections;
+		};
+		E48D9F0D2CE9A3A80041957F /* CoreDataEvolution */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E48D9F0C2CE9A3A80041957F /* XCRemoteSwiftPackageReference "CoreDataEvolution" */;
+			productName = CoreDataEvolution;
 		};
 /* End XCSwiftPackageProductDependency section */
 

--- a/BeeSwift.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/BeeSwift.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "121374f8df4bd0fc72c8a7d3bb25f4397be6b7176d735626ebd621dc1655f2e8",
+  "originHash" : "aa72db5bf8a6483009e722818f5aa2f8c2fb23032be675b0ee51310237f6cb1f",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -26,6 +26,15 @@
       "state" : {
         "revision" : "392bed083e8d193aca16bfa684ee24e4bcff0510",
         "version" : "3.1.0"
+      }
+    },
+    {
+      "identity" : "coredataevolution",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/fatbobman/CoreDataEvolution.git",
+      "state" : {
+        "revision" : "838e638777775100924e6b3d64059aedebcfcc93",
+        "version" : "0.4.1"
       }
     },
     {
@@ -134,6 +143,15 @@
       "state" : {
         "revision" : "937e904258d22af6e447a0b72c0bc67583ef64a2",
         "version" : "1.0.4"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-syntax.git",
+      "state" : {
+        "revision" : "0687f71944021d616d34d922343dcef086855920",
+        "version" : "600.0.1"
       }
     },
     {

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -43,15 +43,11 @@ platform :ios do
         include_simulator_logs: true,
         buildlog_path: "fastlane/test_output",
         xcodebuild_formatter: "xcpretty",
-        xcargs: "-skipPackagePluginValidation",
         ensure_devices_found: true,
     )
   end
   lane :build do
-    build_app(
-        scheme: "BeeSwift",
-        xcargs: "-skipPackagePluginValidation",
-    )
+    build_app(scheme: "BeeSwift")
   end
   lane :beta do
     # Ensure that your git status is not dirty

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -43,11 +43,15 @@ platform :ios do
         include_simulator_logs: true,
         buildlog_path: "fastlane/test_output",
         xcodebuild_formatter: "xcpretty",
+        xcargs: "-skipPackagePluginValidation",
         ensure_devices_found: true,
     )
   end
   lane :build do
-    build_app(scheme: "BeeSwift")
+    build_app(
+        scheme: "BeeSwift",
+        xcargs: "-skipPackagePluginValidation",
+    )
   end
   lane :beta do
     # Ensure that your git status is not dirty


### PR DESCRIPTION
This adds the CoreDataEvolution library via SwiftPackageManager. This provides helpers to allow CoreData to work with actors like SwiftData does, which should help with some threading crashes.

Testing:
None