### PR TITLE
clean code around NSNotification.Name

### DIFF
--- a/BeeKit/Managers/CurrentUserManager.swift
+++ b/BeeKit/Managers/CurrentUserManager.swift
@@ -17,14 +17,16 @@ import SwiftyJSON
 public actor CurrentUserManager {
     let logger = Logger(subsystem: "com.beeminder.beeminder", category: "CurrentUserManager")
 
-    public static let signedInNotificationName     = NSNotification.Name(rawValue: "com.beeminder.signedInNotification")
-    public static let willSignOutNotificationName  = NSNotification.Name(rawValue: "com.beeminder.willSignOutNotification")
-    public static let failedSignInNotificationName = NSNotification.Name(rawValue: "com.beeminder.failedSignInNotification")
-    public static let signedOutNotificationName    = NSNotification.Name(rawValue: "com.beeminder.signedOutNotification")
-    public static let resetNotificationName        = NSNotification.Name(rawValue: "com.beeminder.resetNotification")
-    public static let willResetNotificationName    = NSNotification.Name(rawValue: "com.beeminder.willResetNotification")
-    public static let healthKitMetricRemovedNotificationName = NSNotification.Name(rawValue: "com.beeminder.healthKitMetricRemovedNotification")
-
+    public enum NotificationName {
+        public static let signedIn     = NSNotification.Name(rawValue: "com.beeminder.signedInNotification")
+        public static let willSignOut  = NSNotification.Name(rawValue: "com.beeminder.willSignOutNotification")
+        public static let failedSignIn = NSNotification.Name(rawValue: "com.beeminder.failedSignInNotification")
+        public static let signedOut    = NSNotification.Name(rawValue: "com.beeminder.signedOutNotification")
+        public static let reset        = NSNotification.Name(rawValue: "com.beeminder.resetNotification")
+        public static let willReset    = NSNotification.Name(rawValue: "com.beeminder.willResetNotification")
+        public static let healthKitMetricRemoved = NSNotification.Name(rawValue: "com.beeminder.healthKitMetricRemovedNotification")
+    }
+    
     fileprivate let beemiosSecret = "C0QBFPWqDykIgE6RyQ2OJJDxGxGXuVA2CNqcJM185oOOl4EQTjmpiKgcwjki"
     
     internal static let accessTokenKey = "access_token"
@@ -165,20 +167,20 @@ public actor CurrentUserManager {
         self.setAccessToken(responseJSON[CurrentUserManager.accessTokenKey].string!)
         
         await Task { @MainActor in
-            NotificationCenter.default.post(name: CurrentUserManager.signedInNotificationName, object: self)
+            NotificationCenter.default.post(name: CurrentUserManager.NotificationName.signedIn, object: self)
         }.value
     }
     
     func handleFailedSignin(_ responseError: Error, errorMessage : String?) async throws {
         await Task { @MainActor in
-            NotificationCenter.default.post(name: CurrentUserManager.failedSignInNotificationName, object: self, userInfo: ["error" : responseError])
+            NotificationCenter.default.post(name: CurrentUserManager.NotificationName.failedSignIn, object: self, userInfo: ["error" : responseError])
         }.value
         try await self.signOut()
     }
     
     public func signOut() async throws {
         await Task { @MainActor in
-            NotificationCenter.default.post(name: CurrentUserManager.willSignOutNotificationName, object: self)
+            NotificationCenter.default.post(name: CurrentUserManager.NotificationName.willSignOut, object: self)
         }.value
 
         try deleteUser()
@@ -186,7 +188,7 @@ public actor CurrentUserManager {
         keychain.delete(CurrentUserManager.accessTokenKey)
 
         await Task { @MainActor in
-            NotificationCenter.default.post(name: Notification.Name(rawValue: CurrentUserManager.signedOutNotificationName), object: self)
+            NotificationCenter.default.post(name: CurrentUserManager.NotificationName.signedOut, object: self)
         }.value
     }
 }

--- a/BeeKit/Managers/GoalManager.swift
+++ b/BeeKit/Managers/GoalManager.swift
@@ -18,9 +18,11 @@ import OrderedCollections
 public actor GoalManager {
     private let logger = Logger(subsystem: "com.beeminder.beeminder", category: "GoalManager")
 
-    /// A notification that is triggered any time the data for one or more goals is updated
-    public static let goalsUpdatedNotificationName = NSNotification.Name(rawValue: "com.beeminder.goalsUpdatedNotification")
-
+    public enum NotificationName {
+        /// A notification that is triggered any time the data for one or more goals is updated
+        public static let goalsUpdated = NSNotification.Name(rawValue: "com.beeminder.goalsUpdatedNotification")
+    }
+        
     private let requestManager: RequestManager
     private nonisolated let currentUserManager: CurrentUserManager
 
@@ -42,7 +44,7 @@ public actor GoalManager {
         // 2) Other methods may be called with the actor executor, so it is no longer safe for the constructor to
         //    access class properties.
 
-        NotificationCenter.default.addObserver(self, selector: #selector(self.onSignedOutNotification), name: CurrentUserManager.signedOutNotificationName, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(self.onSignedOutNotification), name: CurrentUserManager.NotificationName.signedOut, object: nil)
     }
 
     /// Return the state of goals the last time they were fetched from the server. This could have been an arbitrarily long time ago.
@@ -132,7 +134,7 @@ public actor GoalManager {
         // Notify all listeners of the update
         await Task { @MainActor in
             modelContainer.viewContext.refreshAllObjects()
-            NotificationCenter.default.post(name: GoalManager.goalsUpdatedNotificationName, object: self)
+            NotificationCenter.default.post(name: GoalManager.NotificationName.goalsUpdated, object: self)
         }.value
     }
 

--- a/BeeSwift/AppDelegate.swift
+++ b/BeeSwift/AppDelegate.swift
@@ -41,8 +41,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         
         NetworkActivityIndicatorManager.shared.isEnabled = true
         
-        NotificationCenter.default.addObserver(self, selector: #selector(self.handleGoalsUpdated), name: GoalManager.goalsUpdatedNotificationName, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(self.handleUserSignedOut), name: CurrentUserManager.signedOutNotificationName, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(self.handleGoalsUpdated), name: GoalManager.NotificationName.goalsUpdated, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(self.handleUserSignedOut), name: CurrentUserManager.NotificationName.signedOut, object: nil)
 
         backgroundUpdates.startUpdatingRegularlyInBackground()
         

--- a/BeeSwift/Components/GoalImageView.swift
+++ b/BeeSwift/Components/GoalImageView.swift
@@ -57,7 +57,7 @@ class GoalImageView : UIView {
         beeLemniscateView.isHidden = true
 
         NotificationCenter.default.addObserver(
-            forName: GoalManager.goalsUpdatedNotificationName,
+            forName: GoalManager.NotificationName.goalsUpdated,
             object: nil,
             queue: OperationQueue.main
         ) { [weak self] _ in

--- a/BeeSwift/Gallery/GalleryViewController.swift
+++ b/BeeSwift/Gallery/GalleryViewController.swift
@@ -65,10 +65,10 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        NotificationCenter.default.addObserver(self, selector: #selector(self.handleSignIn), name: CurrentUserManager.signedInNotificationName, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(self.handleSignOut), name: CurrentUserManager.signedOutNotificationName, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(self.handleSignIn), name: CurrentUserManager.NotificationName.signedIn, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(self.handleSignOut), name: CurrentUserManager.NotificationName.signedOut, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(self.openGoalFromNotification(_:)), name: NSNotification.Name(rawValue: "openGoal"), object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(self.handleGoalsFetchedNotification), name: GoalManager.goalsUpdatedNotificationName, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(self.handleGoalsFetchedNotification), name: GoalManager.NotificationName.goalsUpdated, object: nil)
 
         self.view.addSubview(stackView)
         stackView.axis = .vertical

--- a/BeeSwift/GoalViewController.swift
+++ b/BeeSwift/GoalViewController.swift
@@ -293,7 +293,7 @@ class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTabl
             self.navigationItem.rightBarButtonItems?.append(UIBarButtonItem(image: UIImage(systemName: "stopwatch"), style: .plain, target: self, action: #selector(self.timerButtonPressed)))
         }
 
-        NotificationCenter.default.addObserver(self, selector: #selector(onGoalsUpdatedNotification), name: GoalManager.goalsUpdatedNotificationName, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(onGoalsUpdatedNotification), name: GoalManager.NotificationName.goalsUpdated, object: nil)
 
         setValueTextField()
         updateInterfaceToMatchGoal()

--- a/BeeSwift/Settings/HealthKitConfigViewController.swift
+++ b/BeeSwift/Settings/HealthKitConfigViewController.swift
@@ -50,7 +50,7 @@ class HealthKitConfigViewController: UIViewController {
 
         self.updateGoals()
 
-        NotificationCenter.default.addObserver(self, selector: #selector(self.handleMetricRemovedNotification(notification:)), name: NSNotification.Name(rawValue: CurrentUserManager.healthKitMetricRemovedNotificationName), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(self.handleMetricRemovedNotification(notification:)), name: CurrentUserManager.NotificationName.healthKitMetricRemoved, object: nil)
     }
 
     func updateGoals() {

--- a/BeeSwift/Settings/RemoveHKMetricViewController.swift
+++ b/BeeSwift/Settings/RemoveHKMetricViewController.swift
@@ -89,7 +89,7 @@ class RemoveHKMetricViewController: UIViewController {
                 hud.mode = .customView
                 hud.customView = UIImageView(image: UIImage(systemName: "checkmark"))
 
-                NotificationCenter.default.post(name: CurrentUserManager.healthKitMetricRemovedNotificationName, object: self, userInfo: ["goal": self.goal as Any])
+                NotificationCenter.default.post(name: CurrentUserManager.NotificationName.healthKitMetricRemoved, object: self, userInfo: ["goal": self.goal as Any])
                 
                 DispatchQueue.main.asyncAfter(deadline: .now() + 1, execute: {
                     hud.hide(animated: true, afterDelay: 2)

--- a/BeeSwift/SignInViewController.swift
+++ b/BeeSwift/SignInViewController.swift
@@ -30,8 +30,8 @@ class SignInViewController : UIViewController, UITextFieldDelegate {
             make.edges.equalTo(self.view)
         }
         
-        NotificationCenter.default.addObserver(self, selector: #selector(self.handleFailedSignIn(_:)), name: CurrentUserManager.failedSignInNotificationName, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(self.handleSignedIn(_:)), name: CurrentUserManager.signedInNotificationName, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(self.handleFailedSignIn(_:)), name: CurrentUserManager.NotificationName.failedSignIn, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(self.handleSignedIn(_:)), name: CurrentUserManager.NotificationName.signedIn, object: nil)
         self.view.backgroundColor = UIColor.systemBackground
         
         


### PR DESCRIPTION
## Summary
Some places defined strings that were then meant to be converted to NSNotification.Name. This MR removes that step so the `NSNotification.Name`s can be used directly.

## Validation
Could use as before, notifications such as signing out and goals updated were still observed.