### PR TITLE
Convert `CurrentUserManager` to actor

### DIFF
--- a/BeeKit/Managers/CurrentUserManager.swift
+++ b/BeeKit/Managers/CurrentUserManager.swift
@@ -7,12 +7,14 @@
 //
 
 import CoreData
+import CoreDataEvolution
 import Foundation
 import KeychainSwift
 import OSLog
 import SwiftyJSON
 
-public class CurrentUserManager {
+@NSModelActor(disableGenerateInit: true)
+public actor CurrentUserManager {
     let logger = Logger(subsystem: "com.beeminder.beeminder", category: "CurrentUserManager")
 
     public static let signedInNotificationName     = "com.beeminder.signedInNotification"
@@ -37,24 +39,27 @@ public class CurrentUserManager {
 
     private let keychain = KeychainSwift(keyPrefix: CurrentUserManager.keychainPrefix)
     private let requestManager: RequestManager
-    private let container: BeeminderPersistentContainer
 
     fileprivate static var allKeys: [String] {
         [accessTokenKey, usernameKey, deadbeatKey, defaultLeadtimeKey, defaultAlertstartKey, defaultDeadlineKey, beemTZKey]
     }
     
-    let userDefaults = UserDefaults(suiteName: Constants.appGroupIdentifier)!
-    
+    nonisolated let userDefaults = UserDefaults(suiteName: Constants.appGroupIdentifier)!
+
     init(requestManager: RequestManager, container: BeeminderPersistentContainer) {
         self.requestManager = requestManager
-        self.container = container
+        modelContainer = container
+        let context = container.newBackgroundContext()
+        modelExecutor = .init(context: context)
         migrateValuesToCoreData()
     }
 
     // If there is an existing session based on UserDefaults, create a new User object
-    private func migrateValuesToCoreData() {
+    private nonisolated func migrateValuesToCoreData() {
+        let context = modelContainer.newBackgroundContext()
+
         // If there is already a session do nothing
-        if user() != nil {
+        if user(context: context) != nil {
             return
         }
 
@@ -63,7 +68,6 @@ public class CurrentUserManager {
             return
         }
 
-        let context = container.newBackgroundContext()
 
         // Create a new user
         let _ = User(context: context,
@@ -78,11 +82,10 @@ public class CurrentUserManager {
     }
 
 
-    public func user(context: NSManagedObjectContext? = nil) -> User? {
+    public nonisolated func user(context: NSManagedObjectContext) -> User? {
         do {
             let request = NSFetchRequest<User>(entityName: "User")
-            let requestContext = context ?? container.newBackgroundContext()
-            let users = try requestContext.fetch(request)
+            let users = try context.fetch(request)
             return users.first
         } catch {
             logger.error("Unable to fetch users \(error)")
@@ -91,20 +94,19 @@ public class CurrentUserManager {
     }
 
     private func modifyUser(_ callback: (User)->()) throws {
-        let context = container.newBackgroundContext()
-        guard let user = self.user(context: context) else { return }
+        guard let user = self.user(context: modelContext) else { return }
+        modelContext.refresh(user, mergeChanges: false)
         callback(user)
-        try context.save()
+        try modelContext.save()
     }
 
     private func deleteUser() throws {
-        let context = container.newBackgroundContext()
-
         // Delete any existing users. We expect at most one, but delete all to be safe.
-        while let user = self.user(context: context) {
-            context.delete(user)
+        modelContext.refreshAllObjects()
+        while let user = self.user(context: modelContext) {
+            modelContext.delete(user)
         }
-        try context.save()
+        try modelContext.save()
     }
 
     /// Write a value to the UserDefaults store
@@ -119,20 +121,20 @@ public class CurrentUserManager {
         userDefaults.removeObject(forKey: key)
     }
 
-    public var accessToken :String? {
+    public nonisolated var accessToken :String? {
         return keychain.get(CurrentUserManager.accessTokenKey)
     }
     
     public var username :String? {
-        return user()?.username
+        return user(context: modelContext)?.username
     }
 
     public func signedIn() -> Bool {
         return self.accessToken != nil && self.username != nil
     }
     
-    public func isDeadbeat() -> Bool {
-        return user()?.deadbeat ?? false
+    public nonisolated func isDeadbeat(context: NSManagedObjectContext) -> Bool {
+        return user(context: context)?.deadbeat ?? false
     }
     
     func setAccessToken(_ accessToken: String) {
@@ -151,9 +153,8 @@ public class CurrentUserManager {
     func handleSuccessfulSignin(_ responseJSON: JSON) async throws {
         try deleteUser()
 
-        let context = container.newBackgroundContext()
-        let _ = User(context: context, json: responseJSON)
-        try context.save()
+        let _ = User(context: modelContext, json: responseJSON)
+        try modelContext.save()
 
         if responseJSON["deadbeat"].boolValue {
             self.set(true, forKey: CurrentUserManager.deadbeatKey)
@@ -186,8 +187,8 @@ public class CurrentUserManager {
         self.set(responseJSON[CurrentUserManager.beemTZKey].string!, forKey: CurrentUserManager.beemTZKey)
 
         await Task { @MainActor in
-            guard let user = self.user(context: container.viewContext) else { return }
-            container.viewContext.refresh(user, mergeChanges: false)
+            guard let user = self.user(context: modelContainer.viewContext) else { return }
+            modelContainer.viewContext.refresh(user, mergeChanges: false)
         }.value
     }
     

--- a/BeeKit/Managers/CurrentUserManager.swift
+++ b/BeeKit/Managers/CurrentUserManager.swift
@@ -50,6 +50,7 @@ public actor CurrentUserManager {
         self.requestManager = requestManager
         modelContainer = container
         let context = container.newBackgroundContext()
+        context.name = "CurrentUserManager"
         modelExecutor = .init(context: context)
         migrateValuesToCoreData()
     }
@@ -129,15 +130,15 @@ public actor CurrentUserManager {
         return user(context: modelContext)?.username
     }
 
-    public func signedIn() -> Bool {
-        return self.accessToken != nil && self.username != nil
+    public nonisolated func signedIn(context: NSManagedObjectContext) -> Bool {
+        return self.accessToken != nil && self.user(context: context)?.username != nil
     }
     
     public nonisolated func isDeadbeat(context: NSManagedObjectContext) -> Bool {
         return user(context: context)?.deadbeat ?? false
     }
     
-    func setAccessToken(_ accessToken: String) {
+    nonisolated func setAccessToken(_ accessToken: String) {
         keychain.set(accessToken, forKey: CurrentUserManager.accessTokenKey, withAccess: .accessibleAfterFirstUnlock)
     }
     

--- a/BeeKit/Managers/GoalManager.swift
+++ b/BeeKit/Managers/GoalManager.swift
@@ -55,7 +55,7 @@ public actor GoalManager {
 
     /// Fetch and return the latest set of goals from the server
     public func refreshGoals() async throws {
-        guard let username = currentUserManager.username else {
+        guard let username = await currentUserManager.username else {
             try await currentUserManager.signOut()
             return
         }

--- a/BeeKit/Managers/RequestManager.swift
+++ b/BeeKit/Managers/RequestManager.swift
@@ -33,7 +33,7 @@ public class RequestManager {
 
         var urlWithSubstitutions = url
         if url.contains("{username}") {
-            guard let username = ServiceLocator.currentUserManager.username else {
+            guard let username = await ServiceLocator.currentUserManager.username else {
                 throw ServerError("Attempted to make request to username-based URL \(url) while logged out", requestError: nil)
             }
             urlWithSubstitutions = urlWithSubstitutions.replacingOccurrences(of: "{username}", with: username)

--- a/BeeSwift/Components/GoalImageView.swift
+++ b/BeeSwift/Components/GoalImageView.swift
@@ -91,7 +91,7 @@ class GoalImageView : UIView {
         }
 
         //  - Deadbeat: Placeholder, no animation
-        if ServiceLocator.currentUserManager.isDeadbeat() {
+        if ServiceLocator.currentUserManager.isDeadbeat(context: ServiceLocator.persistentContainer.viewContext) {
             clearGoalGraph()
             return
         }

--- a/BeeSwift/Gallery/GalleryViewController.swift
+++ b/BeeSwift/Gallery/GalleryViewController.swift
@@ -83,7 +83,7 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
             make.left.equalTo(0)
             make.right.equalTo(0)
             make.top.equalTo(self.lastUpdatedView.snp.bottom)
-            if !ServiceLocator.currentUserManager.isDeadbeat() {
+            if !ServiceLocator.currentUserManager.isDeadbeat(context: ServiceLocator.persistentContainer.viewContext) {
                 make.height.equalTo(0)
             }
         }
@@ -299,7 +299,7 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
             make.left.equalTo(0)
             make.right.equalTo(0)
             make.top.equalTo(self.lastUpdatedView.snp.bottom)
-            if !ServiceLocator.currentUserManager.isDeadbeat() {
+            if !ServiceLocator.currentUserManager.isDeadbeat(context: ServiceLocator.persistentContainer.viewContext) {
                 make.height.equalTo(0)
             }
         }

--- a/BeeSwift/Gallery/GalleryViewController.swift
+++ b/BeeSwift/Gallery/GalleryViewController.swift
@@ -162,7 +162,7 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
         self.updateGoals()
         self.fetchGoals()
 
-        if ServiceLocator.currentUserManager.signedIn() {
+        if ServiceLocator.currentUserManager.signedIn(context: ServiceLocator.persistentContainer.viewContext) {
             UNUserNotificationCenter.current().requestAuthorization(options: UNAuthorizationOptions([.alert, .badge, .sound])) { (success, error) in
                 print(success)
                 if success {
@@ -208,7 +208,7 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
     }
     
     override func viewDidAppear(_ animated: Bool) {
-        if !ServiceLocator.currentUserManager.signedIn() {
+        if !ServiceLocator.currentUserManager.signedIn(context: ServiceLocator.persistentContainer.viewContext) {
             let signInVC = SignInViewController()
             signInVC.modalPresentationStyle = .fullScreen
             self.present(signInVC, animated: true, completion: nil)

--- a/BeeSwift/GoalViewController.swift
+++ b/BeeSwift/GoalViewController.swift
@@ -316,7 +316,7 @@ class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTabl
     }
 
     @objc func actionButtonPressed() {
-        guard let username = ServiceLocator.currentUserManager.username,
+        guard let username = goal.owner.username,
             let accessToken = ServiceLocator.currentUserManager.accessToken,
             let viewGoalUrl = URL(string: "\(ServiceLocator.requestManager.baseURLString)/api/v1/users/\(username).json?access_token=\(accessToken)&redirect_to_url=\(ServiceLocator.requestManager.baseURLString)/\(username)/\(self.goal.slug)") else { return }
 

--- a/BeeSwift/GoalViewController.swift
+++ b/BeeSwift/GoalViewController.swift
@@ -316,8 +316,8 @@ class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTabl
     }
 
     @objc func actionButtonPressed() {
-        guard let username = goal.owner.username,
-            let accessToken = ServiceLocator.currentUserManager.accessToken,
+        let username = goal.owner.username
+        guard let accessToken = ServiceLocator.currentUserManager.accessToken,
             let viewGoalUrl = URL(string: "\(ServiceLocator.requestManager.baseURLString)/api/v1/users/\(username).json?access_token=\(accessToken)&redirect_to_url=\(ServiceLocator.requestManager.baseURLString)/\(username)/\(self.goal.slug)") else { return }
 
         let safariVC = SFSafariViewController(url: viewGoalUrl)


### PR DESCRIPTION
As part of moving to use `MSModelActor` instead of abitrary background contexts, this makes `CurrentUserManager` an actor. There remain a few `nonisolated` methods, though these will largely be removed once the migration to `CoreData` is complete.

Testing:
Verified that the app launched and could show a dashboard and refresh goals