### PR TITLE
Color safeSum in forest green as used in the Grayson Dot

### DIFF
--- a/BeeKit/GoalExtensions.swift
+++ b/BeeKit/GoalExtensions.swift
@@ -55,20 +55,16 @@ extension Goal {
     }
 
     public var countdownColor :UIColor {
-        let buf = self.safeBuf
-        if buf < 1 {
+        switch self.safeBuf {
+        case ..<1:
             return UIColor.Beeminder.SafetyBuffer.red
-        }
-        else if buf < 2 {
+        case ..<2:
             return UIColor.Beeminder.SafetyBuffer.orange
-        }
-        else if buf < 3 {
+        case ..<3:
             return UIColor.Beeminder.SafetyBuffer.blue
-        }
-        else if buf < 7 {
+        case ..<7:
             return UIColor.Beeminder.SafetyBuffer.green
-        }
-        else {
+        default:
             return UIColor.Beeminder.SafetyBuffer.forestGreen
         }
     }

--- a/BeeKit/GoalExtensions.swift
+++ b/BeeKit/GoalExtensions.swift
@@ -57,15 +57,20 @@ extension Goal {
     public var countdownColor :UIColor {
         let buf = self.safeBuf
         if buf < 1 {
-            return UIColor.Beeminder.red
+            return UIColor.Beeminder.SafetyBuffer.red
         }
         else if buf < 2 {
-            return UIColor.Beeminder.orange
+            return UIColor.Beeminder.SafetyBuffer.orange
         }
         else if buf < 3 {
-            return UIColor.Beeminder.blue
+            return UIColor.Beeminder.SafetyBuffer.blue
         }
-        return UIColor.Beeminder.green
+        else if buf < 7 {
+            return UIColor.Beeminder.SafetyBuffer.green
+        }
+        else {
+            return UIColor.Beeminder.SafetyBuffer.forestGreen
+        }
     }
 
     public var hideDataEntry: Bool {

--- a/BeeKit/UI/UIColorExtension.swift
+++ b/BeeKit/UI/UIColorExtension.swift
@@ -27,5 +27,13 @@ extension UIColor {
                                            green: 217.0/255.0,
                                            blue: 17.0/255.0,
                                            alpha: 1)
+        
+        public struct SafetyBuffer {
+            public static let red: UIColor = .systemRed // .init(red: 1, green: 0, blue: 0, alpha: 1)
+            public static let orange: UIColor = .systemOrange // .init(red: 1, green: 165/255.0, blue: 00, alpha: 1)
+            public static let blue: UIColor = .systemBlue // .init(red: 63/255.0, green: 63/255.0, blue: 1, alpha: 1)
+            public static let green: UIColor = .systemGreen // .init(red: 0, green: 170/255.0, blue: 0, alpha: 1)
+            public static let forestGreen: UIColor = .init(red: 34/255.0, green: 139/255.0, blue: 34/255.0, alpha: 1)
+        }
     }
 }

--- a/BeeKit/UI/UIColorExtension.swift
+++ b/BeeKit/UI/UIColorExtension.swift
@@ -12,16 +12,9 @@ import UIKit
 extension UIColor {
     
     public struct Beeminder {
-        public static let green = UIColor(red: 81.0/255.0,
-                                          green: 163.0/255.0,
-                                          blue: 81.0/255.0,
-                                          alpha: 1)
-        
-        public static let blue: UIColor = .systemBlue
-        public static let orange: UIColor = .systemOrange
         public static let red: UIColor = .systemRed
         
-        public static let gray = UIColor(white: 0.7, alpha: 1.0)
+        public static let gray = UIColor.systemGray
         
         public static let yellow = UIColor(red: 255.0/255.0,
                                            green: 217.0/255.0,


### PR DESCRIPTION
## Summary
The chart includes the Grayson Dot - a different color green applied to green dots with more than 7d buffer. The iOS app colors the `safeSum` using colors based on the colors of the dots. This text appears in both the gallery in a goal's cell as well as in the goal screen itself. Previously the same green was being used for all `safeSum` with a `safeBuf` greater than three.


## Validation
Ran app in the simulator using the new colors and logic. Made screenshots.



![grayson-green-for-safety-buffer-more-than-seven-on-dark](https://github.com/user-attachments/assets/ff4072b2-c958-469a-b04c-9c842a5b13f5)




Implements #206 