### PR TITLE
Fix styling of the navigation bar

### DIFF
--- a/BeeSwift/SceneDelegate.swift
+++ b/BeeSwift/SceneDelegate.swift
@@ -10,8 +10,13 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         windowScene.requestGeometryUpdate(.iOS(interfaceOrientations: .all))
 
+        let navigationController = UINavigationController(rootViewController: GalleryViewController())
+        navigationController.navigationBar.isTranslucent = false
+        navigationController.navigationBar.barStyle = .black
+        navigationController.navigationBar.tintColor = .white
+
         window = UIWindow(windowScene: windowScene)
-        window?.rootViewController = UINavigationController(rootViewController: GalleryViewController())
+        window?.rootViewController = navigationController
         window?.makeKeyAndVisible()
     }
 }


### PR DESCRIPTION
## Summary
In #555 I removed the StoryBoard for the main app view. In doing so I removed some of the custom styling of the Navigation bar at the top of the app, resulting in colored icons and the dark style not being maintained.

Here we bring back styling to match the old behavior.

## Validation
Ran in the simulator in light and dark mode.

Before this PR:
![before - light.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/rdDeEq3eXw8gG9wtINgo/21bbaaa7-e7a2-4bbc-af29-0b5afcd0d196.png)
![before -dark.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/rdDeEq3eXw8gG9wtINgo/378f4ba2-e388-4dc7-8d00-83908335173b.png)

After this PR:
![after - light.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/rdDeEq3eXw8gG9wtINgo/6cdffd41-00d5-435e-ac4d-26950f620272.png)
![after - dark.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/rdDeEq3eXw8gG9wtINgo/ccd08807-b62b-4997-a1d5-0a920510b05e.png)

