### PR TITLE
Introduce a freshness indicator for the goal screen

### DIFF
--- a/BeeKit/Managers/GoalManager.swift
+++ b/BeeKit/Managers/GoalManager.swift
@@ -27,7 +27,7 @@ public actor GoalManager {
     public var goalsFetchedAt : Date? = nil
     
     // id, not goalname (slug)
-    public private(set) var lastFetchedByGoalId: [String: Date?] = [:]
+    private var lastFetchedByGoalId: [String: Date?] = [:]
 
     private var queuedGoalsBackgroundTaskRunning : Bool = false
 
@@ -94,6 +94,14 @@ public actor GoalManager {
 
     public func forceAutodataRefresh(_ goal: Goal) async throws {
         let _ = try await requestManager.get(url: "/api/v1/users/\(currentUserManager.username!)/goals/\(goal.slug)/refresh_graph.json", parameters: nil)
+    }
+    
+    
+    /// when a goal was last fetched
+    /// - Parameter goalId: goal.id of interest
+    /// - Returns: Date a goal was last fetched or nil
+    public func getDateLastFetchedForGoalWithId(_ goalId: String) -> Date? {
+        lastFetchedByGoalId[goalId]?.map { $0 }
     }
 
     private func updateGoalsFromJson(_ responseJSON: JSON) {

--- a/BeeKit/Managers/GoalManager.swift
+++ b/BeeKit/Managers/GoalManager.swift
@@ -72,7 +72,7 @@ public actor GoalManager {
     public func refreshGoal(_ goalID: NSManagedObjectID) async throws {
         let goal = try modelContext.existingObject(with: goalID) as! Goal
 
-        let responseObject = try await requestManager.get(url: "/api/v1/users/\(goal.owner.username)/goals/\(goal.slug)?datapoints_count=5", parameters: nil)
+        let responseObject = try await requestManager.get(url: "/api/v1/users/\(currentUserManager.username!)/goals/\(goal.slug)?datapoints_count=5", parameters: nil)
         let goalJSON = JSON(responseObject!)
 
         // The goal may have changed during the network operation, reload latest version
@@ -85,7 +85,7 @@ public actor GoalManager {
     }
 
     public func forceAutodataRefresh(_ goal: Goal) async throws {
-        let _ = try await requestManager.get(url: "/api/v1/users/\(goal.owner.username)/goals/\(goal.slug)/refresh_graph.json", parameters: nil)
+        let _ = try await requestManager.get(url: "/api/v1/users/\(currentUserManager.username!)/goals/\(goal.slug)/refresh_graph.json", parameters: nil)
     }
 
     private func updateGoalsFromJson(_ responseJSON: JSON) {

--- a/BeeKit/Managers/GoalManager.swift
+++ b/BeeKit/Managers/GoalManager.swift
@@ -72,7 +72,7 @@ public actor GoalManager {
     public func refreshGoal(_ goalID: NSManagedObjectID) async throws {
         let goal = try modelContext.existingObject(with: goalID) as! Goal
 
-        let responseObject = try await requestManager.get(url: "/api/v1/users/\(currentUserManager.username!)/goals/\(goal.slug)?datapoints_count=5", parameters: nil)
+        let responseObject = try await requestManager.get(url: "/api/v1/users/\(goal.owner.username)/goals/\(goal.slug)?datapoints_count=5", parameters: nil)
         let goalJSON = JSON(responseObject!)
 
         // The goal may have changed during the network operation, reload latest version
@@ -85,7 +85,7 @@ public actor GoalManager {
     }
 
     public func forceAutodataRefresh(_ goal: Goal) async throws {
-        let _ = try await requestManager.get(url: "/api/v1/users/\(currentUserManager.username!)/goals/\(goal.slug)/refresh_graph.json", parameters: nil)
+        let _ = try await requestManager.get(url: "/api/v1/users/\(goal.owner.username)/goals/\(goal.slug)/refresh_graph.json", parameters: nil)
     }
 
     private func updateGoalsFromJson(_ responseJSON: JSON) {

--- a/BeeSwift.xcodeproj/project.pbxproj
+++ b/BeeSwift.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		9B65F2322CFA6427009674A7 /* DeeplinkGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B65F2312CFA6418009674A7 /* DeeplinkGenerator.swift */; };
 		9B8CA57D24B120CA009C86C2 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9B8CA57C24B120CA009C86C2 /* LaunchScreen.storyboard */; };
+		9BFB27E92CFE770F0056D10D /* FreshnessIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BFB27E82CFE770F0056D10D /* FreshnessIndicatorView.swift */; };
 		A10D4E931B07948500A72D29 /* DatapointsTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10D4E921B07948500A72D29 /* DatapointsTableView.swift */; };
 		A10DC2DF207BFCBA00FB7B3A /* RemoveHKMetricViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10DC2DE207BFCBA00FB7B3A /* RemoveHKMetricViewController.swift */; };
 		A11A87C61FEBFF7200A43E47 /* ChooseGoalSortViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11A87C51FEBFF7200A43E47 /* ChooseGoalSortViewController.swift */; };
@@ -220,6 +221,7 @@
 /* Begin PBXFileReference section */
 		9B65F2312CFA6418009674A7 /* DeeplinkGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeeplinkGenerator.swift; sourceTree = "<group>"; };
 		9B8CA57C24B120CA009C86C2 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
+		9BFB27E82CFE770F0056D10D /* FreshnessIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreshnessIndicatorView.swift; sourceTree = "<group>"; };
 		A10D4E921B07948500A72D29 /* DatapointsTableView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatapointsTableView.swift; sourceTree = "<group>"; };
 		A10DC2DE207BFCBA00FB7B3A /* RemoveHKMetricViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoveHKMetricViewController.swift; sourceTree = "<group>"; };
 		A11A87C51FEBFF7200A43E47 /* ChooseGoalSortViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChooseGoalSortViewController.swift; sourceTree = "<group>"; };
@@ -575,6 +577,7 @@
 		E46070FD2B43D98600305DB4 /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				9BFB27E82CFE770F0056D10D /* FreshnessIndicatorView.swift */,
 				A10D4E921B07948500A72D29 /* DatapointsTableView.swift */,
 				E4B0833A2934620500A71564 /* DatapointTableViewController.swift */,
 				E43D9AFA2929C37D00FC1578 /* DatapointValueAccessory.swift */,
@@ -1025,6 +1028,7 @@
 				E43833942AC1473E0098A38F /* InlineDatePicker.swift in Sources */,
 				E55760F526549D310076B95A /* AddDataIntentHandler.swift in Sources */,
 				E5C9EFE62612E02700DBBEAE /* AddDataIntents.intentdefinition in Sources */,
+				9BFB27E92CFE770F0056D10D /* FreshnessIndicatorView.swift in Sources */,
 				A10DC2DF207BFCBA00FB7B3A /* RemoveHKMetricViewController.swift in Sources */,
 				E412DAE12B86A8F70099E483 /* GoalImageView.swift in Sources */,
 				A1619EA41BEECC1500E14B3A /* EditDefaultNotificationsViewController.swift in Sources */,

--- a/BeeSwift/Components/FreshnessIndicatorView.swift
+++ b/BeeSwift/Components/FreshnessIndicatorView.swift
@@ -8,7 +8,6 @@ class FreshnessIndicatorView: UIView {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
         label.font = .preferredFont(forTextStyle: .subheadline)
-        label.font = UIFont.beeminder.defaultFontPlain.withSize(Constants.defaultFontSize)
         label.textAlignment = .center
         return label
     }()

--- a/BeeSwift/Components/FreshnessIndicatorView.swift
+++ b/BeeSwift/Components/FreshnessIndicatorView.swift
@@ -1,0 +1,82 @@
+// Part of BeeSwift. Copyright Beeminder
+
+import UIKit
+import BeeKit
+
+class FreshnessIndicatorView: UIView {
+    private let label: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = .preferredFont(forTextStyle: .subheadline)
+        label.font = UIFont.beeminder.defaultFontPlain.withSize(Constants.defaultFontSize)
+        label.textAlignment = .center
+        return label
+    }()
+    
+    private let formatter: RelativeDateTimeFormatter = {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.dateTimeStyle = .named
+        return formatter
+    }()
+    
+    // Time thresholds for different styles (in seconds)
+    private struct TimeThreshold {
+        static let recent: TimeInterval = 60 * 60
+        // Anything beyond will be considered "old"
+    }
+    
+    private struct Style {
+        let backgroundColor: UIColor
+        let textColor: UIColor
+    }
+    
+    private let styles: [Style] = [
+        // ones we consider recent
+        Style(
+            backgroundColor: .Beeminder.gray,
+            textColor: .label
+        ),
+        // and the old ones
+        Style(
+            backgroundColor: .Beeminder.red,
+            textColor: .label
+        )
+    ]
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupView()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setupView() {
+        addSubview(label)
+        
+        NSLayoutConstraint.activate([
+            label.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 8),
+            label.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -8),
+            label.topAnchor.constraint(equalTo: topAnchor, constant: 4),
+            label.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -4)
+        ])
+    }
+    
+    func update(with date: Date) {
+        let elapsed = -date.timeIntervalSinceNow
+        let style: Style = {
+            let index = elapsed < TimeThreshold.recent ? 0 : 1
+            return styles[index]
+        }()
+
+        let relativeDuration = formatter.localizedString(for: date, relativeTo: Date())
+        let labelText = "Last updated: \(relativeDuration)"
+        
+        UIView.animate(withDuration: 0.2) {
+            self.backgroundColor = style.backgroundColor
+            self.label.textColor = style.textColor
+            self.label.text = labelText
+        }
+    }
+}

