### PR TITLE
Remove copyright symbols

### DIFF
--- a/BeeKit/BeeKit.h
+++ b/BeeKit/BeeKit.h
@@ -3,7 +3,7 @@
 //  BeeKit
 //
 //  Created by Andrew Brett on 5/19/21.
-//  Copyright © 2021 APB. All rights reserved.
+//  Copyright 2021 APB. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/BeeKit/Config.swift.sample
+++ b/BeeKit/Config.swift.sample
@@ -3,7 +3,7 @@
 //  BeeSwift
 //
 //  Created by Andrew Brett on 2/20/20.
-//  Copyright © 2020 APB. All rights reserved.
+//  Copyright 2020 APB. All rights reserved.
 //
 
 import Foundation

--- a/BeeKit/DateUtils.swift
+++ b/BeeKit/DateUtils.swift
@@ -3,7 +3,7 @@
 //  BeeSwift
 //
 //  Created by Theo Spears on 1/27/23.
-//  Copyright © 2023 APB. All rights reserved.
+//  Copyright 2023 APB. All rights reserved.
 //
 
 import Foundation

--- a/BeeKit/HeathKit/HealthKitConfig.swift
+++ b/BeeKit/HeathKit/HealthKitConfig.swift
@@ -3,7 +3,7 @@
 //  BeeSwift
 //
 //  Created by Andy Brett on 3/25/17.
-//  Copyright © 2017 APB. All rights reserved.
+//  Copyright 2017 APB. All rights reserved.
 //
 
 import Foundation

--- a/BeeKit/HeathKit/HealthKitError.swift
+++ b/BeeKit/HeathKit/HealthKitError.swift
@@ -3,7 +3,7 @@
 //  BeeSwift
 //
 //  Created by Theo Spears on 11/5/22.
-//  Copyright © 2022 APB. All rights reserved.
+//  Copyright 2022 APB. All rights reserved.
 //
 
 import Foundation

--- a/BeeKit/Managers/CurrentUserManager.swift
+++ b/BeeKit/Managers/CurrentUserManager.swift
@@ -3,7 +3,7 @@
 //  BeeSwift
 //
 //  Created by Andy Brett on 4/26/15.
-//  Copyright (c) 2015 APB. All rights reserved.
+//  Copyright 2015 APB. All rights reserved.
 //
 
 import CoreData

--- a/BeeKit/Managers/GoalManager.swift
+++ b/BeeKit/Managers/GoalManager.swift
@@ -3,7 +3,7 @@
 //  BeeSwift
 //
 //  Created by Theo Spears on 2/7/23.
-//  Copyright © 2023 APB. All rights reserved.
+//  Copyright 2023 APB. All rights reserved.
 //
 
 import Foundation

--- a/BeeKit/Managers/HealthStoreManager.swift
+++ b/BeeKit/Managers/HealthStoreManager.swift
@@ -3,7 +3,7 @@
 //  BeeSwift
 //
 //  Created by Andy Brett on 11/28/17.
-//  Copyright © 2017 APB. All rights reserved.
+//  Copyright 2017 APB. All rights reserved.
 //
 
 import CoreData

--- a/BeeKit/Managers/RequestManager.swift
+++ b/BeeKit/Managers/RequestManager.swift
@@ -3,7 +3,7 @@
 //  BeeSwift
 //
 //  Created by Andy Brett on 5/10/15.
-//  Copyright (c) 2015 APB. All rights reserved.
+//  Copyright 2015 APB. All rights reserved.
 //
 
 import Foundation

--- a/BeeKit/Managers/SignedRequestManager.swift
+++ b/BeeKit/Managers/SignedRequestManager.swift
@@ -3,7 +3,7 @@
 //  BeeSwift
 //
 //  Created by Andy Brett on 11/30/17.
-//  Copyright © 2017 APB. All rights reserved.
+//  Copyright 2017 APB. All rights reserved.
 //
 
 import Foundation

--- a/BeeKit/Managers/VersionManager.swift
+++ b/BeeKit/Managers/VersionManager.swift
@@ -3,7 +3,7 @@
 //  BeeSwift
 //
 //  Created by Andrew Brett on 3/19/20.
