### PR TITLE
goalvc shows also a goal's rate

### DIFF
--- a/BeeKit/Model/BeeminderModel.xcdatamodeld/BeeminderModel.xcdatamodel/contents
+++ b/BeeKit/Model/BeeminderModel.xcdatamodeld/BeeminderModel.xcdatamodel/contents
@@ -14,6 +14,7 @@
         <attribute name="alertStart" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="autodata" optional="YES" attributeType="String"/>
         <attribute name="deadline" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="goalUnits" optional="YES" attributeType="String"/>
         <attribute name="graphUrl" attributeType="String"/>
         <attribute name="healthKitMetric" optional="YES" attributeType="String"/>
         <attribute name="hhmmFormat" attributeType="Boolean" usesScalarValueType="YES"/>
@@ -25,6 +26,8 @@
         <attribute name="limSum" attributeType="String"/>
         <attribute name="pledge" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="queued" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="rate" optional="YES" attributeType="Double" usesScalarValueType="YES"/>
+        <attribute name="rateUnits" optional="YES" attributeType="String"/>
         <attribute name="safeBuf" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="safeSum" attributeType="String"/>
         <attribute name="slug" attributeType="String" spotlightIndexingEnabled="YES"/>

--- a/BeeKit/Model/BeeminderModel.xcdatamodeld/BeeminderModel.xcdatamodel/contents
+++ b/BeeKit/Model/BeeminderModel.xcdatamodeld/BeeminderModel.xcdatamodel/contents
@@ -14,7 +14,10 @@
         <attribute name="alertStart" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="autodata" optional="YES" attributeType="String"/>
         <attribute name="deadline" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="goalDateRaw" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="goalRateRaw" optional="YES" attributeType="Double" usesScalarValueType="YES"/>
         <attribute name="goalUnits" optional="YES" attributeType="String"/>
+        <attribute name="goalValueRaw" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
         <attribute name="graphUrl" attributeType="String"/>
         <attribute name="healthKitMetric" optional="YES" attributeType="String"/>
         <attribute name="hhmmFormat" attributeType="Boolean" usesScalarValueType="YES"/>
@@ -26,7 +29,6 @@
         <attribute name="limSum" attributeType="String"/>
         <attribute name="pledge" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="queued" attributeType="Boolean" usesScalarValueType="YES"/>
-        <attribute name="rate" optional="YES" attributeType="Double" usesScalarValueType="YES"/>
         <attribute name="rateUnits" optional="YES" attributeType="String"/>
         <attribute name="safeBuf" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="safeSum" attributeType="String"/>

