### PR TITLE
sign in button had corners that did not match its background

### DIFF
--- a/BeeSwift/SignInViewController.swift
+++ b/BeeSwift/SignInViewController.swift
@@ -99,7 +99,6 @@ class SignInViewController : UIViewController, UITextFieldDelegate, SFSafariView
         scrollView.addSubview(self.signInButton)
         self.signInButton.isHidden = true
         self.signInButton.setTitle("Sign In", for: UIControl.State())
-        self.signInButton.backgroundColor = UIColor.Beeminder.gray
         self.signInButton.titleLabel?.font = UIFont.beeminder.defaultFontPlain.withSize(20)
         self.signInButton.titleLabel?.textColor = UIColor.white
         self.signInButton.addTarget(self, action: #selector(SignInViewController.signInButtonPressed), for: UIControl.Event.touchUpInside)


### PR DESCRIPTION
## Summary
Sign In button had dark corners on light mode although it had rounded corners. The two did not look good together.

*For UI changes including screenshots of before and after is great.*
## before
![colored corners](https://github.com/user-attachments/assets/43f3ec09-8e15-414d-adda-33fb9ddfc141)

## after
![after](https://github.com/user-attachments/assets/8346d598-2c31-4a5e-96f7-1d5d36c1878f)


## Validation
ran the app in the simulator

## Issue
Fixes #551 
Related #483 
