### PR TITLE
Do not commit build numbers to git

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -66,10 +66,11 @@ platform :ios do
 
     # Add a git tag for this build. This will automatically
     # use an appropriate git tag name
+    # Note this tag will not include the uncommited version changes
     add_git_tag
 
-    # Push the new commit and tag back to your git remote
-    push_to_git_remote
+    # Push the tag to github
+    push_git_tags
 
     reset_git_repo(
       skip_clean: true,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -62,8 +62,7 @@ platform :ios do
     
     build_app(scheme: "BeeSwift")
 
-    # Commit the version bump
-    commit_version_bump(xcodeproj: "BeeSwift.xcodeproj")
+    upload_to_testflight
 
     # Add a git tag for this build. This will automatically
     # use an appropriate git tag name
@@ -71,8 +70,6 @@ platform :ios do
 
     # Push the new commit and tag back to your git remote
     push_to_git_remote
-    
-    upload_to_testflight
   end
   lane :increment_major_version do
     increment_version_number(

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -70,6 +70,11 @@ platform :ios do
 
     # Push the new commit and tag back to your git remote
     push_to_git_remote
+
+    reset_git_repo(
+      skip_clean: true,
+      files: ["BeeSwift.xcodeproj"]
+    )
   end
   lane :increment_major_version do
     increment_version_number(

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -73,7 +73,10 @@ platform :ios do
 
     reset_git_repo(
       skip_clean: true,
-      files: ["BeeSwift.xcodeproj"]
+      files: [
+        "BeeSwift.xcodeproj",
+        "*/Info.plist"
+      ]
     )
   end
   lane :increment_major_version do


### PR DESCRIPTION
## Summary
Each testflight build has a unique build number. This is required by apple, and also helps identify e.g. which builds crashes are present in. Previously every time we did a build we would update this and check in the new value. This was creating a medium amount of commit noise, so instead we'll still update the value, but not check in the changes.

See #571 for more discussion

## Validation
Ran `fastlane ios beta`
Observed
* A build was created and uploaded with the appropriate build number
* No commits are created
* The repo is clean after the command completes.