### PR TITLE
update button on edit datapoint too small

### DIFF
--- a/BeeSwift/EditDatapointViewController.swift
+++ b/BeeSwift/EditDatapointViewController.swift
@@ -138,6 +138,7 @@ class EditDatapointViewController: UIViewController, UITextFieldDelegate {
         updateButton.snp.makeConstraints { (make) in
             make.left.right.equalTo(formView)
             make.top.equalTo(formView.snp.bottom).offset(20)
+            make.height.equalTo(Constants.defaultTextFieldHeight)
         }
 
         let deleteButton = UIBarButtonItem(barButtonSystemItem: .trash, target: self, action: #selector(self.deleteButtonPressed))


### PR DESCRIPTION
## Summary
use standard button height

fixes #562


## Validation
app in simulator

### Media
#### after
![edit datapoint update button](https://github.com/user-attachments/assets/7e039c7d-2c6b-4e96-8939-7869797b853f)

#### before
![image](https://github.com/user-attachments/assets/b070fa51-934e-4233-923d-45b577f536a1)