-//  Copyright © 2020 APB. All rights reserved.
+//  Copyright 2020 APB. All rights reserved.
 //
 
 import Foundation

--- a/BeeKit/ServiceLocator.swift
+++ b/BeeKit/ServiceLocator.swift
@@ -3,7 +3,7 @@
 //  BeeSwift
 //
 //  Created by Theo Spears on 2/7/23.
-//  Copyright © 2023 APB. All rights reserved.
+//  Copyright 2023 APB. All rights reserved.
 //
 
 import Foundation

--- a/BeeKit/UI/BSButton.swift
+++ b/BeeKit/UI/BSButton.swift
@@ -3,7 +3,7 @@
 //  BeeSwift
 //
 //  Created by Andy Brett on 4/27/15.
-//  Copyright (c) 2015 APB. All rights reserved.
+//  Copyright 2015 APB. All rights reserved.
 //
 
 import Foundation

--- a/BeeKit/UI/BSLabel.swift
+++ b/BeeKit/UI/BSLabel.swift
@@ -3,7 +3,7 @@
 //  BeeSwift
 //
 //  Created by Andy Brett on 4/26/15.
-//  Copyright (c) 2015 APB. All rights reserved.
+//  Copyright 2015 APB. All rights reserved.
 //
 
 import Foundation

--- a/BeeKit/UI/BSTextField.swift
+++ b/BeeKit/UI/BSTextField.swift
@@ -3,7 +3,7 @@
 //  BeeSwift
 //
 //  Created by Andy Brett on 11/22/16.
-//  Copyright © 2016 APB. All rights reserved.
+//  Copyright 2016 APB. All rights reserved.
 //
 
 import Foundation

--- a/BeeKit/UI/UIColorExtension.swift
+++ b/BeeKit/UI/UIColorExtension.swift
@@ -3,7 +3,7 @@
 //  BeeSwift
 //
 //  Created by Andy Brett on 4/26/15.
-//  Copyright (c) 2015 APB. All rights reserved.
+//  Copyright 2015 APB. All rights reserved.
 //
 
 import Foundation

--- a/BeeKit/UI/UIFontExtension.swift
+++ b/BeeKit/UI/UIFontExtension.swift
@@ -3,7 +3,7 @@
 //  BeeSwift
 //
 //  Created by Andy Brett on 11/7/15.
-//  Copyright © 2015 APB. All rights reserved.
+//  Copyright 2015 APB. All rights reserved.
 //
 
 import Foundation

--- a/BeeKit/Util/Constants.swift
+++ b/BeeKit/Util/Constants.swift
@@ -3,7 +3,7 @@
 //  BeeSwift
 //
 //  Created by Andy Brett on 5/15/15.
-//  Copyright (c) 2015 APB. All rights reserved.
+//  Copyright 2015 APB. All rights reserved.
 //
 
 import Foundation

--- a/BeeKitTests/BeeKitTests.swift
+++ b/BeeKitTests/BeeKitTests.swift
@@ -3,7 +3,7 @@
 //  BeeKitTests
 //
 //  Created by Andrew Brett on 5/19/21.
-//  Copyright © 2021 APB. All rights reserved.
+//  Copyright 2021 APB. All rights reserved.
 //
 
 import XCTest

--- a/BeeSwift/AddDataIntentHandler.swift
+++ b/BeeSwift/AddDataIntentHandler.swift
@@ -3,7 +3,7 @@
 //  BeeSwift
 //
 //  Created by Andrew Brett on 3/28/21.
-//  Copyright © 2021 APB. All rights reserved.
+//  Copyright 2021 APB. All rights reserved.
 //
 
 import Foundation

--- a/BeeSwift/AppDelegate.swift
+++ b/BeeSwift/AppDelegate.swift
@@ -3,7 +3,7 @@
 //  BeeSwift
 //
 //  Created by Andy Brett on 4/19/15.
-//  Copyright (c) 2015 APB. All rights reserved.
+//  Copyright 2015 APB. All rights reserved.
 //
 
 import CoreSpotlight

