### PR TITLE
show the goal rate also on gallery

### DIFF
--- a/BeeKit/GoalExtensions.swift
+++ b/BeeKit/GoalExtensions.swift
@@ -86,3 +86,23 @@ extension Goal {
         return candidateDatapoints.first?.value
     }
 }
+
+public extension Goal {
+    private static var goalRateNumberFormatter: NumberFormatter {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.maximumFractionDigits = 3
+        return formatter
+    }
+
+    private var formattedGoalRate: String? {
+        guard let rate = goalRate as NSNumber? else { return nil }
+
+        return Self.goalRateNumberFormatter.string(from: rate)
+    }
+    
+    var currentRate: String? {
+        guard let formattedGoalRate else { return nil }
+        return "\(formattedGoalRate) \(goalUnits) / \(rateUnits)"
+    }
+}

--- a/BeeKit/Model/BeeminderModel.xcdatamodeld/BeeminderModel.xcdatamodel/contents
+++ b/BeeKit/Model/BeeminderModel.xcdatamodeld/BeeminderModel.xcdatamodel/contents
@@ -14,6 +14,7 @@
         <attribute name="alertStart" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="autodata" optional="YES" attributeType="String"/>
         <attribute name="deadline" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="goalUnits" optional="YES" attributeType="String"/>
         <attribute name="graphUrl" attributeType="String"/>
         <attribute name="healthKitMetric" optional="YES" attributeType="String"/>
         <attribute name="hhmmFormat" attributeType="Boolean" usesScalarValueType="YES"/>
@@ -25,6 +26,8 @@
         <attribute name="limSum" attributeType="String"/>
         <attribute name="pledge" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="queued" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="rate" optional="YES" attributeType="Double" usesScalarValueType="YES"/>
+        <attribute name="rateUnits" optional="YES" attributeType="String"/>
         <attribute name="safeBuf" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="safeSum" attributeType="String"/>
         <attribute name="slug" attributeType="String" spotlightIndexingEnabled="YES"/>

--- a/BeeKit/Model/BeeminderModel.xcdatamodeld/BeeminderModel.xcdatamodel/contents
+++ b/BeeKit/Model/BeeminderModel.xcdatamodeld/BeeminderModel.xcdatamodel/contents
@@ -14,7 +14,10 @@
         <attribute name="alertStart" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="autodata" optional="YES" attributeType="String"/>
         <attribute name="deadline" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="goalDateRaw" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="goalRateRaw" optional="YES" attributeType="Double" usesScalarValueType="YES"/>
         <attribute name="goalUnits" optional="YES" attributeType="String"/>
+        <attribute name="goalValueRaw" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
         <attribute name="graphUrl" attributeType="String"/>
         <attribute name="healthKitMetric" optional="YES" attributeType="String"/>
         <attribute name="hhmmFormat" attributeType="Boolean" usesScalarValueType="YES"/>
@@ -26,7 +29,6 @@
         <attribute name="limSum" attributeType="String"/>
         <attribute name="pledge" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="queued" attributeType="Boolean" usesScalarValueType="YES"/>
-        <attribute name="rate" optional="YES" attributeType="Double" usesScalarValueType="YES"/>
         <attribute name="rateUnits" optional="YES" attributeType="String"/>
         <attribute name="safeBuf" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="safeSum" attributeType="String"/>

