### PR TITLE
"app out of date / upgrade suggested" is hard to read

### DIFF
--- a/BeeSwift/Gallery/GalleryViewController.swift
+++ b/BeeSwift/Gallery/GalleryViewController.swift
@@ -55,7 +55,14 @@ class GalleryViewController: UIViewController {
     private lazy var collectionViewLayout = UICollectionViewFlowLayout()
     private lazy var freshnessIndicator = FreshnessIndicatorView()
     
-    private lazy var deadbeatView = UIView()
+    private lazy var deadbeatView: UIView = {
+        let outofdateView = UIView()
+        outofdateView.accessibilityIdentifier = "deadbeatView"
+        outofdateView.backgroundColor = UIColor.Beeminder.gray
+        outofdateView.isHidden = true
+        return outofdateView
+    }()
+    
     private lazy var outofdateView: UIView = {
         let outofdateView = UIView()
         outofdateView.accessibilityIdentifier = "outofdateView"
@@ -79,7 +86,7 @@ class GalleryViewController: UIViewController {
     private lazy var outofdateLabel: BSLabel = {
         let outofdateLabel = BSLabel()
         outofdateLabel.accessibilityIdentifier = "outofdateLabel"
-        outofdateLabel.textColor = UIColor.Beeminder.red
+        outofdateLabel.textColor = UIColor.Beeminder.yellow
         outofdateLabel.numberOfLines = 0
         outofdateLabel.font = UIFont.beeminder.defaultFontHeavy.withSize(12)
         outofdateLabel.textAlignment = .center
@@ -99,7 +106,7 @@ class GalleryViewController: UIViewController {
     private lazy var deadbeatLabel: BSLabel = {
         let deadbeatLabel = BSLabel()
         deadbeatLabel.accessibilityIdentifier = "deadbeatLabel"
-        deadbeatLabel.textColor = UIColor.Beeminder.red
+        deadbeatLabel.textColor = UIColor.Beeminder.yellow
         deadbeatLabel.numberOfLines = 0
         deadbeatLabel.font = UIFont.beeminder.defaultFontHeavy.withSize(13)
         deadbeatLabel.text = "Hey! Beeminder couldn't charge your credit card, so you can't see your graphs. Please update your card on beeminder.com or email support@beeminder.com if this is a mistake."


### PR DESCRIPTION
## Summary
Red on gray was hard to read. 

*For UI changes including screenshots of before and after is great.*
## before
![before - newer version available - dark](https://github.com/user-attachments/assets/51dbddd0-c2af-4850-b6e9-0bbf26a16993)
![before - newer version available - light](https://github.com/user-attachments/assets/a1d04515-8df6-4ea0-9326-e41900c2cf46)

## after
![after - upgrade required - dark](https://github.com/user-attachments/assets/12ceb83f-a68b-4e91-b488-e493111838bd)
![after - upgrade required - light](https://github.com/user-attachments/assets/51141484-34e8-4ff7-9ba5-0256952fe0c4)

![after - deadbeat notice - dark](https://github.com/user-attachments/assets/ade5fa79-bef5-4fc5-9630-9f96e5289434)
![after - deadbeat notice - light](https://github.com/user-attachments/assets/43d163ec-0408-4e93-bc95-e988f649abc1)

## Validation
ran app in simulator
ran in light and dark modes
force displaying of deadbeat
force displaying of app out of date, app upgrade available

