### PR TITLE
Fix CurrentUserManager nonisolated warnings

### DIFF
--- a/BeeKit/Managers/CurrentUserManager.swift
+++ b/BeeKit/Managers/CurrentUserManager.swift
@@ -37,14 +37,12 @@ public actor CurrentUserManager {
 
     internal static let keychainPrefix = "CurrentUserManager_"
 
-    private let keychain = KeychainSwift(keyPrefix: CurrentUserManager.keychainPrefix)
     private let requestManager: RequestManager
 
     fileprivate static var allKeys: [String] {
         [accessTokenKey, usernameKey, deadbeatKey, defaultLeadtimeKey, defaultAlertstartKey, defaultDeadlineKey, beemTZKey]
     }
     
-    nonisolated let userDefaults = UserDefaults(suiteName: Constants.appGroupIdentifier)!
 
     init(requestManager: RequestManager, container: BeeminderPersistentContainer) {
         self.requestManager = requestManager
@@ -60,6 +58,7 @@ public actor CurrentUserManager {
     // If there is an existing session based on UserDefaults, create a new User object
     private nonisolated func migrateValuesToCoreData() {
         let context = modelContainer.newBackgroundContext()
+        let userDefaults = UserDefaults(suiteName: Constants.appGroupIdentifier)!
 
         // If there is already a session do nothing
         if user(context: context) != nil {
@@ -84,6 +83,7 @@ public actor CurrentUserManager {
     }
 
     private nonisolated func cleanUpUserDefaults() {
+        let userDefaults = UserDefaults(suiteName: Constants.appGroupIdentifier)!
         for key in CurrentUserManager.allKeys {
             userDefaults.removeObject(forKey: key)
         }
@@ -138,10 +138,12 @@ public actor CurrentUserManager {
     // MARK: - Keychain Management
 
     nonisolated func setAccessToken(_ accessToken: String) {
+        let keychain = KeychainSwift(keyPrefix: CurrentUserManager.keychainPrefix)
         keychain.set(accessToken, forKey: CurrentUserManager.accessTokenKey, withAccess: .accessibleAfterFirstUnlock)
     }
     
     public nonisolated var accessToken: String? {
+        let keychain = KeychainSwift(keyPrefix: CurrentUserManager.keychainPrefix)
         return keychain.get(CurrentUserManager.accessTokenKey)
     }
 
@@ -187,6 +189,7 @@ public actor CurrentUserManager {
 
         try deleteUser()
 
+        let keychain = KeychainSwift(keyPrefix: CurrentUserManager.keychainPrefix)
         keychain.delete(CurrentUserManager.accessTokenKey)
 
         await Task { @MainActor in


### PR DESCRIPTION
## Summary
CurrentUserManager has some methods which need to be called outside the actor - a mix of methods and constructor. These used some properties which then had to be nonisolated, producing lots of warnings. None of these objects are actually stateful, so just create them on demand in the methods that use them.

## Validation
* [ ] Launch the app
* [ ] Verify it is possible to log out and log in