### PR TITLE
initial date in add datapoint started with tomorrow rather than yesterday

### DIFF
--- a/BeeSwift/GoalViewController.swift
+++ b/BeeSwift/GoalViewController.swift
@@ -502,7 +502,7 @@ class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTabl
         let daystampAssumingMidnightDeadline = Daystamp(fromDate: date,
                                                         deadline: 0)
         
-        return Double(daystampAccountingForTheGoalsDeadline.distance(to: daystampAssumingMidnightDeadline))
+        return Double(daystampAssumingMidnightDeadline.distance(to: daystampAccountingForTheGoalsDeadline))
     }
 
     // MARK: - SFSafariViewControllerDelegate


### PR DESCRIPTION
Given the scenario, now is 1AM and one is entering into GoalVC for a goal with a deadline of 3AM the initial date shown was tomorrow. Expected might have been today and better yet is probably yesterday since 1AM is before the 3AM deadline, thus the daystamp for a datapoint added _now_ is still the (calendar) day before.

Fixes: #473 