### PR TITLE
more zoom levels and more powerful zoom in on goal graph

### DIFF
--- a/BeeSwift/GoalViewController.swift
+++ b/BeeSwift/GoalViewController.swift
@@ -363,7 +363,8 @@ class GoalViewController: UIViewController, DatapointTableViewControllerDelegate
 
     @objc func goalImageTapped() {
         let possibleNextStepUp = self.goalImageScrollView.zoomScale + 2.0
-        let nextZoomLevel: Double = possibleNextStepUp <= 7.0 ? possibleNextStepUp : 1.0
+        let nextZoomLevel = possibleNextStepUp <= self.goalImageScrollView.maximumZoomScale ? possibleNextStepUp : self.goalImageScrollView.minimumZoomScale
+        
         self.goalImageScrollView.setZoomScale(nextZoomLevel, animated: true)
     }
 

--- a/BeeSwift/GoalViewController.swift
+++ b/BeeSwift/GoalViewController.swift
@@ -15,7 +15,7 @@ import Intents
 import BeeKit
 import OSLog
 
-class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTableViewControllerDelegate, UITextFieldDelegate, SFSafariViewControllerDelegate {
+class GoalViewController: UIViewController, DatapointTableViewControllerDelegate, UITextFieldDelegate {
     let elementSpacing = 10
     let sideMargin = 10
     let buttonHeight = 42
@@ -503,10 +503,6 @@ class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTabl
         self.refreshCountdown()
         self.updateLastUpdatedLabel()
     }
-
-    func viewForZooming(in scrollView: UIScrollView) -> UIView? {
-        return self.goalImageView
-    }
     
     private static func makeInitialDateStepperValue(date: Date = Date(), for goal: Goal) -> Double {
         let daystampAccountingForTheGoalsDeadline = Daystamp(fromDate: date,
@@ -525,6 +521,15 @@ class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTabl
 
     // MARK: - SFSafariViewControllerDelegate
 
+}
+
+extension GoalViewController: UIScrollViewDelegate {
+    func viewForZooming(in scrollView: UIScrollView) -> UIView? {
+        return self.goalImageView
+    }
+}
+
+extension GoalViewController: SFSafariViewControllerDelegate {
     func safariViewControllerDidFinish(_ controller: SFSafariViewController) {
         controller.dismiss(animated: true, completion: nil)
     }

--- a/BeeSwift/GoalViewController.swift
+++ b/BeeSwift/GoalViewController.swift
@@ -110,7 +110,7 @@ class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTabl
         self.goalImageScrollView.showsHorizontalScrollIndicator = false
         self.goalImageScrollView.showsVerticalScrollIndicator = false
         self.goalImageScrollView.minimumZoomScale = 1.0
-        self.goalImageScrollView.maximumZoomScale = 3.0
+        self.goalImageScrollView.maximumZoomScale = 7.0
         self.goalImageScrollView.delegate = self
         self.goalImageScrollView.snp.makeConstraints { (make) -> Void in
             make.centerX.equalTo(self.view)
@@ -362,7 +362,9 @@ class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTabl
     }
 
     @objc func goalImageTapped() {
-        self.goalImageScrollView.setZoomScale(self.goalImageScrollView.zoomScale == 1.0 ? 2.0 : 1.0, animated: true)
+        let possibleNextStepUp = self.goalImageScrollView.zoomScale + 2.0
+        let nextZoomLevel: Double = possibleNextStepUp <= 7.0 ? possibleNextStepUp : 1.0
+        self.goalImageScrollView.setZoomScale(nextZoomLevel, animated: true)
     }
 
     func datapointTableViewController(_ datapointTableViewController: DatapointTableViewController, didSelectDatapoint datapoint: BeeDataPoint) {


### PR DESCRIPTION
## Summary
Via double tap on the goal's graph, step through the zoom levels.

One could double tap on the goal's graph to see a zoomed in version. This was at 2x magnification. Now it goes to 7x and from 1x to 3x to 5x and then 7x.

The graph (wrapped still inside a scrollview) still supports the pan to zoom. This zoom's max has also been bumped with this MR.



## Validation
Ran the app in the iPhone simulator. Tapped and zoomed on some graphs.
