### PR TITLE
no need to assume we are dealing with deadbeats

### DIFF
--- a/BeeSwift/Gallery/GalleryViewController.swift
+++ b/BeeSwift/Gallery/GalleryViewController.swift
@@ -115,6 +115,7 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
             make.left.equalTo(10)
             make.right.equalTo(-10)
         }
+        self.deadbeatView.isHidden = true
         
         stackView.addArrangedSubview(self.outofdateView)
         self.outofdateView.accessibilityIdentifier = "outofdateView"
@@ -289,8 +290,8 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
     
 
     func updateDeadbeatVisibility() {
-        guard let user = currentUserManager.user(context: viewContext) else { return }
-        self.deadbeatView.isHidden = !user.deadbeat
+        let isKnownDeadbeat = currentUserManager.user(context: viewContext)?.deadbeat == true
+        self.deadbeatView.isHidden = !isKnownDeadbeat
     }
     
     private let lastUpdatedDateFormatter: RelativeDateTimeFormatter = {


### PR DESCRIPTION
## Summary
App started off claiming user is a deadbeat.
The state resulted from recent changes in #583 where the deadbeat view was hidden or not only when a user was logged in _and_ the default state being to show the deadbeat view.


*For UI changes including screenshots of before and after is great.*

#### before
![Simulator Screenshot - iPhone 12 Pro](https://github.com/user-attachments/assets/bf36515f-a50b-43d4-8a10-799558212552)


#### after
![Simulator Screenshot - iPhone 12 Pro - 2024-12-30 at 14 33 48](https://github.com/user-attachments/assets/c52b30d7-c9f0-4160-a08c-f1f5eabfe643)

## Validation
signed out, started app anew, signed in
in simulator



Fixes #586