--- a/BeeKit/Model/Goal.swift
+++ b/BeeKit/Model/Goal.swift
@@ -51,6 +51,15 @@ public class Goal: NSManagedObject {
     @NSManaged public var won: Bool
     /// The label for the y-axis of the graph. E.g., "Cumulative total hours".
     @NSManaged public var yAxis: String
+    
+    /// Goal units, like "hours" or "pushups" or "pages".
+    @NSManaged public var goalUnits: String
+    
+    /// Rate units. One of y, m, w, d, h indicating that the rate of the bright red line is yearly, monthly, weekly, daily, or hourly.
+    @NSManaged public var rateUnits: String
+    
+    /// The slope of the (final section of the) bright red line. You must also consider runits to fully specify the rate. NOTE: this may be null
+    @NSManaged public var rate: Double
 
     @NSManaged public var recentData: Set<DataPoint>
 
@@ -171,7 +180,11 @@ public class Goal: NSManagedObject {
         self.useDefaults = json["use_defaults"].boolValue
         self.won = json["won"].boolValue
         self.yAxis = json["yaxis"].stringValue
-
+        
+        self.goalUnits = json["gunits"].stringValue
+        self.rateUnits = json["runits"].stringValue
+        self.rate = json["rate"].doubleValue
+        
         // Replace recent data with results from server
         // Note at present this leaks data points in the main db. This is probably fine for now
         let newRecentData = Set<DataPoint>(json["recent_data"].arrayValue.map {

--- a/BeeSwift/GoalViewController.swift
+++ b/BeeSwift/GoalViewController.swift
@@ -506,12 +506,29 @@ class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTabl
         try await ServiceLocator.goalManager.refreshGoal(self.goal.objectID)
         updateInterfaceToMatchGoal()
     }
+    
+    private static var goalRateNumberFormatter: NumberFormatter {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.maximumFractionDigits = 3
+        return formatter
+    }
+    
+    private var formattedGoalRate: String? {
+        guard let rate = goal.goalRate as NSNumber? else { return nil }
+        
+        return Self.goalRateNumberFormatter.string(from: rate)
+    }
 
     func updateInterfaceToMatchGoal() {
         self.datapointTableController.hhmmformat = goal.hhmmFormat
         self.datapointTableController.datapoints = goal.recentData.sorted(by: {$0.updatedAt < $1.updatedAt})
 
-        self.goalRateLabel.text = "\(goal.rate) \(goal.goalUnits) / \(goal.rateUnits)"
+        self.goalRateLabel.isHidden = formattedGoalRate == nil
+        self.goalRateLabel.text = {
+            guard let formattedGoalRate else { return nil }
+            return "\(formattedGoalRate) \(goal.goalUnits) / \(goal.rateUnits)"
+        }()
         
         self.refreshCountdown()
         self.updateLastUpdatedLabel()

--- a/BeeSwift/GoalViewController.swift
+++ b/BeeSwift/GoalViewController.swift
@@ -39,6 +39,7 @@ class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTabl
     fileprivate var scrollView = UIScrollView()
     fileprivate var submitButton = BSButton()
     fileprivate let headerWidth = Double(1.0/3.0)
+    private let goalRateLabel = BSLabel()
 
     // date corresponding to the datapoint to be created
     private var date: Date = Date()
@@ -135,12 +136,24 @@ class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTabl
             make.right.equalTo(self.goalImageScrollView)
         }
         self.goalImageView.goal = self.goal
+        
+        self.scrollView.addSubview(goalRateLabel)
+        self.goalRateLabel.snp.makeConstraints { make in
+            make.top.equalTo(self.goalImageScrollView.snp.bottom).offset(elementSpacing)
+            make.height.equalTo(Constants.defaultFontSize)
+            make.left.equalTo(self.goalImageScrollView).offset(sideMargin)
+            make.right.equalTo(self.goalImageScrollView).offset(-sideMargin)
+        }
+        self.goalRateLabel.textAlignment = .center
+        self.goalRateLabel.font = UIFont.preferredFont(forTextStyle: .footnote).withSize(Constants.defaultFontSize * 0.9)
+        self.goalRateLabel.textColor = .label.withAlphaComponent(0.8)
+
 
         self.addChild(self.datapointTableController)
         self.scrollView.addSubview(self.datapointTableController.view)
         self.datapointTableController.delegate = self
         self.datapointTableController.view.snp.makeConstraints { (make) -> Void in
-            make.top.equalTo(self.goalImageScrollView.snp.bottom).offset(elementSpacing)
+            make.top.equalTo(self.goalRateLabel.snp.bottom).offset(elementSpacing)
             make.left.equalTo(self.goalImageScrollView).offset(sideMargin)
             make.right.equalTo(self.goalImageScrollView).offset(-sideMargin)
         }
@@ -498,6 +511,8 @@ class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTabl
         self.datapointTableController.hhmmformat = goal.hhmmFormat
         self.datapointTableController.datapoints = goal.recentData.sorted(by: {$0.updatedAt < $1.updatedAt})
 
+        self.goalRateLabel.text = "\(goal.rate) \(goal.goalUnits) / \(goal.rateUnits)"
+        
         self.refreshCountdown()
         self.updateLastUpdatedLabel()
     }


### PR DESCRIPTION
## Summary
In its current form, the app neither shows the deltas/totals nor does it show a goal's rate. Thus it takes guess work from looking at the graph to determine how many units are needed for a number of safe days.

(Deltas in #547)
This is a basic implementation that shows the goal rate, consisting of gunits, rate, and gunits.
The three attributes have been added to the Goal model and to the definition for Core Data. A new label has been introduced on the goalvc, between the graph and the recent datapoints, showing the rate.


*For UI changes including screenshots of before and after is great.*
![Screenshot 2025-01-06 at 18 47 00](https://github.com/user-attachments/assets/b2615f51-70a5-4927-b70a-fe78dfca7d79)

## Validation
ran app in simulator


## Issues
Fixes #557
- [x] Handle also the case when rate is not set (goal is defined by date and value)