--- a/BeeKit/Model/Goal.swift
+++ b/BeeKit/Model/Goal.swift
@@ -51,6 +51,15 @@ public class Goal: NSManagedObject {
     @NSManaged public var won: Bool
     /// The label for the y-axis of the graph. E.g., "Cumulative total hours".
     @NSManaged public var yAxis: String
+    
+    /// Goal units, like "hours" or "pushups" or "pages".
+    @NSManaged public var goalUnits: String
+    
+    /// Rate units. One of y, m, w, d, h indicating that the rate of the bright red line is yearly, monthly, weekly, daily, or hourly.
+    @NSManaged public var rateUnits: String
+    
+    /// The slope of the (final section of the) bright red line. You must also consider runits to fully specify the rate. NOTE: this may be null
+    @NSManaged public var rate: Double
 
     @NSManaged public var recentData: Set<DataPoint>
 
@@ -171,7 +180,11 @@ public class Goal: NSManagedObject {
         self.useDefaults = json["use_defaults"].boolValue
         self.won = json["won"].boolValue
         self.yAxis = json["yaxis"].stringValue
-
+        
+        self.goalUnits = json["gunits"].stringValue
+        self.rateUnits = json["runits"].stringValue
+        self.rate = json["rate"].doubleValue
+        
         // Replace recent data with results from server
         // Note at present this leaks data points in the main db. This is probably fine for now
         let newRecentData = Set<DataPoint>(json["recent_data"].arrayValue.map {

--- a/BeeSwift/GoalCollectionViewCell.swift
+++ b/BeeSwift/GoalCollectionViewCell.swift
@@ -16,6 +16,7 @@ class GoalCollectionViewCell: UICollectionViewCell {
     let todaytaLabel :BSLabel = BSLabel()
     let thumbnailImageView = GoalImageView(isThumbnail: true)
     let safesumLabel :BSLabel = BSLabel()
+    let rateLabel = BSLabel()
     let margin = 8
     
     var goal: Goal? {
@@ -27,6 +28,7 @@ class GoalCollectionViewCell: UICollectionViewCell {
             self.todaytaLabel.text = goal?.todayta == true ? "✓" : ""
             self.safesumLabel.text = goal?.capitalSafesum()
             self.safesumLabel.textColor = goal?.countdownColor ?? UIColor.Beeminder.gray
+            self.rateLabel.text = goal?.currentRate
         }
     }
     
@@ -38,6 +40,7 @@ class GoalCollectionViewCell: UICollectionViewCell {
         self.contentView.addSubview(self.todaytaLabel)
         self.contentView.addSubview(self.thumbnailImageView)
         self.contentView.addSubview(self.safesumLabel)
+        self.contentView.addSubview(self.rateLabel)
         self.contentView.backgroundColor = .systemBackground
 
         self.slugLabel.font = UIFont.beeminder.defaultFontHeavy
@@ -78,7 +81,16 @@ class GoalCollectionViewCell: UICollectionViewCell {
         self.safesumLabel.numberOfLines = 0
         self.safesumLabel.snp.makeConstraints { (make) -> Void in
             make.left.equalTo(self.thumbnailImageView.snp.right).offset(5)
-            make.centerY.equalTo(self.thumbnailImageView.snp.centerY)
+            make.centerY.equalTo(self.thumbnailImageView.snp.centerY).offset(-8)
+            make.right.equalTo(-self.margin)
+        }
+        
+        self.rateLabel.textAlignment = .center
+        self.rateLabel.font = UIFont.preferredFont(forTextStyle: .footnote)
+        self.rateLabel.numberOfLines = 0
+        self.rateLabel.snp.makeConstraints { make in
+            make.left.equalTo(self.thumbnailImageView.snp.right).offset(5)
+            make.centerY.equalTo(self.thumbnailImageView.snp.centerY).offset(8)
             make.right.equalTo(-self.margin)
         }
     }

--- a/BeeSwift/GoalViewController.swift
+++ b/BeeSwift/GoalViewController.swift
@@ -40,6 +40,7 @@ class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTabl
     fileprivate var submitButton = BSButton()
     fileprivate let headerWidth = Double(1.0/3.0)
     fileprivate let viewGoalActivityType = "com.beeminder.viewGoal"
+    private let goalRateLabel = BSLabel()
 
     // date corresponding to the datapoint to be created
     private var date: Date = Date()
@@ -136,12 +137,24 @@ class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTabl
             make.right.equalTo(self.goalImageScrollView)
         }
         self.goalImageView.goal = self.goal
+        
+        self.scrollView.addSubview(goalRateLabel)
+        self.goalRateLabel.snp.makeConstraints { make in
+            make.top.equalTo(self.goalImageScrollView.snp.bottom).offset(elementSpacing)
+            make.height.equalTo(Constants.defaultFontSize)
+            make.left.equalTo(self.goalImageScrollView).offset(sideMargin)
+            make.right.equalTo(self.goalImageScrollView).offset(-sideMargin)
+        }
+        self.goalRateLabel.textAlignment = .center
+        self.goalRateLabel.font = UIFont.preferredFont(forTextStyle: .footnote).withSize(Constants.defaultFontSize * 0.9)
+        self.goalRateLabel.textColor = .label.withAlphaComponent(0.8)
+
 
         self.addChild(self.datapointTableController)
         self.scrollView.addSubview(self.datapointTableController.view)
         self.datapointTableController.delegate = self
         self.datapointTableController.view.snp.makeConstraints { (make) -> Void in
-            make.top.equalTo(self.goalImageScrollView.snp.bottom).offset(elementSpacing)
+            make.top.equalTo(self.goalRateLabel.snp.bottom).offset(elementSpacing)
             make.left.equalTo(self.goalImageScrollView).offset(sideMargin)
             make.right.equalTo(self.goalImageScrollView).offset(-sideMargin)
         }
@@ -499,6 +512,8 @@ class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTabl
         self.datapointTableController.hhmmformat = goal.hhmmFormat
         self.datapointTableController.datapoints = goal.recentData.sorted(by: {$0.updatedAt < $1.updatedAt})
 
+        self.goalRateLabel.text = "\(goal.rate) \(goal.goalUnits) / \(goal.rateUnits)"
+        
         self.refreshCountdown()
         self.updateLastUpdatedLabel()
     }

--- a/BeeSwift/GoalViewController.swift
+++ b/BeeSwift/GoalViewController.swift
@@ -507,12 +507,29 @@ class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTabl
         try await ServiceLocator.goalManager.refreshGoal(self.goal.objectID)
         updateInterfaceToMatchGoal()
     }
+    
+    private static var goalRateNumberFormatter: NumberFormatter {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.maximumFractionDigits = 3
+        return formatter
+    }
+    
+    private var formattedGoalRate: String? {
+        guard let rate = goal.goalRate as NSNumber? else { return nil }
+        
+        return Self.goalRateNumberFormatter.string(from: rate)
+    }
 
     func updateInterfaceToMatchGoal() {
         self.datapointTableController.hhmmformat = goal.hhmmFormat
         self.datapointTableController.datapoints = goal.recentData.sorted(by: {$0.updatedAt < $1.updatedAt})
 
-        self.goalRateLabel.text = "\(goal.rate) \(goal.goalUnits) / \(goal.rateUnits)"
+        self.goalRateLabel.isHidden = formattedGoalRate == nil
+        self.goalRateLabel.text = {
+            guard let formattedGoalRate else { return nil }
+            return "\(formattedGoalRate) \(goal.goalUnits) / \(goal.rateUnits)"
+        }()
         
         self.refreshCountdown()
         self.updateLastUpdatedLabel()

--- a/BeeSwift/GoalViewController.swift
+++ b/BeeSwift/GoalViewController.swift
@@ -507,29 +507,13 @@ class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTabl
         try await ServiceLocator.goalManager.refreshGoal(self.goal.objectID)
         updateInterfaceToMatchGoal()
     }
-    
-    private static var goalRateNumberFormatter: NumberFormatter {
-        let formatter = NumberFormatter()
-        formatter.numberStyle = .decimal
-        formatter.maximumFractionDigits = 3
-        return formatter
-    }
-    
-    private var formattedGoalRate: String? {
-        guard let rate = goal.goalRate as NSNumber? else { return nil }
-        
-        return Self.goalRateNumberFormatter.string(from: rate)
-    }
 
     func updateInterfaceToMatchGoal() {
         self.datapointTableController.hhmmformat = goal.hhmmFormat
         self.datapointTableController.datapoints = goal.recentData.sorted(by: {$0.updatedAt < $1.updatedAt})
 
-        self.goalRateLabel.isHidden = formattedGoalRate == nil
-        self.goalRateLabel.text = {
-            guard let formattedGoalRate else { return nil }
-            return "\(formattedGoalRate) \(goal.goalUnits) / \(goal.rateUnits)"
-        }()
+        self.goalRateLabel.isHidden = goal.currentRate == nil
+        self.goalRateLabel.text = goal.currentRate
         
         self.refreshCountdown()
         self.updateLastUpdatedLabel()


### PR DESCRIPTION
## Summary
Without needing to venture into the goal for the current rate, they are now shown on the gallery. This builds off of #611, containing its changes as well.

*For UI changes including screenshots of before and after is great.*
Here are some examples:

![Screenshot 2025-01-07 at 10 11 29](https://github.com/user-attachments/assets/446f619d-240a-4694-bee0-b93ff4676c00)
![Screenshot 2025-01-07 at 10 11 49](https://github.com/user-attachments/assets/efd6e6ec-70f0-434c-a47a-3432624d73a4)
![Screenshot 2025-01-07 at 10 19 17](https://github.com/user-attachments/assets/26cd44fb-4fc0-420f-81db-767a856d0c12)


## Validation
ran app in simulator

Fixes: #557