### PR TITLE
settings shows user's timezone, provide ptr to fetch user

### DIFF
--- a/BeeSwift/Settings/SettingsViewController.swift
+++ b/BeeSwift/Settings/SettingsViewController.swift
@@ -92,7 +92,7 @@ class SettingsViewController: UIViewController {
     }
     
     @objc private func fetchUser() {
-        Task { [weak self] @MainActor in
+        Task { @MainActor [weak self] in
             self?.tableView.isUserInteractionEnabled = false
             try? await ServiceLocator.currentUserManager.refreshUser()
             

--- a/BeeSwift/Settings/SettingsViewController.swift
+++ b/BeeSwift/Settings/SettingsViewController.swift
@@ -92,7 +92,7 @@ class SettingsViewController: UIViewController {
     }
     
     @objc private func fetchUser() {
-        Task { [weak self] in
+        Task { [weak self] @MainActor in
             self?.tableView.isUserInteractionEnabled = false
             try? await ServiceLocator.currentUserManager.refreshUser()
             

--- a/BeeSwift/Settings/SettingsViewController.swift
+++ b/BeeSwift/Settings/SettingsViewController.swift
@@ -34,10 +34,13 @@ class SettingsViewController: UIViewController {
         
         self.tableView.delegate = self
         self.tableView.dataSource = self
-        self.tableView.isScrollEnabled = false
         self.tableView.tableFooterView = UIView()
         self.tableView.register(SettingsTableViewCell.self, forCellReuseIdentifier: self.cellReuseIdentifier)
-
+        self.tableView.refreshControl = {
+            let refreshControl = UIRefreshControl()
+            refreshControl.addTarget(self, action: #selector(self.fetchUser), for: UIControl.Event.valueChanged)
+            return refreshControl
+        }()
 
         let versionLabel = BSLabel()
         self.view.addSubview(versionLabel)
@@ -86,6 +89,19 @@ class SettingsViewController: UIViewController {
     @objc
     func showLogsTapped() {
         self.navigationController?.pushViewController(LogsViewController(), animated: true)
+    }
+    
+    @objc private func fetchUser() {
+        Task { [weak self] in
+            self?.tableView.isUserInteractionEnabled = false
+            try? await ServiceLocator.currentUserManager.refreshUser()
+            
+            self?.tableView.reloadData()
+            self?.tableView.layoutIfNeeded()
+            self?.tableView.refreshControl?.endRefreshing()
+            
+            self?.tableView.isUserInteractionEnabled = true
+        }
     }
 
 }


### PR DESCRIPTION
## Summary
Settings shows the user's timezone but only a few places in the app were fetching the user: fetching default notification settings (entering the default notification settings screen) and upon signing in.
This MR allows the user to trigger a fetch of the User endpoint via a Pull-To-Refresh on the Settings screen.

*For UI changes including screenshots of before and after is great.*
![settings - ptr](https://github.com/user-attachments/assets/f03a815d-adb1-4b62-a821-2a6a176e4732)

## Validation
used the app in the simulator
change the timezone at the website
tapped around in the app again both entering settings and pull to refresh from settings


Fixes #507 and helps out with #360