### PR TITLE
gallery accounted for no longer displayed keyboard

### DIFF
--- a/BeeSwift/Gallery/GalleryViewController.swift
+++ b/BeeSwift/Gallery/GalleryViewController.swift
@@ -207,6 +207,17 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
         }
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        self.collectionView!.snp.remakeConstraints { make in
+            make.top.equalTo(self.searchBar.snp.bottom)
+            make.left.equalTo(self.view.safeAreaLayoutGuide.snp.leftMargin)
+            make.right.equalTo(self.view.safeAreaLayoutGuide.snp.rightMargin)
+            make.bottom.equalTo(self.collectionView!.keyboardLayoutGuide.snp.top)
+        }
+    }
+    
     override func viewDidAppear(_ animated: Bool) {
         if !ServiceLocator.currentUserManager.signedIn(context: ServiceLocator.persistentContainer.viewContext) {
             let signInVC = SignInViewController()


### PR DESCRIPTION
## Summary
space could have been allocated for a keyboard that was not shown when returning to the gallery from a goal with the keyboard shown

follow-up to #536 