### PR TITLE
Make User model updates more like Goal and DataPoint

### DIFF
--- a/BeeKit/Managers/CurrentUserManager.swift
+++ b/BeeKit/Managers/CurrentUserManager.swift
@@ -193,14 +193,7 @@ public class CurrentUserManager {
         try deleteUser()
 
         let context = container.newBackgroundContext()
-
-        let _ = User(context: context,
-             username: responseJSON[CurrentUserManager.usernameKey].string!,
-             deadbeat: responseJSON["deadbeat"].boolValue,
-             timezone: responseJSON[CurrentUserManager.beemTZKey].string!,
-             defaultAlertStart: responseJSON[CurrentUserManager.defaultAlertstartKey].intValue,
-             defaultDeadline: responseJSON[CurrentUserManager.defaultDeadlineKey].intValue,
-             defaultLeadTime: responseJSON[CurrentUserManager.defaultLeadtimeKey].intValue)
+        let _ = User(context: context, json: responseJSON)
         try context.save()
 
         if responseJSON["deadbeat"].boolValue {
@@ -217,19 +210,19 @@ public class CurrentUserManager {
         }.value
     }
     
-    public func syncNotificationDefaults() async throws {
+    public func refreshUser() async throws {
         let response = try await requestManager.get(url: "api/v1/users/\(username!).json", parameters: [:])
         let responseJSON = JSON(response!)
 
         try! modifyUser { user in
-            user.defaultAlertStart = responseJSON["default_alertstart"].intValue
-            user.defaultDeadline = responseJSON["default_deadline"].intValue
-            user.defaultLeadTime = responseJSON["default_leadtime"].intValue
+            user.updateToMatch(json: responseJSON)
         }
 
-        self.set(responseJSON["default_alertstart"].number!, forKey: "default_alertstart")
-        self.set(responseJSON["default_deadline"].number!, forKey: "default_deadline")
-        self.set(responseJSON["default_leadtime"].number!, forKey: "default_leadtime")
+        self.set(responseJSON[CurrentUserManager.usernameKey].string!, forKey: CurrentUserManager.usernameKey)
+        self.set(responseJSON[CurrentUserManager.defaultAlertstartKey].number!, forKey: CurrentUserManager.defaultAlertstartKey)
+        self.set(responseJSON[CurrentUserManager.defaultDeadlineKey].number!, forKey: CurrentUserManager.defaultDeadlineKey)
+        self.set(responseJSON[CurrentUserManager.defaultLeadtimeKey].number!, forKey: CurrentUserManager.defaultLeadtimeKey)
+        self.set(responseJSON[CurrentUserManager.beemTZKey].string!, forKey: CurrentUserManager.beemTZKey)
     }
     
     func handleFailedSignin(_ responseError: Error, errorMessage : String?) async throws {

--- a/BeeKit/Model/User.swift
+++ b/BeeKit/Model/User.swift
@@ -1,6 +1,8 @@
 import Foundation
 import CoreData
 
+import SwiftyJSON
+
 @objc(User)
 public class User: NSManagedObject {
     @NSManaged public var username: String
@@ -35,6 +37,24 @@ public class User: NSManagedObject {
         self.defaultAlertStart = defaultAlertStart
         self.defaultDeadline = defaultDeadline
         self.defaultLeadTime = defaultLeadTime
+
+        lastModifiedLocal = Date()
+    }
+
+    public init(context: NSManagedObjectContext, json: JSON) {
+        let entity = NSEntityDescription.entity(forEntityName: "User", in: context)!
+        super.init(entity: entity, insertInto: context)
+
+        self.updateToMatch(json: json)
+    }
+
+    public func updateToMatch(json: JSON) {
+        self.username = json["username"].string!
+        self.deadbeat = json["deadbeat"].bool!
+        self.timezone = json["timezone"].string!
+        self.defaultAlertStart = json["default_alertstart"].int!
+        self.defaultDeadline = json["default_deadline"].int!
+        self.defaultLeadTime = json["default_leadtime"].int!
 
         lastModifiedLocal = Date()
     }

--- a/BeeSwift/Settings/EditGoalNotificationsViewController.swift
+++ b/BeeSwift/Settings/EditGoalNotificationsViewController.swift
@@ -126,7 +126,7 @@ class EditGoalNotificationsViewController : EditNotificationsViewController {
                     }
 
                     do {
-                        try await ServiceLocator.currentUserManager.syncNotificationDefaults()
+                        try await ServiceLocator.currentUserManager.refreshUser()
                     } catch {
                         self.logger.error("Error syncing notification defaults")
                         // TODO: Show UI failure


### PR DESCRIPTION
Change the structure of User creation and update code to more closely match Goal/DataPoint. This makes User responsible for updating from json results itself. As part of this, change the incremental user update code from just syncing notification properties to all properties.

This is a step towards fixing timezone issues, but isn't a complete fix as we still don't actually trigger a user refresh on a regular basis.

Testing:
Verified the app can load and login
Verify the goal notification settings toggle still works