--- a/BeeSwift/BeeSwift-Bridging-Header.h
+++ b/BeeSwift/BeeSwift-Bridging-Header.h
@@ -3,7 +3,7 @@
 //  BeeSwift
 //
 //  Created by Andy Brett on 4/19/15.
-//  Copyright (c) 2015 APB. All rights reserved.
+//  Copyright 2015 APB. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/BeeSwift/Components/DatapointTableViewController.swift
+++ b/BeeSwift/Components/DatapointTableViewController.swift
@@ -3,7 +3,7 @@
 //  BeeSwift
 //
 //  Created by Theo Spears on 11/27/22.
-//  Copyright © 2022 APB. All rights reserved.
+//  Copyright 2022 APB. All rights reserved.
 //
 
 import Foundation

--- a/BeeSwift/Components/DatapointValueAccessory.swift
+++ b/BeeSwift/Components/DatapointValueAccessory.swift
@@ -3,7 +3,7 @@
 //  BeeSwift
 //
 //  Created by Theo Spears on 11/19/22.
-//  Copyright © 2022 APB. All rights reserved.
+//  Copyright 2022 APB. All rights reserved.
 //
 
 import Foundation

--- a/BeeSwift/Components/DatapointsTableView.swift
+++ b/BeeSwift/Components/DatapointsTableView.swift
@@ -3,7 +3,7 @@
 //  BeeSwift
 //
 //  Created by Andy Brett on 5/16/15.
-//  Copyright (c) 2015 APB. All rights reserved.
+//  Copyright 2015 APB. All rights reserved.
 //
 
 import Foundation

--- a/BeeSwift/Config.sample.swift
+++ b/BeeSwift/Config.sample.swift
@@ -3,7 +3,7 @@
 //  BeeSwift
 //
 //  Created by Andy Brett on 11/29/17.
-//  Copyright © 2017 APB. All rights reserved.
+//  Copyright 2017 APB. All rights reserved.
 //
 
 import Foundation

--- a/BeeSwift/DatapointTableViewCell.swift
+++ b/BeeSwift/DatapointTableViewCell.swift
@@ -3,7 +3,7 @@
 //  BeeSwift
 //
 //  Created by Andy Brett on 5/12/15.
-//  Copyright (c) 2015 APB. All rights reserved.
+//  Copyright 2015 APB. All rights reserved.
 //
 
 import Foundation

--- a/BeeSwift/EditDatapointViewController.swift
+++ b/BeeSwift/EditDatapointViewController.swift
@@ -3,7 +3,7 @@
 //  BeeSwift
 //
 //  Created by Andy Brett on 8/8/18.
-//  Copyright © 2018 APB. All rights reserved.
+//  Copyright 2018 APB. All rights reserved.
 //
 
 import UIKit

--- a/BeeSwift/Gallery/ChooseGoalSortViewController.swift
+++ b/BeeSwift/Gallery/ChooseGoalSortViewController.swift
@@ -4,7 +4,7 @@
 //  BeeSwift
 //
 //  Created by Andy Brett on 12/21/17.
-//  Copyright © 2017 APB. All rights reserved.
+//  Copyright 2017 APB. All rights reserved.
 //
 
 import UIKit

--- a/BeeSwift/Gallery/GalleryViewController.swift
+++ b/BeeSwift/Gallery/GalleryViewController.swift
@@ -3,7 +3,7 @@
 //  BeeSwift
 //
 //  Created by Andy Brett on 4/19/15.
-//  Copyright (c) 2015 APB. All rights reserved.
+//  Copyright 2015 APB. All rights reserved.
 //
 
 import UIKit

--- a/BeeSwift/GoalCollectionViewCell.swift
+++ b/BeeSwift/GoalCollectionViewCell.swift
@@ -3,7 +3,7 @@
 //  BeeSwift
 //
 //  Created by Andy Brett on 4/24/15.
-//  Copyright (c) 2015 APB. All rights reserved.
+//  Copyright 2015 APB. All rights reserved.
 //
 
 import Foundation

--- a/BeeSwift/GoalViewController.swift
+++ b/BeeSwift/GoalViewController.swift
@@ -3,7 +3,7 @@
 //  BeeSwift
 //
 //  Created by Andy Brett on 4/24/15.
