### PR TITLE
Remove ServiceLocator references from GalleryViewController

### DIFF
--- a/BeeSwift/Gallery/GalleryViewController.swift
+++ b/BeeSwift/Gallery/GalleryViewController.swift
@@ -13,6 +13,7 @@ import SwiftyJSON
 import HealthKit
 import SafariServices
 import OSLog
+import CoreData
 
 import BeeKit
 

--- a/BeeSwift/SceneDelegate.swift
+++ b/BeeSwift/SceneDelegate.swift
@@ -10,7 +10,15 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         windowScene.requestGeometryUpdate(.iOS(interfaceOrientations: .all))
 
-        let navigationController = UINavigationController(rootViewController: GalleryViewController())
+        let galleryVC = GalleryViewController(
+            currentUserManager: ServiceLocator.currentUserManager,
+            viewContext: ServiceLocator.persistentContainer.viewContext,
+            versionManager: ServiceLocator.versionManager,
+            goalManager: ServiceLocator.goalManager,
+            healthStoreManager: ServiceLocator.healthStoreManager
+        )
+        
+        let navigationController = UINavigationController(rootViewController: galleryVC)
         navigationController.navigationBar.isTranslucent = false
         navigationController.navigationBar.barStyle = .black
         navigationController.navigationBar.tintColor = .white

--- a/BeeSwift/SceneDelegate.swift
+++ b/BeeSwift/SceneDelegate.swift
@@ -3,6 +3,8 @@
 import Foundation
 import UIKit
 
+import BeeKit
+
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     var window: UIWindow?
 


### PR DESCRIPTION
## Summary
I'd like to move the app away from having direct references to ServiceLocator and instead have classes gain references to the dependencies they need via dependency injection. 

This makes a start in that direction with GalleryViewController. Now this is created in code via SceneDelegate we can pass in its dependencies at construction time.

## Validation
* [x] Verify that the app can launch and show the gallery view
* [x] Verify it is possible to pull to refresh the goals list