### PR TITLE
Switch the gallery view to use a StackView instead of manual layout

### DIFF
--- a/BeeSwift/Gallery/GalleryViewController.swift
+++ b/BeeSwift/Gallery/GalleryViewController.swift
@@ -20,6 +20,7 @@ import BeeKit
 class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayout, UICollectionViewDelegate, UICollectionViewDataSource, UISearchBarDelegate, SFSafariViewControllerDelegate {
     let logger = Logger(subsystem: "com.beeminder.beeminder", category: "GalleryViewController")
 
+    var stackView = UIStackView()
     var collectionView :UICollectionView?
     var collectionViewLayout :UICollectionViewFlowLayout?
     private let freshnessIndicator = FreshnessIndicatorView()
@@ -42,9 +43,21 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
         NotificationCenter.default.addObserver(self, selector: #selector(self.handleSignOut), name: NSNotification.Name(rawValue: CurrentUserManager.signedOutNotificationName), object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(self.openGoalFromNotification(_:)), name: NSNotification.Name(rawValue: "openGoal"), object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(self.handleGoalsFetchedNotification), name: NSNotification.Name(rawValue: GoalManager.goalsUpdatedNotificationName), object: nil)
-        
+
+        self.view.addSubview(stackView)
+        stackView.axis = .vertical
+        stackView.alignment = .fill
+        stackView.distribution = .fill
+        stackView.spacing = 0
+        stackView.snp.makeConstraints { (make) -> Void in
+            make.top.left.right.equalTo(self.view.safeAreaLayoutGuide)
+            // We are happy for the bottom of the scrollview to be partially obscured by the
+            // home indicator. This looks better than a bit white area at the bottom.
+            make.bottom.equalTo(self.view)
+        }
+
         self.collectionViewLayout = UICollectionViewFlowLayout()
-        self.collectionView = UICollectionView(frame: self.view.frame, collectionViewLayout: self.collectionViewLayout!)
+        self.collectionView = UICollectionView(frame: stackView.frame, collectionViewLayout: self.collectionViewLayout!)
         self.collectionView?.backgroundColor = .systemBackground
         self.collectionView?.alwaysBounceVertical = true
         self.collectionView?.register(UICollectionReusableView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionFooter, withReuseIdentifier: "footer")
@@ -55,93 +68,69 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
         let item = UIBarButtonItem(image: UIImage(systemName: "gearshape.fill"), style: UIBarButtonItem.Style.plain, target: self, action: #selector(self.settingsButtonPressed))
         self.navigationItem.rightBarButtonItem = item
         
-        self.view.addSubview(self.freshnessIndicator)
-        self.freshnessIndicator.snp.makeConstraints { (make) -> Void in
-            make.top.equalTo(self.view.safeAreaLayoutGuide.snp.topMargin)
-            make.left.equalTo(0)
-            make.right.equalTo(0)
-        }
-        
+        stackView.addArrangedSubview(self.freshnessIndicator)
         self.updateLastUpdatedLabel()
         Timer.scheduledTimer(timeInterval: 60, target: self, selector: #selector(GalleryViewController.updateLastUpdatedLabel), userInfo: nil, repeats: true)
         
-        self.view.addSubview(self.deadbeatView)
+        stackView.addArrangedSubview(self.deadbeatView)
+        self.deadbeatView.accessibilityIdentifier = "deadbeatView"
         self.deadbeatView.backgroundColor = UIColor.Beeminder.gray
-        self.deadbeatView.snp.makeConstraints { (make) -> Void in
-            make.left.equalTo(0)
-            make.right.equalTo(0)
-            make.top.equalTo(self.freshnessIndicator.snp.bottom)
-            if !ServiceLocator.currentUserManager.isDeadbeat(context: ServiceLocator.persistentContainer.viewContext) {
-                make.height.equalTo(0)
-            }
+        if !ServiceLocator.currentUserManager.isDeadbeat(context: ServiceLocator.persistentContainer.viewContext) {
+            self.deadbeatView.isHidden = true
         }
-        
+
         let deadbeatLabel = BSLabel()
         self.deadbeatView.addSubview(deadbeatLabel)
+        deadbeatLabel.accessibilityIdentifier = "deadbeatLabel"
         deadbeatLabel.textColor = UIColor.Beeminder.red
         deadbeatLabel.numberOfLines = 0
         deadbeatLabel.font = UIFont.beeminder.defaultFontHeavy.withSize(13)
         deadbeatLabel.text = "Hey! Beeminder couldn't charge your credit card, so you can't see your graphs. Please update your card on beeminder.com or email support@beeminder.com if this is a mistake."
         deadbeatLabel.snp.makeConstraints { (make) -> Void in
-            make.top.equalTo(3)
-            make.bottom.equalTo(-3)
+            make.top.equalTo(4)
+            make.bottom.equalTo(-4)
             make.left.equalTo(10)
             make.right.equalTo(-10)
         }
         
-        self.view.addSubview(self.outofdateView)
+        stackView.addArrangedSubview(self.outofdateView)
+        self.outofdateView.accessibilityIdentifier = "outofdateView"
         self.outofdateView.backgroundColor = UIColor.Beeminder.gray
-        self.outofdateView.snp.makeConstraints { (make) in
-            make.right.left.equalTo(0)
-            make.top.equalTo(self.deadbeatView.snp.bottom)
-            make.height.equalTo(0)
-        }
-        
+        self.outofdateView.isHidden = true
+
         self.outofdateView.addSubview(self.outofdateLabel)
+        self.outofdateLabel.accessibilityIdentifier = "outofdateLabel"
         self.outofdateLabel.textColor = UIColor.Beeminder.red
         self.outofdateLabel.numberOfLines = 0
         self.outofdateLabel.font = UIFont.beeminder.defaultFontHeavy.withSize(12)
         self.outofdateLabel.textAlignment = .center
         self.outofdateLabel.snp.makeConstraints { (make) in
-            make.top.equalTo(3)
-            make.bottom.equalTo(-3)
+            make.top.equalTo(6)
+            make.bottom.equalTo(-6)
             make.left.equalTo(10)
             make.right.equalTo(-10)
         }
         
-        self.view.addSubview(self.searchBar)
+        stackView.addArrangedSubview(self.searchBar)
+        self.searchBar.accessibilityIdentifier = "searchBar"
         self.searchBar.delegate = self
         self.searchBar.placeholder = "Filter goals by slug"
         self.searchBar.isHidden = true
         self.searchBar.showsCancelButton = true
-        self.searchBar.snp.makeConstraints { (make) in
-            make.left.right.equalTo(0)
-            make.top.equalTo(self.outofdateView.snp.bottom)
-            make.height.equalTo(0)
-        }
-        
+
         self.collectionView!.delegate = self
         self.collectionView!.dataSource = self
         self.collectionView!.register(GoalCollectionViewCell.self, forCellWithReuseIdentifier: self.cellReuseIdentifier)
-        self.view.addSubview(self.collectionView!)
-        
+        stackView.addArrangedSubview(self.collectionView!)
+
         self.collectionView?.refreshControl = {
             let refreshControl = UIRefreshControl()
             refreshControl.addTarget(self, action: #selector(self.fetchGoals), for: UIControl.Event.valueChanged)
             return refreshControl
         }()
-        
-        self.collectionView!.snp.makeConstraints { (make) -> Void in
-            make.top.equalTo(self.searchBar.snp.bottom)
-            make.left.equalTo(self.view.safeAreaLayoutGuide.snp.leftMargin)
-            make.right.equalTo(self.view.safeAreaLayoutGuide.snp.rightMargin)
-            make.bottom.equalTo(self.collectionView!.keyboardLayoutGuide.snp.top)
-        }
-        
-        self.view.addSubview(self.noGoalsLabel)
-        self.noGoalsLabel.snp.makeConstraints { (make) in
-            make.top.left.right.equalTo(self.collectionView!)
-        }
+
+        stackView.addArrangedSubview(self.noGoalsLabel)
+        self.noGoalsLabel.accessibilityIdentifier = "noGoalsLabel"
         self.noGoalsLabel.text = "You have no Beeminder goals!\n\nYou'll need to create one before this app will be any use."
         self.noGoalsLabel.textAlignment = .center
         self.noGoalsLabel.numberOfLines = 0
@@ -167,26 +156,17 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
 
                 switch updateState {
                 case .UpdateRequired:
-                    self.outofdateView.snp.remakeConstraints { (make) -> Void in
-                        make.left.equalTo(0)
-                        make.right.equalTo(0)
-                        make.top.equalTo(self.deadbeatView.snp.bottom)
-                        make.height.equalTo(42)
-                    }
+                    self.outofdateView.isHidden = false
                     self.outofdateLabel.isHidden = false
                     self.outofdateLabel.text = "This version of the Beeminder app is no longer supported.\n Please update to the newest version in the App Store."
                     self.collectionView?.isHidden = true
                 case .UpdateSuggested:
-                    self.outofdateView.snp.remakeConstraints { (make) -> Void in
-                        make.left.equalTo(0)
-                        make.right.equalTo(0)
-                        make.top.equalTo(self.deadbeatView.snp.bottom)
-                        make.height.equalTo(42)
-                    }
+                    self.outofdateView.isHidden = false
                     self.outofdateLabel.isHidden = false
                     self.outofdateLabel.text = "There is a new version of the Beeminder app in the App Store.\nPlease update when you have a moment."
                     self.collectionView?.isHidden = false
                 case .UpToDate:
+                    self.outofdateView.isHidden = true
                     self.collectionView?.isHidden = false
                 }
             } catch let error as VersionError {
@@ -242,20 +222,6 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
         } else {
             self.searchBar.becomeFirstResponder()
         }
-        
-        self.updateSearchBarConstraints()
-    }
-    
-    private func updateSearchBarConstraints() {
-        self.searchBar.snp.remakeConstraints { (make) in
-            make.left.right.equalTo(0)
-            make.top.equalTo(self.outofdateView.snp.bottom)
-            if self.searchBar.isHidden {
-                make.height.equalTo(0)
-            } else {
-                make.height.equalTo(self.maxSearchBarHeight)
-            }
-        }
     }
     
     @objc func handleSignIn() {
@@ -294,14 +260,8 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
     
 
     func updateDeadbeatHeight() {
-        self.deadbeatView.snp.remakeConstraints { (make) -> Void in
-            make.left.equalTo(0)
-            make.right.equalTo(0)
-            make.top.equalTo(self.freshnessIndicator.snp.bottom)
-            if !ServiceLocator.currentUserManager.isDeadbeat(context: ServiceLocator.persistentContainer.viewContext) {
-                make.height.equalTo(0)
-            }
-        }
+        let isDeadbeat = ServiceLocator.currentUserManager.isDeadbeat(context: ServiceLocator.persistentContainer.viewContext)
+        self.deadbeatView.isHidden = !isDeadbeat
     }
     
     private let lastUpdatedDateFormatter: RelativeDateTimeFormatter = {

--- a/BeeSwift/Gallery/GalleryViewController.swift
+++ b/BeeSwift/Gallery/GalleryViewController.swift
@@ -139,6 +139,7 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
         self.noGoalsLabel.textAlignment = .center
         self.noGoalsLabel.numberOfLines = 0
         self.noGoalsLabel.isHidden = true
+        // When shown this label should fill all remaining space so it is centered on the screen.
         self.noGoalsLabel.setContentHuggingPriority(UILayoutPriority(UILayoutPriority.defaultLow.rawValue - 10), for: .vertical)
 
         self.updateGoals()

--- a/BeeSwift/Gallery/GalleryViewController.swift
+++ b/BeeSwift/Gallery/GalleryViewController.swift
@@ -21,6 +21,7 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
     let logger = Logger(subsystem: "com.beeminder.beeminder", category: "GalleryViewController")
 
     var stackView = UIStackView()
+    var collectionContainer = UIView()
     var collectionView :UICollectionView?
     var collectionViewLayout :UICollectionViewFlowLayout?
     private let freshnessIndicator = FreshnessIndicatorView()
@@ -49,11 +50,10 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
         stackView.alignment = .fill
         stackView.distribution = .fill
         stackView.spacing = 0
+        stackView.insetsLayoutMarginsFromSafeArea = true
         stackView.snp.makeConstraints { (make) -> Void in
-            make.top.left.right.equalTo(self.view.safeAreaLayoutGuide)
-            // We are happy for the bottom of the scrollview to be partially obscured by the
-            // home indicator. This looks better than a bit white area at the bottom.
-            make.bottom.equalTo(self.view)
+            make.top.left.right.equalToSuperview()
+            make.bottom.equalTo(stackView.keyboardLayoutGuide.snp.top)
         }
 
         self.collectionViewLayout = UICollectionViewFlowLayout()
@@ -116,10 +116,16 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
         self.searchBar.isHidden = true
         self.searchBar.showsCancelButton = true
 
+        stackView.addArrangedSubview(self.collectionContainer)
+
+        self.collectionContainer.addSubview(self.collectionView!)
         self.collectionView!.delegate = self
         self.collectionView!.dataSource = self
         self.collectionView!.register(GoalCollectionViewCell.self, forCellWithReuseIdentifier: self.cellReuseIdentifier)
-        stackView.addArrangedSubview(self.collectionView!)
+        self.collectionView?.snp.makeConstraints { (make) in
+            make.top.bottom.equalTo(collectionContainer)
+            make.left.right.equalTo(collectionContainer.safeAreaLayoutGuide)
+        }
 
         self.collectionView?.refreshControl = {
             let refreshControl = UIRefreshControl()

--- a/BeeSwift/Gallery/GalleryViewController.swift
+++ b/BeeSwift/Gallery/GalleryViewController.swift
@@ -87,8 +87,8 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
         deadbeatLabel.font = UIFont.beeminder.defaultFontHeavy.withSize(13)
         deadbeatLabel.text = "Hey! Beeminder couldn't charge your credit card, so you can't see your graphs. Please update your card on beeminder.com or email support@beeminder.com if this is a mistake."
         deadbeatLabel.snp.makeConstraints { (make) -> Void in
-            make.top.equalTo(4)
-            make.bottom.equalTo(-4)
+            make.top.equalTo(3)
+            make.bottom.equalTo(-3)
             make.left.equalTo(10)
             make.right.equalTo(-10)
         }
@@ -105,8 +105,8 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
         self.outofdateLabel.font = UIFont.beeminder.defaultFontHeavy.withSize(12)
         self.outofdateLabel.textAlignment = .center
         self.outofdateLabel.snp.makeConstraints { (make) in
-            make.top.equalTo(6)
-            make.bottom.equalTo(-6)
+            make.top.equalTo(3)
+            make.bottom.equalTo(-3)
             make.left.equalTo(10)
             make.right.equalTo(-10)
         }

--- a/BeeSwift/Gallery/GalleryViewController.swift
+++ b/BeeSwift/Gallery/GalleryViewController.swift
@@ -20,8 +20,8 @@ import BeeKit
 class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayout, UICollectionViewDelegate, UICollectionViewDataSource, UISearchBarDelegate, SFSafariViewControllerDelegate {
     let logger = Logger(subsystem: "com.beeminder.beeminder", category: "GalleryViewController")
 
-    var stackView = UIStackView()
-    var collectionContainer = UIView()
+    let stackView = UIStackView()
+    let collectionContainer = UIView()
     var collectionView :UICollectionView?
     var collectionViewLayout :UICollectionViewFlowLayout?
     private let freshnessIndicator = FreshnessIndicatorView()

--- a/BeeSwift/Gallery/GalleryViewController.swift
+++ b/BeeSwift/Gallery/GalleryViewController.swift
@@ -75,9 +75,7 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
         stackView.addArrangedSubview(self.deadbeatView)
         self.deadbeatView.accessibilityIdentifier = "deadbeatView"
         self.deadbeatView.backgroundColor = UIColor.Beeminder.gray
-        if !ServiceLocator.currentUserManager.isDeadbeat(context: ServiceLocator.persistentContainer.viewContext) {
-            self.deadbeatView.isHidden = true
-        }
+        updateDeadbeatVisibility()
 
         let deadbeatLabel = BSLabel()
         self.deadbeatView.addSubview(deadbeatLabel)
@@ -259,7 +257,7 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
     }
     
 
-    func updateDeadbeatHeight() {
+    func updateDeadbeatVisibility() {
         let isDeadbeat = ServiceLocator.currentUserManager.isDeadbeat(context: ServiceLocator.persistentContainer.viewContext)
         self.deadbeatView.isHidden = !isDeadbeat
     }
@@ -352,7 +350,7 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
         self.collectionView?.refreshControl?.endRefreshing()
         MBProgressHUD.hide(for: self.view, animated: true)
         self.collectionView!.reloadData()
-        self.updateDeadbeatHeight()
+        self.updateDeadbeatVisibility()
         self.lastUpdated = Date()
         self.updateLastUpdatedLabel()
         if self.goals.count == 0 {

--- a/BeeSwift/Gallery/GalleryViewController.swift
+++ b/BeeSwift/Gallery/GalleryViewController.swift
@@ -139,7 +139,7 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
         self.noGoalsLabel.textAlignment = .center
         self.noGoalsLabel.numberOfLines = 0
         self.noGoalsLabel.isHidden = true
-        self.noGoalsLabel.setContentHuggingPriority(.defaultLow, for: .vertical)
+        self.noGoalsLabel.setContentHuggingPriority(UILayoutPriority(UILayoutPriority.defaultLow.rawValue - 10), for: .vertical)
 
         self.updateGoals()
         self.fetchGoals()
@@ -362,10 +362,10 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
         self.updateLastUpdatedLabel()
         if self.goals.count == 0 {
             self.noGoalsLabel.isHidden = false
-            self.collectionView?.isHidden = true
+            self.collectionContainer.isHidden = true
         } else {
             self.noGoalsLabel.isHidden = true
-            self.collectionView?.isHidden = false
+            self.collectionContainer.isHidden = false
         }
         let searchItem = UIBarButtonItem(barButtonSystemItem: .search, target: self, action: #selector(self.searchButtonPressed))
         self.navigationItem.leftBarButtonItem = searchItem

--- a/BeeSwift/Gallery/GalleryViewController.swift
+++ b/BeeSwift/Gallery/GalleryViewController.swift
@@ -139,7 +139,8 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
         self.noGoalsLabel.textAlignment = .center
         self.noGoalsLabel.numberOfLines = 0
         self.noGoalsLabel.isHidden = true
-        
+        self.noGoalsLabel.setContentHuggingPriority(.defaultLow, for: .vertical)
+
         self.updateGoals()
         self.fetchGoals()
 

--- a/BeeSwift/Gallery/GalleryViewController.swift
+++ b/BeeSwift/Gallery/GalleryViewController.swift
@@ -163,12 +163,10 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
                 switch updateState {
                 case .UpdateRequired:
                     self.outofdateView.isHidden = false
-                    self.outofdateLabel.isHidden = false
                     self.outofdateLabel.text = "This version of the Beeminder app is no longer supported.\n Please update to the newest version in the App Store."
                     self.collectionView?.isHidden = true
                 case .UpdateSuggested:
                     self.outofdateView.isHidden = false
-                    self.outofdateLabel.isHidden = false
                     self.outofdateLabel.text = "There is a new version of the Beeminder app in the App Store.\nPlease update when you have a moment."
                     self.collectionView?.isHidden = false
                 case .UpToDate:


### PR DESCRIPTION
## Summary
Previously we used SnapKit and lots of constraints in order to control the layout of the gallery view. This was a bunch of code, and cause constraint violation warnings due to margins being impossible in conjunction with hiding elements by setting their height to 0.

Here we migrate to use UIStackView which automatically handles constraints, sizing, and removing hidden views. This lets us delete a lot of code, and also fixes a bug where there would be a rendering glitch if returning to the gallery view from a goal view where the keyboard was hidden - previously the area the keyboard had occupied would appear blank.

Known issues to fix before merging: The background for last updated, deadbeat, etc, do not use the full width of the screen.

## Validation
Loaded the app on iPhone and iPad
* Checked the layout looks good in portrait and landscape
* Checked with and without keyboard
* Checked navigating from goal view back to gallery view
* Confirmed with the keyboard visible you can still scroll all goals
