### PR TITLE
Gallery's list is now fed by nsfetchedresultscontroller

### DIFF
--- a/BeeSwift/Gallery/GalleryViewController.swift
+++ b/BeeSwift/Gallery/GalleryViewController.swift
@@ -67,7 +67,7 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
         self.healthStoreManager = healthStoreManager
         
         let fetchRequest = Goal.fetchRequest() as! NSFetchRequest<Goal>
-        fetchRequest.sortDescriptors = [NSSortDescriptor(keyPath: \Goal.urgencyKey, ascending: true)]
+        fetchRequest.sortDescriptors = Self.preferredSort
         fetchedResultsController = .init(fetchRequest: fetchRequest,
                                          managedObjectContext: viewContext,
                                          sectionNameKeyPath: nil, cacheName: nil)
@@ -350,7 +350,7 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
         self.didUpdateGoals()
     }
     
-    private var preferredSort: [NSSortDescriptor] {
+    static private var preferredSort: [NSSortDescriptor] {
         let selectedGoalSort = UserDefaults.standard.value(forKey: Constants.selectedGoalSortKey) as? String ?? Constants.urgencyGoalSortString
         
         switch selectedGoalSort {
@@ -383,7 +383,7 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
             self.fetchedResultsController.fetchRequest.predicate = nil
         }
         
-        self.fetchedResultsController.fetchRequest.sortDescriptors = preferredSort
+        self.fetchedResultsController.fetchRequest.sortDescriptors = Self.preferredSort
         try? self.fetchedResultsController.performFetch()
     }
     

--- a/BeeSwift/Gallery/GalleryViewController.swift
+++ b/BeeSwift/Gallery/GalleryViewController.swift
@@ -484,7 +484,7 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
     
     private func configureDataSource() {
         let cellRegistration = UICollectionView.CellRegistration<GoalCollectionViewCell, NSManagedObjectID> { [weak self] cell, indexPath, goalObjectId in
-            let goal = self?.fetchedResultsController.fetchedObjects?.first(where: { $0.objectID == goalObjectId })
+            let goal = self?.fetchedResultsController.object(at: indexPath)
             cell.configure(with: goal)
         }
         

--- a/BeeSwift/Gallery/GalleryViewController.swift
+++ b/BeeSwift/Gallery/GalleryViewController.swift
@@ -18,7 +18,7 @@ import CoreData
 import BeeKit
 
 
-class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayout, UICollectionViewDelegate, UISearchBarDelegate, SFSafariViewControllerDelegate {
+class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayout, UICollectionViewDelegate, UISearchBarDelegate, SFSafariViewControllerDelegate, NSFetchedResultsControllerDelegate {
     let logger = Logger(subsystem: "com.beeminder.beeminder", category: "GalleryViewController")
 
     // Dependencies
@@ -506,9 +506,8 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
         controller.dismiss(animated: true, completion: nil)
         self.fetchGoals()
     }
-}
-
-extension GalleryViewController: NSFetchedResultsControllerDelegate {
+    
+    // MARK: - NSFetchedResultsControllerDelegate
     func controller(_ controller: NSFetchedResultsController<any NSFetchRequestResult>, didChangeContentWith snapshot: NSDiffableDataSourceSnapshotReference) {
         dataSource.apply(snapshot as GallerySnapshot, animatingDifferences: true)
     }

--- a/BeeSwift/Gallery/GalleryViewController.swift
+++ b/BeeSwift/Gallery/GalleryViewController.swift
@@ -87,7 +87,6 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
         NotificationCenter.default.addObserver(self, selector: #selector(self.handleSignIn), name: CurrentUserManager.NotificationName.signedIn, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(self.handleSignOut), name: CurrentUserManager.NotificationName.signedOut, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(self.openGoalFromNotification(_:)), name: GalleryViewController.NotificationName.openGoal, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(self.handleGoalsFetchedNotification), name: GoalManager.NotificationName.goalsUpdated, object: nil)
 
         self.view.addSubview(stackView)
         stackView.axis = .vertical
@@ -244,11 +243,6 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
             self.updateGoals()
             self.fetchGoals()
         }
-    }
-    
-    @objc func handleGoalsFetchedNotification() {
-        logger.debug("\(#function)")
-        logger.debug("doing nothing because GalleryVC should be informed over Core Data about updates to goals of interest")
     }
     
     @objc func settingsButtonPressed() {


### PR DESCRIPTION
## Summary
The initial loading (displaying) of goals on the gallery was slow. The app was still relying on passing and receiving nsnotification/notifications.
With the data in Core Data, the NSFetchedResultsController can be used.

Migrated galleryVC to use the fetched results controller.
Updated the sorting implementation accordingly, directly applying the sort type to the fetchRequest itself.
Updated the filtering as well to also apply directly to the fetchRequest.


*For UI changes including screenshots of before and after is great.*
UI wise this looks the same, just faster/more responsive.

## Validation
Ran the app in the simulator.
Changed sorting.
Changed filters.
Signed in.
Signed out.
Navigated from Gallery to Goal and back.
Sent app into background. Brought back into foreground.
Force quit app, relaunched app.


## Tickets
helps with #588  