--- a/BeeSwift/Gallery/GalleryViewController.swift
+++ b/BeeSwift/Gallery/GalleryViewController.swift
@@ -22,8 +22,7 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
 
     var collectionView :UICollectionView?
     var collectionViewLayout :UICollectionViewFlowLayout?
-    let lastUpdatedView = UIView()
-    let lastUpdatedLabel = BSLabel()
+    private let freshnessIndicator = FreshnessIndicatorView()
     let cellReuseIdentifier = "Cell"
     var deadbeatView = UIView()
     var outofdateView = UIView()
@@ -56,20 +55,9 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
         let item = UIBarButtonItem(image: UIImage(systemName: "gearshape.fill"), style: UIBarButtonItem.Style.plain, target: self, action: #selector(self.settingsButtonPressed))
         self.navigationItem.rightBarButtonItem = item
         
-        self.view.addSubview(self.lastUpdatedView)
-        self.lastUpdatedView.backgroundColor = UIColor.Beeminder.gray
-        self.lastUpdatedView.snp.makeConstraints { (make) -> Void in
+        self.view.addSubview(self.freshnessIndicator)
+        self.freshnessIndicator.snp.makeConstraints { (make) -> Void in
             make.top.equalTo(self.view.safeAreaLayoutGuide.snp.topMargin)
-            make.left.equalTo(0)
-            make.right.equalTo(0)
-        }
-        
-        self.lastUpdatedView.addSubview(self.lastUpdatedLabel)
-        self.lastUpdatedLabel.font = UIFont.beeminder.defaultFontPlain.withSize(Constants.defaultFontSize)
-        self.lastUpdatedLabel.textAlignment = NSTextAlignment.center
-        self.lastUpdatedLabel.snp.makeConstraints { (make) -> Void in
-            make.top.equalTo(3)
-            make.bottom.equalTo(-3)
             make.left.equalTo(0)
             make.right.equalTo(0)
         }
@@ -82,7 +70,7 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
         self.deadbeatView.snp.makeConstraints { (make) -> Void in
             make.left.equalTo(0)
             make.right.equalTo(0)
-            make.top.equalTo(self.lastUpdatedView.snp.bottom)
+            make.top.equalTo(self.freshnessIndicator.snp.bottom)
             if !ServiceLocator.currentUserManager.isDeadbeat(context: ServiceLocator.persistentContainer.viewContext) {
                 make.height.equalTo(0)
             }
@@ -309,7 +297,7 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
         self.deadbeatView.snp.remakeConstraints { (make) -> Void in
             make.left.equalTo(0)
             make.right.equalTo(0)
-            make.top.equalTo(self.lastUpdatedView.snp.bottom)
+            make.top.equalTo(self.freshnessIndicator.snp.bottom)
             if !ServiceLocator.currentUserManager.isDeadbeat(context: ServiceLocator.persistentContainer.viewContext) {
                 make.height.equalTo(0)
             }
@@ -325,8 +313,7 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
     @objc func updateLastUpdatedLabel() {
         let lastUpdated = self.lastUpdated ?? .distantPast
         
-        self.lastUpdatedView.backgroundColor = lastUpdated.timeIntervalSinceNow < -3600 ? UIColor.Beeminder.red : UIColor.Beeminder.gray
-        self.lastUpdatedLabel.text = "Last updated: " + lastUpdatedDateFormatter.localizedString(for: lastUpdated, relativeTo: Date())
+        self.freshnessIndicator.update(with: lastUpdated)
     }
 
     

--- a/BeeSwift/GoalViewController.swift
+++ b/BeeSwift/GoalViewController.swift
@@ -495,7 +495,7 @@ class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTabl
 
     func updateGoalAndInterface() async throws {
         try await ServiceLocator.goalManager.refreshGoal(self.goal.objectID)
-        self.lastFetched = await ServiceLocator.goalManager.getDateLastFetchedForGoalWithId(self.goal.id)
+        self.lastFetched = goal.lastModifiedLocal
         updateInterfaceToMatchGoal()
     }
 

--- a/BeeSwift/GoalViewController.swift
+++ b/BeeSwift/GoalViewController.swift
@@ -23,13 +23,6 @@ class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTabl
     private let logger = Logger(subsystem: "com.beeminder.com", category: "GoalViewController")
 
     let goal: Goal
-
-
-    private var lastFetched: Date? {
-        didSet {
-            updateLastUpdatedLabel()
-        }
-    }
     
     private let timeElapsedView = FreshnessIndicatorView()
     fileprivate var goalImageView = GoalImageView(isThumbnail: false)
@@ -53,7 +46,6 @@ class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTabl
     
     init(goal: Goal) {
         self.goal = goal
-        self.lastFetched = goal.lastModifiedLocal
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -495,7 +487,6 @@ class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTabl
 
     func updateGoalAndInterface() async throws {
         try await ServiceLocator.goalManager.refreshGoal(self.goal.objectID)
-        self.lastFetched = goal.lastModifiedLocal
         updateInterfaceToMatchGoal()
     }
 
@@ -504,6 +495,7 @@ class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTabl
         self.datapointTableController.datapoints = goal.recentData.sorted(by: {$0.updatedAt < $1.updatedAt})
 
         self.refreshCountdown()
+        self.updateLastUpdatedLabel()
     }
 
     func viewForZooming(in scrollView: UIScrollView) -> UIView? {
@@ -520,7 +512,7 @@ class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTabl
     }
     
     @objc func updateLastUpdatedLabel() {
-        let lastUpdated = self.lastFetched ?? .distantPast
+        let lastUpdated = self.goal.lastModifiedLocal
         
         self.timeElapsedView.update(with: lastUpdated)
     }


### PR DESCRIPTION
## Summary
In line with #246, this provides an indicator of freshness on the goal screen. It reuses the one from the gallery screen.

## Media

https://github.com/user-attachments/assets/b2549822-e1b0-42de-9dea-f451bee4fad4


## Validation
Ran app in simulator
Viewed both gallery and goal, navigating back and forth.
Sent the app to background, back into foreground, varying sometimes with the gallery open, sometimes with a goal open.
Also watched the last updated since label be updated while just leaving the app open with the goal view showing

Fixes #246
