### PR TITLE
Reduce CurrentUserManager wrappers

### DIFF
--- a/BeeKit/Managers/CurrentUserManager.swift
+++ b/BeeKit/Managers/CurrentUserManager.swift
@@ -132,27 +132,12 @@ public class CurrentUserManager {
         return (user()?.defaultLeadTime ?? 0) as NSNumber
     }
     
-    public func setDefaultLeadTime(_ leadtime : NSNumber) {
-        try! modifyUser { $0.defaultLeadTime = leadtime as! Int }
-        self.set(leadtime, forKey: CurrentUserManager.defaultLeadtimeKey)
-    }
-
     public func defaultAlertstart() -> Int {
         return (user()?.defaultAlertStart ?? 0) as Int
     }
     
-    public func setDefaultAlertstart(_ alertstart : Int) {
-        try! modifyUser { $0.defaultAlertStart = alertstart }
-        self.set(alertstart, forKey: CurrentUserManager.defaultAlertstartKey)
-    }
-    
     public func defaultDeadline() -> Int {
         return (user()?.defaultDeadline ?? 0) as Int
-    }
-    
-    public func setDefaultDeadline(_ deadline : Int) {
-        try! modifyUser { $0.defaultDeadline = deadline }
-        self.set(deadline, forKey: CurrentUserManager.defaultDeadlineKey)
     }
     
     public func signedIn() -> Bool {

--- a/BeeKit/Managers/CurrentUserManager.swift
+++ b/BeeKit/Managers/CurrentUserManager.swift
@@ -185,7 +185,6 @@ public class CurrentUserManager {
         self.set(responseJSON[CurrentUserManager.defaultLeadtimeKey].number!, forKey: CurrentUserManager.defaultLeadtimeKey)
         self.set(responseJSON[CurrentUserManager.beemTZKey].string!, forKey: CurrentUserManager.beemTZKey)
 
-        // TODO: Refresh the user in mpain thread
         await Task { @MainActor in
             guard let user = self.user(context: container.viewContext) else { return }
             container.viewContext.refresh(user, mergeChanges: false)

--- a/BeeKit/Managers/CurrentUserManager.swift
+++ b/BeeKit/Managers/CurrentUserManager.swift
@@ -184,6 +184,12 @@ public class CurrentUserManager {
         self.set(responseJSON[CurrentUserManager.defaultDeadlineKey].number!, forKey: CurrentUserManager.defaultDeadlineKey)
         self.set(responseJSON[CurrentUserManager.defaultLeadtimeKey].number!, forKey: CurrentUserManager.defaultLeadtimeKey)
         self.set(responseJSON[CurrentUserManager.beemTZKey].string!, forKey: CurrentUserManager.beemTZKey)
+
+        // TODO: Refresh the user in mpain thread
+        await Task { @MainActor in
+            guard let user = self.user(context: container.viewContext) else { return }
+            container.viewContext.refresh(user, mergeChanges: false)
+        }.value
     }
     
     func handleFailedSignin(_ responseError: Error, errorMessage : String?) async throws {

--- a/BeeKit/Managers/CurrentUserManager.swift
+++ b/BeeKit/Managers/CurrentUserManager.swift
@@ -119,7 +119,6 @@ public class CurrentUserManager {
         userDefaults.removeObject(forKey: key)
     }
 
-    
     public var accessToken :String? {
         return keychain.get(CurrentUserManager.accessTokenKey)
     }
@@ -128,37 +127,12 @@ public class CurrentUserManager {
         return user()?.username
     }
 
-    public func defaultLeadTime() -> NSNumber {
-        return (user()?.defaultLeadTime ?? 0) as NSNumber
-    }
-    
-    public func defaultAlertstart() -> Int {
-        return (user()?.defaultAlertStart ?? 0) as Int
-    }
-    
-    public func defaultDeadline() -> Int {
-        return (user()?.defaultDeadline ?? 0) as Int
-    }
-    
     public func signedIn() -> Bool {
         return self.accessToken != nil && self.username != nil
     }
     
     public func isDeadbeat() -> Bool {
         return user()?.deadbeat ?? false
-    }
-    
-    public func timezone() -> String {
-        return user()?.timezone ?? "Unknown"
-    }
-    
-    public func setDeadbeat(_ deadbeat: Bool) {
-        try! modifyUser { $0.deadbeat = deadbeat }
-        if deadbeat {
-            self.set(true, forKey: CurrentUserManager.deadbeatKey)
-        } else {
-            self.removeObject(forKey: CurrentUserManager.deadbeatKey)
-        }
     }
     
     func setAccessToken(_ accessToken: String) {
@@ -182,7 +156,9 @@ public class CurrentUserManager {
         try context.save()
 
         if responseJSON["deadbeat"].boolValue {
-            self.setDeadbeat(true)
+            self.set(true, forKey: CurrentUserManager.deadbeatKey)
+        } else {
+            self.removeObject(forKey: CurrentUserManager.deadbeatKey)
         }
         self.setAccessToken(responseJSON[CurrentUserManager.accessTokenKey].string!)
         self.set(responseJSON[CurrentUserManager.usernameKey].string!, forKey: CurrentUserManager.usernameKey)

--- a/BeeSwift/Settings/EditDefaultNotificationsViewController.swift
+++ b/BeeSwift/Settings/EditDefaultNotificationsViewController.swift
@@ -33,7 +33,7 @@ class EditDefaultNotificationsViewController: EditNotificationsViewController {
             let params = [ "default_leadtime" : leadtime ]
             do {
                 let _ = try await ServiceLocator.requestManager.put(url: "api/v1/users/{username}.json", parameters: params)
-                ServiceLocator.currentUserManager.setDefaultLeadTime(leadtime)
+                try await ServiceLocator.currentUserManager.refreshUser()
             } catch {
                 logger.error("Error setting default leadtime: \(error)")
                 // show alert
@@ -53,7 +53,7 @@ class EditDefaultNotificationsViewController: EditNotificationsViewController {
                 let params = ["default_alertstart" : self.midnightOffsetFromTimePickerView()]
                 do {
                     let _ = try await ServiceLocator.requestManager.put(url: "api/v1/users/{username}.json", parameters: params)
-                    ServiceLocator.currentUserManager.setDefaultAlertstart(self.midnightOffsetFromTimePickerView())
+                    try await ServiceLocator.currentUserManager.refreshUser()
                 } catch {
                     logger.error("Error setting default alert start: \(error)")
                     //foo
@@ -64,7 +64,7 @@ class EditDefaultNotificationsViewController: EditNotificationsViewController {
                 let params = ["default_deadline" : self.midnightOffsetFromTimePickerView()]
                 do {
                     let _ = try await ServiceLocator.requestManager.put(url: "api/v1/users/{username}.json", parameters: params)
-                    ServiceLocator.currentUserManager.setDefaultDeadline(self.midnightOffsetFromTimePickerView())
+                    try await ServiceLocator.currentUserManager.refreshUser()
                 } catch {
                     logger.error("Error setting default deadline: \(error)")
                     //foo

--- a/BeeSwift/Settings/EditDefaultNotificationsViewController.swift
+++ b/BeeSwift/Settings/EditDefaultNotificationsViewController.swift
@@ -13,16 +13,19 @@ import BeeKit
 
 class EditDefaultNotificationsViewController: EditNotificationsViewController {
     private let logger = Logger(subsystem: "com.beeminder.beeminder", category: "EditDefaultNotificationsViewController")
-    
+
+    private let user: User
+
     override init() {
+        self.user = ServiceLocator.currentUserManager.user(context: ServiceLocator.persistentContainer.viewContext)!
         super.init()
-        self.leadTimeStepper.value = ServiceLocator.currentUserManager.defaultLeadTime().doubleValue
-        self.alertstart = ServiceLocator.currentUserManager.defaultAlertstart()
-        self.deadline = ServiceLocator.currentUserManager.defaultDeadline()
+        self.leadTimeStepper.value = Double(user.defaultLeadTime)
+        self.alertstart = self.user.defaultAlertStart
+        self.deadline = self.user.defaultDeadline
     }
 
     required init?(coder aDecoder: NSCoder) {
-        super.init(coder: aDecoder)
+        fatalError("init(coder:) has not been implemented")
     }
     
     override func sendLeadTimeToServer(_ timer : Timer) {

--- a/BeeSwift/Settings/EditGoalNotificationsViewController.swift
+++ b/BeeSwift/Settings/EditGoalNotificationsViewController.swift
@@ -15,10 +15,12 @@ import BeeKit
 class EditGoalNotificationsViewController : EditNotificationsViewController {
     private let logger = Logger(subsystem: "com.beeminder.beeminder", category: "EditGoalNotificationsViewController")
 
+    let user: User
     let goal: Goal
     fileprivate var useDefaultsSwitch = UISwitch()
     
     init(goal : Goal) {
+        self.user = ServiceLocator.currentUserManager.user(context: ServiceLocator.persistentContainer.viewContext)!
         self.goal = goal
         
         super.init()
@@ -133,10 +135,10 @@ class EditGoalNotificationsViewController : EditNotificationsViewController {
                         return
                     }
 
-                    self.leadTimeStepper.value = ServiceLocator.currentUserManager.defaultLeadTime().doubleValue
+                    self.leadTimeStepper.value = Double(self.user.defaultLeadTime)
                     self.updateLeadTimeLabel()
-                    self.alertstart = ServiceLocator.currentUserManager.defaultAlertstart()
-                    self.deadline   = ServiceLocator.currentUserManager.defaultDeadline()
+                    self.alertstart = self.user.defaultAlertStart
+                    self.deadline   = self.user.defaultDeadline
                     self.timePickerEditingMode = self.timePickerEditingMode // trigger the setter which updates the timePicker components
                 }
             }))

--- a/BeeSwift/Settings/SettingsViewController.swift
+++ b/BeeSwift/Settings/SettingsViewController.swift
@@ -139,7 +139,9 @@ extension SettingsViewController : UITableViewDataSource, UITableViewDelegate {
             cell.imageName = "Notifications"
             cell.accessoryType = .disclosureIndicator
         case 2:
-            cell.title = "Time zone: \(ServiceLocator.currentUserManager.timezone())"
+            let user = ServiceLocator.currentUserManager.user(context: ServiceLocator.persistentContainer.viewContext)
+            let timezone = user?.timezone ?? "Unknown"
+            cell.title = "Time zone: \(timezone)"
             cell.imageName = "Clock"
             cell.accessoryType = .none
         case 3:


### PR DESCRIPTION
Previously many attributes on `User` were read using wrappers in `CurrentUserManager`. These wrappers would do lots of context allocation. Get rid of the wrappers, and have the end users just read from the `User` object directly.

Testing:
Verified that it was still possible to change goal notification settings