### PR TITLE
badge count not reset upon logout

### DIFF
--- a/BeeSwift/AppDelegate.swift
+++ b/BeeSwift/AppDelegate.swift
@@ -133,8 +133,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         assert(Thread.isMainThread, "updateBadgeCount must be run on the main thread")
 
         let context = ServiceLocator.persistentContainer.viewContext
-        guard let goals = ServiceLocator.goalManager.staleGoals(context: context) else { return }
-        let beemergencyCount = goals.count(where: { $0.safeBuf < 1})
+        
+        let beemergencyCount = ServiceLocator.goalManager
+            .staleGoals(context: context)?
+            .count(where: { $0.safeBuf < 1}) ?? 0
+        
         logger.notice("Updating Beemergency badge count to \(beemergencyCount, privacy: .public)")
 
         UNUserNotificationCenter.current().setBadgeCount(beemergencyCount)

--- a/BeeSwift/AppDelegate.swift
+++ b/BeeSwift/AppDelegate.swift
@@ -43,8 +43,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         
         NetworkActivityIndicatorManager.shared.isEnabled = true
         
-        NotificationCenter.default.addObserver(self, selector: #selector(self.updateBadgeCount), name: NSNotification.Name(rawValue: GoalManager.goalsUpdatedNotificationName), object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(self.updateBadgeCount), name: NSNotification.Name(rawValue: CurrentUserManager.signedOutNotificationName), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(self.handleGoalsUpdated), name: NSNotification.Name(rawValue: GoalManager.goalsUpdatedNotificationName), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(self.handleUserSignedOut), name: NSNotification.Name(rawValue: CurrentUserManager.signedOutNotificationName), object: nil)
 
         backgroundUpdates.startUpdatingRegularlyInBackground()
         
@@ -128,19 +128,24 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
         logger.notice("application:didFailToRegisterForRemoteNotificationsWithError")
     }
-    
-    @objc func updateBadgeCount() {
-        assert(Thread.isMainThread, "updateBadgeCount must be run on the main thread")
+
+    @objc private func handleGoalsUpdated() {
+        assert(Thread.isMainThread, "\(#function) must be run on the main thread")
 
         let context = ServiceLocator.persistentContainer.viewContext
-        
-        let beemergencyCount = ServiceLocator.goalManager
-            .staleGoals(context: context)?
-            .count(where: { $0.safeBuf < 1}) ?? 0
-        
+        guard let goals = ServiceLocator.goalManager.staleGoals(context: context) else { return }
+        let beemergencyCount = goals.count(where: { $0.safeBuf < 1})
         logger.notice("Updating Beemergency badge count to \(beemergencyCount, privacy: .public)")
 
         UNUserNotificationCenter.current().setBadgeCount(beemergencyCount)
+    }
+    
+    @objc private func handleUserSignedOut() {
+        assert(Thread.isMainThread, "\(#function) must be run on the main thread")
+
+        logger.notice("User signed out; updating Beemergency badge count to 0")
+
+        UNUserNotificationCenter.current().setBadgeCount(0)
     }
 
     private func refreshGoalsAndLogErrors() {


### PR DESCRIPTION
## Summary
Badge count is not being set when a user logs out. 


## Validation
Ran the app in the simulator. Signed in with account that had beemergencies. Noted the badge count. Signed out. Noticed the badge count. 

## Issue
Fixes #553