### PR TITLE
Avoid keyboard obscuring last goals in gallery view

### DIFF
--- a/BeeSwift/Gallery/GalleryViewController.swift
+++ b/BeeSwift/Gallery/GalleryViewController.swift
@@ -147,7 +147,7 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
             make.top.equalTo(self.searchBar.snp.bottom)
             make.left.equalTo(self.view.safeAreaLayoutGuide.snp.leftMargin)
             make.right.equalTo(self.view.safeAreaLayoutGuide.snp.rightMargin)
-            make.bottom.equalTo(0)
+            make.bottom.equalTo(self.collectionView!.keyboardLayoutGuide.snp.top)
         }
         
         self.view.addSubview(self.noGoalsLabel)


### PR DESCRIPTION
## Summary
Previously when using the goal filter, the keyboard would obscure the last goals in the list. Here we make the scrollview resize itself to only take up the section of screen above the keyboard so you can always scroll to the bottom.

This is an alternative approach to #503

## Validation
Loaded the gallery view on device
* Verified when keyboard is hidden the scroll view expands to take up the entire screen
* Verified when the filter box is focused and the keyboard appears it is still possible to scroll down to last goal
