### PR TITLE
Remove CurrentUserManager.isDeadbeat

### DIFF
--- a/BeeKit/Managers/CurrentUserManager.swift
+++ b/BeeKit/Managers/CurrentUserManager.swift
@@ -103,10 +103,6 @@ public actor CurrentUserManager {
         }
     }
 
-    public nonisolated func isDeadbeat(context: NSManagedObjectContext) -> Bool {
-        return user(context: context)?.deadbeat ?? false
-    }
-    
     public var username: String? {
         return user(context: modelContext)?.username
     }

--- a/BeeSwift/Components/GoalImageView.swift
+++ b/BeeSwift/Components/GoalImageView.swift
@@ -90,14 +90,14 @@ class GoalImageView : UIView {
             inProgressDownload = nil
         }
 
-        //  - Deadbeat: Placeholder, no animation
-        if ServiceLocator.currentUserManager.isDeadbeat(context: ServiceLocator.persistentContainer.viewContext) {
+        //  No Goal: Placeholder, no animation
+        guard let goal = self.goal else {
             clearGoalGraph()
             return
         }
 
-        //  No Goal: Placeholder, no animation
-        guard let goal = self.goal else {
+        //  - Deadbeat: Placeholder, no animation
+        if goal.owner.deadbeat {
             clearGoalGraph()
             return
         }

--- a/BeeSwift/Gallery/GalleryViewController.swift
+++ b/BeeSwift/Gallery/GalleryViewController.swift
@@ -289,8 +289,8 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
     
 
     func updateDeadbeatVisibility() {
-        let isDeadbeat = currentUserManager.isDeadbeat(context: viewContext)
-        self.deadbeatView.isHidden = !isDeadbeat
+        guard let user = currentUserManager.user(context: viewContext) else { return }
+        self.deadbeatView.isHidden = !user.deadbeat
     }
     
     private let lastUpdatedDateFormatter: RelativeDateTimeFormatter = {


### PR DESCRIPTION
## Summary
CurrentUserManager.isDeadbeat was just a thin wrapper around `User.deadbeat`. Using the wrapper meant that components had additional dependencies. In particular this makes dependency injection with collection cells difficult. Switch to just using the property directly.

## Validation
Launch app in simulator. Confirm we can load gallery, and see images in gallery and goal view
