### PR TITLE
HealthKitConfig.metrics

### DIFF
--- a/BeeKit/GoalExtensions.swift
+++ b/BeeKit/GoalExtensions.swift
@@ -6,9 +6,7 @@ extension Goal {
         if self.autodata == "ifttt" { return "IFTTT" }
         if self.autodata == "api" { return "API" }
         if self.autodata == "apple" {
-            let metric = HealthKitConfig.metrics.first(where: { (metric) -> Bool in
-                metric.databaseString == self.healthKitMetric
-            })
+            let metric = HealthKitConfig.metrics.first(where: { $0.databaseString == self.healthKitMetric })
             return self.healthKitMetric == nil ? "Apple" : metric?.humanText
         }
         if let autodata = self.autodata, autodata.count > 0 { return autodata.capitalized }

--- a/BeeKit/GoalExtensions.swift
+++ b/BeeKit/GoalExtensions.swift
@@ -6,7 +6,7 @@ extension Goal {
         if self.autodata == "ifttt" { return "IFTTT" }
         if self.autodata == "api" { return "API" }
         if self.autodata == "apple" {
-            let metric = HealthKitConfig.shared.metrics.first(where: { (metric) -> Bool in
+            let metric = HealthKitConfig.metrics.first(where: { (metric) -> Bool in
                 metric.databaseString == self.healthKitMetric
             })
             return self.healthKitMetric == nil ? "Apple" : metric?.humanText

--- a/BeeKit/HeathKit/HealthKitConfig.swift
+++ b/BeeKit/HeathKit/HealthKitConfig.swift
@@ -9,12 +9,9 @@
 import Foundation
 import HealthKit
 
-
-public class HealthKitConfig : NSObject {
-    public static let shared = HealthKitConfig()
-
-    public let metrics : [HealthKitMetric] = {
-        var allMetrics : [HealthKitMetric] = [
+public enum HealthKitConfig {
+    public static var metrics: [HealthKitMetric] {
+        [
             // Activity
             QuantityHealthKitMetric(humanText: "Active energy", databaseString: "activeEnergy", category: .Activity, hkQuantityTypeIdentifier: .activeEnergyBurned, precision: [HKUnit.largeCalorie(): 0]),
             QuantityHealthKitMetric(humanText: "Cycling distance", databaseString: "cyclingDistance", category: .Activity, hkQuantityTypeIdentifier: .distanceCycling),
@@ -57,11 +54,9 @@ public class HealthKitConfig : NSObject {
             // Sleep
             TimeInBedHealthKitMetric(humanText: "Time in bed", databaseString: "timeInBed", category: .Sleep),
             TimeAsleepHealthKitMetric(humanText: "Time asleep", databaseString: "timeAsleep", category: .Sleep),
-            
+
             // Other
             QuantityHealthKitMetric(humanText: "Time in Daylight", databaseString: "timeInDaylight", category: .Other, hkQuantityTypeIdentifier: .timeInDaylight),
         ]
-        
-        return allMetrics
-    }()
+    }
 }

--- a/BeeKit/Managers/HealthStoreManager.swift
+++ b/BeeKit/Managers/HealthStoreManager.swift
@@ -149,9 +149,9 @@ public actor HealthStoreManager {
 
         for metricName in metricNames {
             if monitors[metricName] == nil {
-                guard let metric = HealthKitConfig.metrics.first(where: { (metric) -> Bool in
-                    metric.databaseString == metricName
-                }) else {
+                guard
+                    let metric = HealthKitConfig.metrics.first(where: { $0.databaseString == metricName })
+                else {
                     logger.error("No metric found for \(metricName, privacy: .public)")
                     continue
                 }
@@ -195,9 +195,9 @@ public actor HealthStoreManager {
     }
 
     private func updateWithRecentData(goal: Goal, days: Int) async throws {
-        guard let metric = HealthKitConfig.metrics.first(where: { (metric) -> Bool in
-            metric.databaseString == goal.healthKitMetric
-        }) else {
+        guard
+            let metric = HealthKitConfig.metrics.first(where: { $0.databaseString == goal.healthKitMetric })
+        else {
             throw HealthKitError("No metric found for goal \(goal.slug) with metric \(goal.healthKitMetric ?? "nil")")
         }
         let newDataPoints = try await metric.recentDataPoints(days: days, deadline: goal.deadline, healthStore: healthStore)

--- a/BeeKit/Managers/HealthStoreManager.swift
+++ b/BeeKit/Managers/HealthStoreManager.swift
@@ -149,7 +149,7 @@ public actor HealthStoreManager {
 
         for metricName in metricNames {
             if monitors[metricName] == nil {
-                guard let metric = HealthKitConfig.shared.metrics.first(where: { (metric) -> Bool in
+                guard let metric = HealthKitConfig.metrics.first(where: { (metric) -> Bool in
                     metric.databaseString == metricName
                 }) else {
                     logger.error("No metric found for \(metricName, privacy: .public)")
@@ -195,7 +195,7 @@ public actor HealthStoreManager {
     }
 
     private func updateWithRecentData(goal: Goal, days: Int) async throws {
-        guard let metric = HealthKitConfig.shared.metrics.first(where: { (metric) -> Bool in
+        guard let metric = HealthKitConfig.metrics.first(where: { (metric) -> Bool in
             metric.databaseString == goal.healthKitMetric
         }) else {
             throw HealthKitError("No metric found for goal \(goal.slug) with metric \(goal.healthKitMetric ?? "nil")")

--- a/BeeSwift/Settings/ChooseHKMetricViewController.swift
+++ b/BeeSwift/Settings/ChooseHKMetricViewController.swift
@@ -86,7 +86,7 @@ class ChooseHKMetricViewController: UIViewController {
 
 extension ChooseHKMetricViewController : UITableViewDelegate, UITableViewDataSource {
     var sortedHKMetrics: [HealthKitMetric] {
-        HealthKitConfig.shared.metrics.sorted { (lhs, rhs) -> Bool in
+        HealthKitConfig.metrics.sorted { (lhs, rhs) -> Bool in
             lhs.humanText < rhs.humanText
         }
     }

--- a/BeeSwift/Settings/ChooseHKMetricViewController.swift
+++ b/BeeSwift/Settings/ChooseHKMetricViewController.swift
@@ -86,9 +86,7 @@ class ChooseHKMetricViewController: UIViewController {
 
 extension ChooseHKMetricViewController : UITableViewDelegate, UITableViewDataSource {
     var sortedHKMetrics: [HealthKitMetric] {
-        HealthKitConfig.metrics.sorted { (lhs, rhs) -> Bool in
-            lhs.humanText < rhs.humanText
-        }
+        HealthKitConfig.metrics.sorted(using: SortDescriptor(\.humanText))
     }
 
     var sortedMetricsByCategory: Dictionary<HealthKitCategory, [HealthKitMetric]> {


### PR DESCRIPTION
HealthKitConfig was meant to be a singleton, providing access to the list of supported HealthKit metrics. 
Used the `enum` for namespace with _static_ computed property for access to the goods.