### PR TITLE
Simplify file header template

### DIFF
--- a/BeeSwift.xcodeproj/xcshareddata/IDETemplateMacros.plist
+++ b/BeeSwift.xcodeproj/xcshareddata/IDETemplateMacros.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>FILEHEADER</key>
+    <string></string>
+</dict>
+</plist>

--- a/BeeSwift.xcodeproj/xcshareddata/IDETemplateMacros.plist
+++ b/BeeSwift.xcodeproj/xcshareddata/IDETemplateMacros.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
     <key>FILEHEADER</key>
-    <string></string>
+    <string> Part of BeeSwift. Copyright Beeminder</string>
 </dict>
 </plist>

--- a/BeeSwift/World.swift
+++ b/BeeSwift/World.swift
@@ -1,0 +1,4 @@
+//
+
+
+import Foundation

--- a/BeeSwift/World.swift
+++ b/BeeSwift/World.swift
@@ -1,4 +1,0 @@
-//
-
-
-import Foundation


### PR DESCRIPTION
This switches to a much shorter template at the top of files. Ideally I would like to completely remove the header, but that doesn't seem supported, and results in an empty comment. This at least is shorter than the default.

Validation:
Created a new file in XCode and checked the comment was as expected.