### PR TITLE
show when healthkit linked goal was last synced with healthkit

### DIFF
--- a/BeeKit/Managers/HealthStoreManager.swift
+++ b/BeeKit/Managers/HealthStoreManager.swift
@@ -205,5 +205,10 @@ public actor HealthStoreManager {
         let nonZeroDataPoints = newDataPoints.filter { dataPoint in dataPoint.value != 0 }
         logger.notice("Updating \(metric.databaseString, privacy: .public) goal with \(nonZeroDataPoints.count, privacy: .public) datapoints. Skipped \(newDataPoints.count - nonZeroDataPoints.count, privacy: .public) empty points.")
         try await ServiceLocator.dataPointManager.updateToMatchDataPoints(goalID: goal.objectID, healthKitDataPoints: nonZeroDataPoints)
+        
+        try await modelContext.perform {
+            goal.lastSyncedWithHealthKit = Date()
+            try self.modelContext.save()
+        }
     }
 }

--- a/BeeKit/Model/BeeminderModel.xcdatamodeld/BeeminderModel.xcdatamodel/contents
+++ b/BeeKit/Model/BeeminderModel.xcdatamodeld/BeeminderModel.xcdatamodel/contents
@@ -20,6 +20,7 @@
         <attribute name="id" attributeType="String"/>
         <attribute name="initDay" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="lastModifiedLocal" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="lastSyncedWithHealthKit" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="lastTouch" attributeType="String"/>
         <attribute name="leadTime" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="limSum" attributeType="String"/>

--- a/BeeKit/Model/Goal.swift
+++ b/BeeKit/Model/Goal.swift
@@ -65,6 +65,8 @@ public class Goal: NSManagedObject {
 
     /// The last time this record in the CoreData store was updated
     @NSManaged public var lastModifiedLocal: Date
+    
+    @NSManaged public var lastSyncedWithHealthKit: Date?
 
     public init(
         context: NSManagedObjectContext,
@@ -121,6 +123,7 @@ public class Goal: NSManagedObject {
         self.yAxis = yAxis
 
         lastModifiedLocal = Date()
+        lastSyncedWithHealthKit = Date.distantPast
     }
 
     public init(context: NSManagedObjectContext, owner: User, json: JSON) {
@@ -129,6 +132,8 @@ public class Goal: NSManagedObject {
         self.owner = owner
         self.id = json["id"].string!
 
+        lastSyncedWithHealthKit = Date.distantPast
+        
         self.updateToMatch(json: json)
     }
 

--- a/BeeSwift/GoalViewController.swift
+++ b/BeeSwift/GoalViewController.swift
@@ -38,6 +38,7 @@ class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTabl
     fileprivate var countdownLabel = BSLabel()
     fileprivate var scrollView = UIScrollView()
     fileprivate var submitButton = BSButton()
+    private let pullToRefreshView = PullToRefreshView()
     fileprivate let headerWidth = Double(1.0/3.0)
     fileprivate let viewGoalActivityType = "com.beeminder.viewGoal"
 
@@ -269,14 +270,9 @@ class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTabl
         }
 
         if self.goal.isDataProvidedAutomatically {
-            let pullToRefreshView = PullToRefreshView()
             scrollView.addSubview(pullToRefreshView)
 
-            if self.goal.isLinkedToHealthKit {
-                pullToRefreshView.message = "Pull down to synchronize with Apple Health"
-            } else {
-                pullToRefreshView.message = "Pull down to update"
-            }
+            refreshPullDown()
 
             pullToRefreshView.snp.makeConstraints { (make) in
                 make.top.equalTo(self.datapointTableController.view.snp.bottom).offset(elementSpacing)
@@ -360,6 +356,21 @@ class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTabl
     @objc func refreshCountdown() {
         self.countdownLabel.textColor = self.goal.countdownColor
         self.countdownLabel.text = self.goal.capitalSafesum()
+    }
+    
+    private func refreshPullDown() {
+        let dateFormatter = ISO8601DateFormatter()
+        dateFormatter.formatOptions = [.withFullDate, .withFullTime]
+        
+        let lastSynced = goal.lastSyncedWithHealthKit.map { dateFormatter.string(from: $0) } ?? "not yet"
+        
+        if self.goal.isLinkedToHealthKit {
+            pullToRefreshView.message = "Pull down to synchronize with Apple Health"
+                + "\n"
+            + "Last synced: \(lastSynced)"
+        } else {
+            pullToRefreshView.message = "Pull down to update"
+        }
     }
 
     @objc func goalImageTapped() {
@@ -501,6 +512,7 @@ class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTabl
 
         self.refreshCountdown()
         self.updateLastUpdatedLabel()
+        self.refreshPullDown()
     }
 
     func viewForZooming(in scrollView: UIScrollView) -> UIView? {


### PR DESCRIPTION
## Summary
The user can see the most recent datapoints and can infer from that when the last sync took place. This PR displays the date directly so the user need not infer when that might have been.

*For UI changes including screenshots of before and after is great.*
![Simulator Screenshot - iPhone 12 Pro](https://github.com/user-attachments/assets/ec882300-60f0-4eea-ba24-5408d9a5eff8)


## Validation
ran app in simulator


## Tickets
Fixes #193 
