### PR TITLE
Fix GoalViewController memory leak

### DIFF
--- a/BeeSwift/Components/DatapointTableViewController.swift
+++ b/BeeSwift/Components/DatapointTableViewController.swift
@@ -11,7 +11,7 @@ import UIKit
 
 import BeeKit
 
-protocol DatapointTableViewControllerDelegate {
+protocol DatapointTableViewControllerDelegate: AnyObject {
     func datapointTableViewController(_ datapointTableViewController: DatapointTableViewController, didSelectDatapoint datapoint: BeeDataPoint)
 }
 
@@ -20,7 +20,7 @@ class DatapointTableViewController : UIViewController, UITableViewDelegate, UITa
     fileprivate var datapointsTableView = DatapointsTableView()
 
 
-    public var delegate : DatapointTableViewControllerDelegate?
+    public weak var delegate : DatapointTableViewControllerDelegate?
 
     public var datapoints : [BeeDataPoint] = [] {
         didSet {

--- a/BeeSwift/GoalViewController.swift
+++ b/BeeSwift/GoalViewController.swift
@@ -34,7 +34,7 @@ class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTabl
     fileprivate var valueStepper = UIStepper()
     fileprivate var valueDecimalRemnant : Double = 0.0
     fileprivate var goalImageScrollView = UIScrollView()
-    fileprivate var pollTimer : Timer?
+    fileprivate var lastUpdatedTimer: Timer?
     fileprivate var countdownLabel = BSLabel()
     fileprivate var scrollView = UIScrollView()
     fileprivate var submitButton = BSButton()
@@ -72,8 +72,7 @@ class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTabl
         }
         
         self.updateLastUpdatedLabel()
-        Timer.scheduledTimer(timeInterval: 60, target: self, selector: #selector(GoalViewController.updateLastUpdatedLabel), userInfo: nil, repeats: true)
-        
+        lastUpdatedTimer = Timer.scheduledTimer(timeInterval: 60, target: self, selector: #selector(GoalViewController.updateLastUpdatedLabel), userInfo: nil, repeats: true)
         
         self.view.addSubview(self.scrollView)
         self.scrollView.snp.makeConstraints { (make) -> Void in
@@ -524,6 +523,12 @@ class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTabl
     }
 }
 
+override func viewDidDisappear(_ animated: Bool) {
+    super.viewDidDisappear(animated)
+    NotificationCenter.default.removeObserver(self)
+    lastUpdatedTimer?.invalidate()
+    lastUpdatedTimer = nil
+}
 
 private extension DateFormatter {
     private static let urtextDateFormatter: DateFormatter = {

--- a/BeeSwift/GoalViewController.swift
+++ b/BeeSwift/GoalViewController.swift
@@ -310,7 +310,6 @@ class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTabl
 
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
-        NotificationCenter.default.removeObserver(self)
         lastUpdatedTimer?.invalidate()
         lastUpdatedTimer = nil
     }

--- a/BeeSwift/GoalViewController.swift
+++ b/BeeSwift/GoalViewController.swift
@@ -308,6 +308,13 @@ class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTabl
         self.commentTextField.iq.distanceFromKeyboard = addDataPointAdditionalKeyboardDistance
     }
 
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        NotificationCenter.default.removeObserver(self)
+        lastUpdatedTimer?.invalidate()
+        lastUpdatedTimer = nil
+    }
+
     @objc func onGoalsUpdatedNotification() {
         updateInterfaceToMatchGoal()
     }
@@ -521,13 +528,6 @@ class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTabl
     func safariViewControllerDidFinish(_ controller: SFSafariViewController) {
         controller.dismiss(animated: true, completion: nil)
     }
-}
-
-override func viewDidDisappear(_ animated: Bool) {
-    super.viewDidDisappear(animated)
-    NotificationCenter.default.removeObserver(self)
-    lastUpdatedTimer?.invalidate()
-    lastUpdatedTimer = nil
 }
 
 private extension DateFormatter {


### PR DESCRIPTION
## Summary
We were retaining references to GoalViewController meaning it was not correctly cleaned up when leaving the view. There were two causes of this.
1. A reference cycle between `GoalViewController` and `DatapointTableController` (fixed via weak ref)
2. A Timer maintaining a reference to the view (fixed via invalidating the timer on hide).

Fixes #590

## Validation
Ran the app in the simulator. Navigated to the goal view and back several times. Ran the XCode memory graph debugger.
Before this patch: Observed many GoalViewController still in memory
After this patch: No copies of the class in memory

Logged out and logged into the app. Observed there was no longer a crash reading goal objects.