-//  Copyright (c) 2015 APB. All rights reserved.
+//  Copyright 2015 APB. All rights reserved.
 //
 
 import Foundation

--- a/BeeSwift/HealthKitConfigTableViewCell.swift
+++ b/BeeSwift/HealthKitConfigTableViewCell.swift
@@ -3,7 +3,7 @@
 //  BeeSwift
 //
 //  Created by Andy Brett on 3/15/17.
-//  Copyright © 2017 APB. All rights reserved.
+//  Copyright 2017 APB. All rights reserved.
 //
 
 import UIKit

--- a/BeeSwift/HealthKitMetricTableViewCell.swift
+++ b/BeeSwift/HealthKitMetricTableViewCell.swift
@@ -3,7 +3,7 @@
 //  BeeSwift
 //
 //  Created by Andy Brett on 3/29/17.
-//  Copyright © 2017 APB. All rights reserved.
+//  Copyright 2017 APB. All rights reserved.
 //
 
 import UIKit

--- a/BeeSwift/Settings/ChooseHKMetricViewController.swift
+++ b/BeeSwift/Settings/ChooseHKMetricViewController.swift
@@ -3,7 +3,7 @@
 //  BeeSwift
 //
 //  Created by Andy Brett on 3/29/17.
-//  Copyright © 2017 APB. All rights reserved.
+//  Copyright 2017 APB. All rights reserved.
 //
 
 import UIKit

--- a/BeeSwift/Settings/ConfigureNotificationsViewController.swift
+++ b/BeeSwift/Settings/ConfigureNotificationsViewController.swift
@@ -3,7 +3,7 @@
 //  BeeSwift
 //
 //  Created by Andy Brett on 12/20/17.
-//  Copyright © 2017 APB. All rights reserved.
+//  Copyright 2017 APB. All rights reserved.
 //
 
 import UIKit

--- a/BeeSwift/Settings/EditDefaultNotificationsViewController.swift
+++ b/BeeSwift/Settings/EditDefaultNotificationsViewController.swift
@@ -3,7 +3,7 @@
 //  BeeSwift
 //
 //  Created by Andy Brett on 11/7/15.
-//  Copyright © 2015 APB. All rights reserved.
+//  Copyright 2015 APB. All rights reserved.
 //
 
 import Foundation

--- a/BeeSwift/Settings/EditGoalNotificationsViewController.swift
+++ b/BeeSwift/Settings/EditGoalNotificationsViewController.swift
@@ -3,7 +3,7 @@
 //  BeeSwift
 //
 //  Created by Andy Brett on 11/7/15.
-//  Copyright © 2015 APB. All rights reserved.
+//  Copyright 2015 APB. All rights reserved.
 //
 
 import Foundation

--- a/BeeSwift/Settings/EditNotificationsViewController.swift
+++ b/BeeSwift/Settings/EditNotificationsViewController.swift
@@ -3,7 +3,7 @@
 //  BeeSwift
 //
 //  Created by Andy Brett on 11/2/15.
-//  Copyright © 2015 APB. All rights reserved.
+//  Copyright 2015 APB. All rights reserved.
 //
 
 import Foundation

--- a/BeeSwift/Settings/HealthKitConfigViewController.swift
+++ b/BeeSwift/Settings/HealthKitConfigViewController.swift
@@ -3,7 +3,7 @@
 //  BeeSwift
 //
 //  Created by Andy Brett on 3/14/17.
-//  Copyright © 2017 APB. All rights reserved.
+//  Copyright 2017 APB. All rights reserved.
 //
 
 import UIKit

--- a/BeeSwift/Settings/RemoveHKMetricViewController.swift
+++ b/BeeSwift/Settings/RemoveHKMetricViewController.swift
@@ -3,7 +3,7 @@
 //  BeeSwift
 //
 //  Created by Andy Brett on 4/9/18.
-//  Copyright © 2018 APB. All rights reserved.
+//  Copyright 2018 APB. All rights reserved.
 //
 
 import UIKit

