### PR TITLE
Use viewContext when updating badge count

### DIFF
--- a/BeeSwift/AppDelegate.swift
+++ b/BeeSwift/AppDelegate.swift
@@ -131,8 +131,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     
     @objc func updateBadgeCount() {
         logger.notice("Updating badge count")
+        assert(Thread.isMainThread, "This code must be run on the main thread")
 
-        let context = ServiceLocator.persistentContainer.newBackgroundContext()
+        let context = ServiceLocator.persistentContainer.viewContext
         guard let goals = ServiceLocator.goalManager.staleGoals(context: context) else { return }
         let beemergencyCount = goals.count(where: { $0.safeBuf < 1})
         logger.notice("Beemergency count is \(beemergencyCount, privacy: .public)")


### PR DESCRIPTION
It looks like updating the badge count for the app always happens on the main thread, which means it can use the viewContext. Add an appropriate assertion and switch to this context.

Testing:
Verified the app could launch and update goals