### PR TITLE
Reduce badge count update noise

### DIFF
--- a/BeeSwift/AppDelegate.swift
+++ b/BeeSwift/AppDelegate.swift
@@ -130,13 +130,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     }
     
     @objc func updateBadgeCount() {
-        logger.notice("Updating badge count")
-        assert(Thread.isMainThread, "This code must be run on the main thread")
+        assert(Thread.isMainThread, "updateBadgeCount must be run on the main thread")
 
         let context = ServiceLocator.persistentContainer.viewContext
         guard let goals = ServiceLocator.goalManager.staleGoals(context: context) else { return }
         let beemergencyCount = goals.count(where: { $0.safeBuf < 1})
-        logger.notice("Beemergency count is \(beemergencyCount, privacy: .public)")
+        logger.notice("Updating Beemergency badge count to \(beemergencyCount, privacy: .public)")
 
         UNUserNotificationCenter.current().setBadgeCount(beemergencyCount)
     }


### PR DESCRIPTION
We were printing two log lines every time we updated the badge count. This seems excessive, reduce just to a single line.

Testing:
Ran app on device