--- a/BeeSwift/Settings/SettingsViewController.swift
+++ b/BeeSwift/Settings/SettingsViewController.swift
@@ -3,7 +3,7 @@
 //  BeeSwift
 //
 //  Created by Andy Brett on 4/27/15.
-//  Copyright (c) 2015 APB. All rights reserved.
+//  Copyright 2015 APB. All rights reserved.
 //
 
 import Foundation

--- a/BeeSwift/SettingsTableViewCell.swift
+++ b/BeeSwift/SettingsTableViewCell.swift
@@ -3,7 +3,7 @@
 //  BeeSwift
 //
 //  Created by Andy Brett on 11/2/15.
-//  Copyright © 2015 APB. All rights reserved.
+//  Copyright 2015 APB. All rights reserved.
 //
 
 import Foundation

--- a/BeeSwift/SignInViewController.swift
+++ b/BeeSwift/SignInViewController.swift
@@ -3,7 +3,7 @@
 //  BeeSwift
 //
 //  Created by Andy Brett on 4/26/15.
-//  Copyright (c) 2015 APB. All rights reserved.
+//  Copyright 2015 APB. All rights reserved.
 //
 
 import Foundation

--- a/BeeSwift/TimerViewController.swift
+++ b/BeeSwift/TimerViewController.swift
@@ -3,7 +3,7 @@
 //  BeeSwift
 //
 //  Created by Andy Brett on 1/1/18.
-//  Copyright © 2018 APB. All rights reserved.
+//  Copyright 2018 APB. All rights reserved.
 //
 
 import UIKit

--- a/BeeSwiftTests/BeeSwiftTests.swift
+++ b/BeeSwiftTests/BeeSwiftTests.swift
@@ -3,7 +3,7 @@
 //  BeeSwiftTests
 //
 //  Created by Andy Brett on 4/19/15.
-//  Copyright (c) 2015 APB. All rights reserved.
+//  Copyright 2015 APB. All rights reserved.
 //
 
 import UIKit

--- a/BeeSwiftTests/GoalTests.swift
+++ b/BeeSwiftTests/GoalTests.swift
@@ -3,7 +3,7 @@
 //  BeeSwiftTests
 //
 //  Created by Theo Spears on 7/30/23.
-//  Copyright © 2023 APB. All rights reserved.
+//  Copyright 2023 APB. All rights reserved.
 //
 
 import CoreData

--- a/BeeSwiftTests/LogReaderTests.swift
+++ b/BeeSwiftTests/LogReaderTests.swift
@@ -3,7 +3,7 @@
 //  BeeSwiftTests
 //
 //  Created by Theo Spears on 5/3/23.
-//  Copyright © 2023 APB. All rights reserved.
+//  Copyright 2023 APB. All rights reserved.
 //
 
 import XCTest

--- a/BeeSwiftTests/TotalSleepMinutesTests.swift
+++ b/BeeSwiftTests/TotalSleepMinutesTests.swift
@@ -3,7 +3,7 @@
 //  BeeSwiftTests
 //
 //  Created by Theo Spears on 1/8/23.
-//  Copyright © 2023 APB. All rights reserved.
+//  Copyright 2023 APB. All rights reserved.
 //
 
 import XCTest

--- a/BeeSwiftUITests/BeeSwiftUITests.swift
+++ b/BeeSwiftUITests/BeeSwiftUITests.swift
@@ -3,7 +3,7 @@
 //  BeeSwiftUITests
 //
 //  Created by Andrew Brett on 8/14/20.
-//  Copyright © 2020 APB. All rights reserved.
+//  Copyright 2020 APB. All rights reserved.
 //
 
 import XCTest

--- a/LICENSE
+++ b/LICENSE
@@ -6,7 +6,7 @@ it "Beeminder", etc. We're modeling this on CodeCombat's license.
 
 The following applies to the actual Swift source code in this repository.
 
-Copyright (c) 2011-Present Beeminder
+Copyright 2011-Present Beeminder
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary
It turns out Claude is very bad at generating the copyright symbol. Attempts to do any kind of AI based code changes often introduce spurious diffs where the copyright symbol is removed, which then need to be manually undone.

Work around this by just removing them all. The symbol is an allowable alternative to the word Copyright, so you don't need both.

## Validation
None