### PR TITLE
Use NSModelActor for HealthStoreManager

### DIFF
--- a/BeeSwift/AppDelegate.swift
+++ b/BeeSwift/AppDelegate.swift
@@ -38,7 +38,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         if HKHealthStore.isHealthDataAvailable() {
                 // We must register queries for all our healthkit metrics before this method completes
                 // in order to successfully be delivered background updates.
-                ServiceLocator.healthStoreManager.silentlyInstallObservers()
+            ServiceLocator.healthStoreManager.silentlyInstallObservers(context: ServiceLocator.persistentContainer.viewContext)
         }
         
         NetworkActivityIndicatorManager.shared.isEnabled = true

--- a/BeeSwift/BackgroundUpdates.swift
+++ b/BeeSwift/BackgroundUpdates.swift
@@ -45,7 +45,7 @@ class BackgroundUpdates {
                 async let goalUpdateResult: () = ServiceLocator.healthStoreManager.updateAllGoalsWithRecentData(days: 3)
 
                 try await ServiceLocator.goalManager.refreshGoals()
-                ServiceLocator.healthStoreManager.silentlyInstallObservers()
+                ServiceLocator.healthStoreManager.silentlyInstallObservers(context: ServiceLocator.persistentContainer.viewContext)
 
                 try await goalUpdateResult
             } catch {


### PR DESCRIPTION
This converts HealthStoreManager to be an actor. This allows us to us NSModelActor and have correct threading for CoreData, hopefully avoiding some crashes. Because this exposes a method which must be non-async, there's some usage of `nonisolated`.

Testing:
Ran on device, verified it would sync metrics on startup, and on pull to refresh.