### PR TITLE
Switch to non-blocking fork of CoreDataEvolution

### DIFF
--- a/BeeSwift.xcodeproj/project.pbxproj
+++ b/BeeSwift.xcodeproj/project.pbxproj
@@ -99,9 +99,9 @@
 		E462BA5329ADACAC00E80EF0 /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = E462BA5229ADACAC00E80EF0 /* Alamofire */; };
 		E462BA5A29AEF02500E80EF0 /* IQKeyboardManagerSwift in Frameworks */ = {isa = PBXBuildFile; productRef = E462BA5929AEF02500E80EF0 /* IQKeyboardManagerSwift */; };
 		E46DC80F2AA58DF20059FDFE /* PullToRefreshHint.swift in Sources */ = {isa = PBXBuildFile; fileRef = E46DC80E2AA58DF20059FDFE /* PullToRefreshHint.swift */; };
+		E47445F42CEEA42D003B2DF3 /* CoreDataEvolution in Frameworks */ = {isa = PBXBuildFile; productRef = E47445F32CEEA42D003B2DF3 /* CoreDataEvolution */; };
 		E486DE2629B0403700F338B2 /* OrderedCollections in Frameworks */ = {isa = PBXBuildFile; productRef = E486DE2529B0403700F338B2 /* OrderedCollections */; };
 		E486DE2A29B0410A00F338B2 /* OrderedCollections in Frameworks */ = {isa = PBXBuildFile; productRef = E486DE2929B0410A00F338B2 /* OrderedCollections */; };
-		E48D9F0E2CE9A3A80041957F /* CoreDataEvolution in Frameworks */ = {isa = PBXBuildFile; productRef = E48D9F0D2CE9A3A80041957F /* CoreDataEvolution */; };
 		E48E2714296B75E4008013C0 /* TotalSleepMinutesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E48E2713296B75E4008013C0 /* TotalSleepMinutesTests.swift */; };
 		E48E27202973261F008013C0 /* BackgroundUpdates.swift in Sources */ = {isa = PBXBuildFile; fileRef = E48E271F2973261F008013C0 /* BackgroundUpdates.swift */; };
 		E4B083392932F90400A71564 /* ConfigureHKMetricViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4B083382932F90400A71564 /* ConfigureHKMetricViewController.swift */; };
@@ -379,7 +379,7 @@
 				E458C8242AD11D7F000DCA5C /* KeychainSwift in Frameworks */,
 				E458C8202AD11D35000DCA5C /* SwiftyJSON in Frameworks */,
 				E458C8292AD12057000DCA5C /* OrderedCollections in Frameworks */,
-				E48D9F0E2CE9A3A80041957F /* CoreDataEvolution in Frameworks */,
+				E47445F42CEEA42D003B2DF3 /* CoreDataEvolution in Frameworks */,
 				E458C8222AD11D40000DCA5C /* Alamofire in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -792,7 +792,7 @@
 				E458C8212AD11D40000DCA5C /* Alamofire */,
 				E458C8232AD11D7F000DCA5C /* KeychainSwift */,
 				E458C8282AD12057000DCA5C /* OrderedCollections */,
-				E48D9F0D2CE9A3A80041957F /* CoreDataEvolution */,
+				E47445F32CEEA42D003B2DF3 /* CoreDataEvolution */,
 			);
 			productName = BeeKit;
 			productReference = E57BE6E02655EBD900BA540B /* BeeKit.framework */;
@@ -945,7 +945,7 @@
 				E462BA5829AEF02500E80EF0 /* XCRemoteSwiftPackageReference "IQKeyboardManager" */,
 				E486DE2429B0403700F338B2 /* XCRemoteSwiftPackageReference "swift-collections" */,
 				E41286EF2A62E6840093D598 /* XCRemoteSwiftPackageReference "keychain-swift" */,
-				E48D9F0C2CE9A3A80041957F /* XCRemoteSwiftPackageReference "CoreDataEvolution" */,
+				E47445F22CEEA42D003B2DF3 /* XCRemoteSwiftPackageReference "CoreDataEvolution" */,
 			);
 			productRefGroup = A196CB151AE4142E00B90A3E /* Products */;
 			projectDirPath = "";
@@ -1863,20 +1863,20 @@
 				minimumVersion = 8.0.0;
 			};
 		};
+		E47445F22CEEA42D003B2DF3 /* XCRemoteSwiftPackageReference "CoreDataEvolution" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/theospears/CoreDataEvolution";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.4.1;
+			};
+		};
 		E486DE2429B0403700F338B2 /* XCRemoteSwiftPackageReference "swift-collections" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/apple/swift-collections.git";
 			requirement = {
 				kind = upToNextMajorVersion;
 				minimumVersion = 1.0.0;
-			};
-		};
-		E48D9F0C2CE9A3A80041957F /* XCRemoteSwiftPackageReference "CoreDataEvolution" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/fatbobman/CoreDataEvolution.git";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.4.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
@@ -1967,6 +1967,11 @@
 			package = E462BA5829AEF02500E80EF0 /* XCRemoteSwiftPackageReference "IQKeyboardManager" */;
 			productName = IQKeyboardManagerSwift;
 		};
+		E47445F32CEEA42D003B2DF3 /* CoreDataEvolution */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E47445F22CEEA42D003B2DF3 /* XCRemoteSwiftPackageReference "CoreDataEvolution" */;
+			productName = CoreDataEvolution;
+		};
 		E486DE2529B0403700F338B2 /* OrderedCollections */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = E486DE2429B0403700F338B2 /* XCRemoteSwiftPackageReference "swift-collections" */;
@@ -1976,11 +1981,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = E486DE2429B0403700F338B2 /* XCRemoteSwiftPackageReference "swift-collections" */;
 			productName = OrderedCollections;
-		};
-		E48D9F0D2CE9A3A80041957F /* CoreDataEvolution */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = E48D9F0C2CE9A3A80041957F /* XCRemoteSwiftPackageReference "CoreDataEvolution" */;
-			productName = CoreDataEvolution;
 		};
 /* End XCSwiftPackageProductDependency section */
 

--- a/BeeSwift.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/BeeSwift.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "aa72db5bf8a6483009e722818f5aa2f8c2fb23032be675b0ee51310237f6cb1f",
+  "originHash" : "f9dfc8ea9bd799643133227de52cd3a0abd8893024d3620e0c2b3ce774474906",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -31,9 +31,9 @@
     {
       "identity" : "coredataevolution",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/fatbobman/CoreDataEvolution.git",
+      "location" : "https://github.com/theospears/CoreDataEvolution",
       "state" : {
-        "revision" : "838e638777775100924e6b3d64059aedebcfcc93",
+        "revision" : "07fe6a6bafb5caa3daabdda14fe438a802269d86",
         "version" : "0.4.1"
       }
     },


### PR DESCRIPTION
The CoreDataEvolution library is written in a way that it can sometimes cause deadlocks between actors.[1] Switch to a fork which appears to address the deadlock issues for BeeSwift while waiting for an upstream fix.

Testing:
Ran app on device and observed it did not deadlock. Also observed the fix addresses the deadlock in my minimal repro case.

[1] https://github.com/fatbobman/CoreDataEvolution/issues/1