### PR TITLE
bump Gallery's collectionView to UICollectionViewDiffableDataSource

### DIFF
--- a/BeeSwift/Gallery/GalleryViewController.swift
+++ b/BeeSwift/Gallery/GalleryViewController.swift
@@ -382,6 +382,7 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
         var snapshot = NSDiffableDataSourceSnapshot<Section, Goal>()
         snapshot.appendSections([.main])
         snapshot.appendItems(goalsToShow, toSection: .main)
+        snapshot.reconfigureItems(goalsToShow)
         dataSource.apply(snapshot, animatingDifferences: true)
     }
 

--- a/BeeSwift/Gallery/GalleryViewController.swift
+++ b/BeeSwift/Gallery/GalleryViewController.swift
@@ -441,10 +441,9 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         // After a rotation or other size change the optimal width for our cells may have changed.
         // We instruct the collectionView to reload so widths are recalculated.
-        coordinator.animate { _ in } completion: { [weak self] _ in
-            guard let self else { return }
-            self.applySnapshot()
-        }
+        coordinator.animate(alongsideTransition: { _ in }, completion: { _ in
+            self.collectionViewLayout?.invalidateLayout()
+        })
     }
 
     @objc func openGoalFromNotification(_ notification: Notification) {

--- a/BeeSwift/Gallery/GalleryViewController.swift
+++ b/BeeSwift/Gallery/GalleryViewController.swift
@@ -30,8 +30,8 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
 
     let stackView = UIStackView()
     let collectionContainer = UIView()
-    var collectionView :UICollectionView?
-    var collectionViewLayout :UICollectionViewFlowLayout?
+    var collectionView :UICollectionView!
+    var collectionViewLayout :UICollectionViewFlowLayout!
     private let freshnessIndicator = FreshnessIndicatorView()
     var deadbeatView = UIView()
     var outofdateView = UIView()
@@ -150,15 +150,15 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
 
         stackView.addArrangedSubview(self.collectionContainer)
 
-        self.collectionContainer.addSubview(self.collectionView!)
-        self.collectionView!.delegate = self
+        self.collectionContainer.addSubview(self.collectionView)
+        self.collectionView.delegate = self
         
-        self.collectionView?.snp.makeConstraints { (make) in
+        self.collectionView.snp.makeConstraints { (make) in
             make.top.bottom.equalTo(collectionContainer)
             make.left.right.equalTo(collectionContainer.safeAreaLayoutGuide)
         }
 
-        self.collectionView?.refreshControl = {
+        self.collectionView.refreshControl = {
             let refreshControl = UIRefreshControl()
             refreshControl.addTarget(self, action: #selector(self.fetchGoals), for: UIControl.Event.valueChanged)
             return refreshControl
@@ -195,14 +195,14 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
                 case .UpdateRequired:
                     self.outofdateView.isHidden = false
                     self.outofdateLabel.text = "This version of the Beeminder app is no longer supported.\n Please update to the newest version in the App Store."
-                    self.collectionView?.isHidden = true
+                    self.collectionView.isHidden = true
                 case .UpdateSuggested:
                     self.outofdateView.isHidden = false
                     self.outofdateLabel.text = "There is a new version of the Beeminder app in the App Store.\nPlease update when you have a moment."
-                    self.collectionView?.isHidden = false
+                    self.collectionView.isHidden = false
                 case .UpToDate:
                     self.outofdateView.isHidden = true
-                    self.collectionView?.isHidden = false
+                    self.collectionView.isHidden = false
                 }
             } catch let error as VersionError {
                 logger.error("Error checking for current version: \(error)")
@@ -213,11 +213,11 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
-        self.collectionView!.snp.remakeConstraints { make in
+        self.collectionView.snp.remakeConstraints { make in
             make.top.equalTo(self.searchBar.snp.bottom)
             make.left.equalTo(self.view.safeAreaLayoutGuide.snp.leftMargin)
             make.right.equalTo(self.view.safeAreaLayoutGuide.snp.rightMargin)
-            make.bottom.equalTo(self.collectionView!.keyboardLayoutGuide.snp.top)
+            make.bottom.equalTo(self.collectionView.keyboardLayoutGuide.snp.top)
         }
         
         applySnapshot()
@@ -273,12 +273,7 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
     @objc func handleSignOut() {
         self.goals = []
         self.filteredGoals = []
-        
-        var snapshot = NSDiffableDataSourceSnapshot<Int, Goal>()
-        snapshot.appendSections([0])
-        snapshot.appendItems(filteredGoals)
-        dataSource.apply(snapshot, animatingDifferences: true)
-        
+        self.applySnapshot()
         if self.presentedViewController != nil {
             if type(of: self.presentedViewController!) == SignInViewController.self { return }
         }
@@ -337,9 +332,9 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
                     alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
                     self.present(alert, animated: true, completion: nil)
                 }
-                self.collectionView?.refreshControl?.endRefreshing()
+                self.collectionView.refreshControl?.endRefreshing()
                 MBProgressHUD.hide(for: self.view, animated: true)
-                self.collectionView!.reloadData()
+                self.collectionView.reloadData()
             }
         }
     }
@@ -390,7 +385,7 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
 
     @objc func didUpdateGoals() {
         self.setupHealthKit()
-        self.collectionView?.refreshControl?.endRefreshing()
+        self.collectionView.refreshControl?.endRefreshing()
         MBProgressHUD.hide(for: self.view, animated: true)
         self.applySnapshot()
         self.updateDeadbeatVisibility()
@@ -414,8 +409,8 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         let minimumWidth: CGFloat = 320
 
-        let availableWidth = self.collectionView!.frame.width - self.collectionView!.contentInset.left - self.collectionView!.contentInset.right
-        let itemSpacing = self.collectionViewLayout!.minimumInteritemSpacing
+        let availableWidth = self.collectionView.frame.width - self.collectionView.contentInset.left - self.collectionView.contentInset.right
+        let itemSpacing = self.collectionViewLayout.minimumInteritemSpacing
 
         // Calculate how many cells could fit at the minimum width, rounding down (as we can't show a fractional cell)
         // We need to account for there being margin between cells, so there is 1 fewer margin than cell. We do this by
@@ -430,7 +425,7 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
         // Calculate how wide a cell can be. This can be larger than our minimum width because we
         // may have rounded down the number of cells. E.g. if we could have fit 1.5 minimum width
         // cells we will only show 1, but can make it 50% wider than minimum
-        let targetWidth = (availableWidth + itemSpacing) / CGFloat(cellsWhileMaintainingMinimumWidth) -  self.collectionViewLayout!.minimumInteritemSpacing
+        let targetWidth = (availableWidth + itemSpacing) / CGFloat(cellsWhileMaintainingMinimumWidth) -  self.collectionViewLayout.minimumInteritemSpacing
 
         return CGSize(width: targetWidth, height: 120)
     }
@@ -449,10 +444,7 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
         // We instruct the collectionView to reload so widths are recalculated.
         coordinator.animate { _ in } completion: { [weak self] _ in
             guard let self else { return }
-            var snapshot = NSDiffableDataSourceSnapshot<Int, Goal>()
-            snapshot.appendSections([0])
-            snapshot.appendItems(filteredGoals)
-            dataSource.apply(snapshot, animatingDifferences: true)
+            self.applySnapshot()
         }
     }
 
@@ -483,10 +475,10 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
     
     private func configureCollectionView() {
         self.collectionViewLayout = UICollectionViewFlowLayout()
-        self.collectionView = UICollectionView(frame: stackView.frame, collectionViewLayout: self.collectionViewLayout!)
-        self.collectionView?.backgroundColor = .systemBackground
-        self.collectionView?.alwaysBounceVertical = true
-        self.collectionView?.register(UICollectionReusableView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionFooter, withReuseIdentifier: "footer")
+        self.collectionView = UICollectionView(frame: stackView.frame, collectionViewLayout: self.collectionViewLayout)
+        self.collectionView.backgroundColor = .systemBackground
+        self.collectionView.alwaysBounceVertical = true
+        self.collectionView.register(UICollectionReusableView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionFooter, withReuseIdentifier: "footer")
     }
     
     private func configureDataSource() {
@@ -494,7 +486,7 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
             cell.configure(with: goal)
         }
         
-        self.dataSource = .init(collectionView: collectionView!, cellProvider: { collectionView, indexPath, goal in
+        self.dataSource = .init(collectionView: collectionView, cellProvider: { collectionView, indexPath, goal in
             collectionView.dequeueConfiguredReusableCell(using: cellRegistration,
                                                          for: indexPath,
                                                          item: goal)
@@ -502,7 +494,7 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
         dataSource.supplementaryViewProvider = { collectionView, kind, indexPath in
             collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: "footer", for: indexPath)
         }
-        self.collectionView?.dataSource = dataSource
+        self.collectionView.dataSource = dataSource
     }
     
     // MARK: - SFSafariViewControllerDelegate

--- a/BeeSwift/Gallery/GalleryViewController.swift
+++ b/BeeSwift/Gallery/GalleryViewController.swift
@@ -334,7 +334,7 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
                 }
                 self.collectionView.refreshControl?.endRefreshing()
                 MBProgressHUD.hide(for: self.view, animated: true)
-                self.collectionView.reloadData()
+                self.applySnapshot()
             }
         }
     }

--- a/BeeSwift/Gallery/GalleryViewController.swift
+++ b/BeeSwift/Gallery/GalleryViewController.swift
@@ -377,9 +377,11 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
     }
     
     private func applySnapshot() {
+        let goalsToShow = versionManager.lastChckedUpdateState() == .UpdateRequired ? [] : filteredGoals
+        
         var snapshot = NSDiffableDataSourceSnapshot<Section, Goal>()
         snapshot.appendSections([.main])
-        snapshot.appendItems(filteredGoals, toSection: .main)
+        snapshot.appendItems(goalsToShow, toSection: .main)
         dataSource.apply(snapshot, animatingDifferences: true)
     }
 
@@ -400,10 +402,6 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
         }
         let searchItem = UIBarButtonItem(barButtonSystemItem: .search, target: self, action: #selector(self.searchButtonPressed))
         self.navigationItem.leftBarButtonItem = searchItem
-    }
-
-    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return versionManager.lastChckedUpdateState() == .UpdateRequired ? 0 : self.filteredGoals.count
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {

--- a/BeeSwift/Gallery/GalleryViewController.swift
+++ b/BeeSwift/Gallery/GalleryViewController.swift
@@ -440,7 +440,6 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
     
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         // After a rotation or other size change the optimal width for our cells may have changed.
-        // We instruct the collectionView to reload so widths are recalculated.
         coordinator.animate(alongsideTransition: { _ in }, completion: { _ in
             self.collectionViewLayout?.invalidateLayout()
         })

--- a/BeeSwift/Gallery/GalleryViewController.swift
+++ b/BeeSwift/Gallery/GalleryViewController.swift
@@ -377,7 +377,10 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
     }
     
     private func applySnapshot() {
-        let goalsToShow = versionManager.lastChckedUpdateState() == .UpdateRequired ? [] : filteredGoals
+        var goalsToShow: [Goal] {
+            guard versionManager.lastChckedUpdateState() != .UpdateRequired else { return [] }
+            return filteredGoals
+        }
         
         var snapshot = NSDiffableDataSourceSnapshot<Section, Goal>()
         snapshot.appendSections([.main])

--- a/BeeSwift/Gallery/GalleryViewController.swift
+++ b/BeeSwift/Gallery/GalleryViewController.swift
@@ -18,7 +18,7 @@ import CoreData
 import BeeKit
 
 
-class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayout, UICollectionViewDelegate, UICollectionViewDataSource, UISearchBarDelegate, SFSafariViewControllerDelegate {
+class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayout, UICollectionViewDelegate, UISearchBarDelegate, SFSafariViewControllerDelegate {
     let logger = Logger(subsystem: "com.beeminder.beeminder", category: "GalleryViewController")
 
     // Dependencies
@@ -43,6 +43,8 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
     
     var goals : [Goal] = []
     var filteredGoals : [Goal] = []
+    
+    var dataSource: UICollectionViewDiffableDataSource<Int, Goal>!
     
     public enum NotificationName {
         public static let openGoal = Notification.Name(rawValue: "com.beeminder.openGoal")
@@ -84,11 +86,25 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
             make.bottom.equalTo(stackView.keyboardLayoutGuide.snp.top)
         }
 
+        
+        
         self.collectionViewLayout = UICollectionViewFlowLayout()
         self.collectionView = UICollectionView(frame: stackView.frame, collectionViewLayout: self.collectionViewLayout!)
         self.collectionView?.backgroundColor = .systemBackground
         self.collectionView?.alwaysBounceVertical = true
         self.collectionView?.register(UICollectionReusableView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionFooter, withReuseIdentifier: "footer")
+        
+        self.dataSource = .init(collectionView: collectionView!, cellProvider: { collectionView, indexPath, itemIdentifier in
+            let cell = collectionView.dequeueReusableCell(withReuseIdentifier: self.cellReuseIdentifier, for: indexPath) as! GoalCollectionViewCell
+            cell.goal = self.filteredGoals[indexPath.row]
+            
+            return cell
+        })
+        dataSource.supplementaryViewProvider = { collectionView, kind, indexPath in
+            let footerView = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: "footer", for: indexPath)
+            return footerView
+        }
+        self.collectionView?.dataSource = dataSource
 
         self.view.backgroundColor = .systemBackground
         self.title = "Goals"
@@ -149,7 +165,7 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
 
         self.collectionContainer.addSubview(self.collectionView!)
         self.collectionView!.delegate = self
-        self.collectionView!.dataSource = self
+        
         self.collectionView!.register(GoalCollectionViewCell.self, forCellWithReuseIdentifier: self.cellReuseIdentifier)
         self.collectionView?.snp.makeConstraints { (make) in
             make.top.bottom.equalTo(collectionContainer)
@@ -217,6 +233,11 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
             make.right.equalTo(self.view.safeAreaLayoutGuide.snp.rightMargin)
             make.bottom.equalTo(self.collectionView!.keyboardLayoutGuide.snp.top)
         }
+        
+        var snapshot = NSDiffableDataSourceSnapshot<Int, Goal>()
+        snapshot.appendSections([0])
+        snapshot.appendItems(filteredGoals)
+        dataSource.apply(snapshot, animatingDifferences: true)
     }
     
     override func viewDidAppear(_ animated: Bool) {
@@ -269,7 +290,12 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
     @objc func handleSignOut() {
         self.goals = []
         self.filteredGoals = []
-        self.collectionView?.reloadData()
+        
+        var snapshot = NSDiffableDataSourceSnapshot<Int, Goal>()
+        snapshot.appendSections([0])
+        snapshot.appendItems(filteredGoals)
+        dataSource.apply(snapshot, animatingDifferences: true)
+        
         if self.presentedViewController != nil {
             if type(of: self.presentedViewController!) == SignInViewController.self { return }
         }
@@ -376,7 +402,12 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
         self.setupHealthKit()
         self.collectionView?.refreshControl?.endRefreshing()
         MBProgressHUD.hide(for: self.view, animated: true)
-        self.collectionView!.reloadData()
+        
+        var snapshot = NSDiffableDataSourceSnapshot<Int, Goal>()
+        snapshot.appendSections([0])
+        snapshot.appendItems(filteredGoals)
+        dataSource.apply(snapshot, animatingDifferences: true)
+        
         self.updateDeadbeatVisibility()
         self.lastUpdated = Date()
         self.updateLastUpdatedLabel()
@@ -393,10 +424,6 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
 
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return versionManager.lastChckedUpdateState() == .UpdateRequired ? 0 : self.filteredGoals.count
-    }
-    
-    func numberOfSections(in collectionView: UICollectionView) -> Int {
-        return 1
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
@@ -423,16 +450,6 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
         return CGSize(width: targetWidth, height: 120)
     }
     
-    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        let cell:GoalCollectionViewCell = self.collectionView!.dequeueReusableCell(withReuseIdentifier: self.cellReuseIdentifier, for: indexPath) as! GoalCollectionViewCell
-        
-        let goal:Goal = self.filteredGoals[(indexPath as NSIndexPath).row]
-
-        cell.goal = goal
-        
-        return cell
-    }
-    
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForFooterInSection section: Int) -> CGSize {
         return CGSize(width: 320, height: section == 0 && self.goals.count > 0 ? 5 : 0)
     }
@@ -445,8 +462,12 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         // After a rotation or other size change the optimal width for our cells may have changed.
         // We instruct the collectionView to reload so widths are recalculated.
-        coordinator.animate { _ in } completion: { _ in
-            self.collectionView?.reloadData()
+        coordinator.animate { _ in } completion: { [weak self] _ in
+            guard let self else { return }
+            var snapshot = NSDiffableDataSourceSnapshot<Int, Goal>()
+            snapshot.appendSections([0])
+            snapshot.appendItems(filteredGoals)
+            dataSource.apply(snapshot, animatingDifferences: true)
         }
     }
 

--- a/BeeSwift/Gallery/GalleryViewController.swift
+++ b/BeeSwift/Gallery/GalleryViewController.swift
@@ -30,8 +30,8 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
 
     let stackView = UIStackView()
     let collectionContainer = UIView()
-    var collectionView :UICollectionView!
-    var collectionViewLayout :UICollectionViewFlowLayout!
+    var collectionView :UICollectionView?
+    var collectionViewLayout :UICollectionViewFlowLayout?
     private let freshnessIndicator = FreshnessIndicatorView()
     var deadbeatView = UIView()
     var outofdateView = UIView()
@@ -150,15 +150,15 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
 
         stackView.addArrangedSubview(self.collectionContainer)
 
-        self.collectionContainer.addSubview(self.collectionView)
-        self.collectionView.delegate = self
+        self.collectionContainer.addSubview(self.collectionView!)
+        self.collectionView!.delegate = self
         
-        self.collectionView.snp.makeConstraints { (make) in
+        self.collectionView?.snp.makeConstraints { (make) in
             make.top.bottom.equalTo(collectionContainer)
             make.left.right.equalTo(collectionContainer.safeAreaLayoutGuide)
         }
 
-        self.collectionView.refreshControl = {
+        self.collectionView?.refreshControl = {
             let refreshControl = UIRefreshControl()
             refreshControl.addTarget(self, action: #selector(self.fetchGoals), for: UIControl.Event.valueChanged)
             return refreshControl
@@ -195,14 +195,14 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
                 case .UpdateRequired:
                     self.outofdateView.isHidden = false
                     self.outofdateLabel.text = "This version of the Beeminder app is no longer supported.\n Please update to the newest version in the App Store."
-                    self.collectionView.isHidden = true
+                    self.collectionView?.isHidden = true
                 case .UpdateSuggested:
                     self.outofdateView.isHidden = false
                     self.outofdateLabel.text = "There is a new version of the Beeminder app in the App Store.\nPlease update when you have a moment."
-                    self.collectionView.isHidden = false
+                    self.collectionView?.isHidden = false
                 case .UpToDate:
                     self.outofdateView.isHidden = true
-                    self.collectionView.isHidden = false
+                    self.collectionView?.isHidden = false
                 }
             } catch let error as VersionError {
                 logger.error("Error checking for current version: \(error)")
@@ -213,11 +213,11 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
-        self.collectionView.snp.remakeConstraints { make in
+        self.collectionView!.snp.remakeConstraints { make in
             make.top.equalTo(self.searchBar.snp.bottom)
             make.left.equalTo(self.view.safeAreaLayoutGuide.snp.leftMargin)
             make.right.equalTo(self.view.safeAreaLayoutGuide.snp.rightMargin)
-            make.bottom.equalTo(self.collectionView.keyboardLayoutGuide.snp.top)
+            make.bottom.equalTo(self.collectionView!.keyboardLayoutGuide.snp.top)
         }
         
         applySnapshot()
@@ -332,7 +332,7 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
                     alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
                     self.present(alert, animated: true, completion: nil)
                 }
-                self.collectionView.refreshControl?.endRefreshing()
+                self.collectionView?.refreshControl?.endRefreshing()
                 MBProgressHUD.hide(for: self.view, animated: true)
                 self.applySnapshot()
             }
@@ -391,7 +391,7 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
 
     @objc func didUpdateGoals() {
         self.setupHealthKit()
-        self.collectionView.refreshControl?.endRefreshing()
+        self.collectionView?.refreshControl?.endRefreshing()
         MBProgressHUD.hide(for: self.view, animated: true)
         self.applySnapshot()
         self.updateDeadbeatVisibility()
@@ -411,8 +411,8 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         let minimumWidth: CGFloat = 320
 
-        let availableWidth = self.collectionView.frame.width - self.collectionView.contentInset.left - self.collectionView.contentInset.right
-        let itemSpacing = self.collectionViewLayout.minimumInteritemSpacing
+        let availableWidth = self.collectionView!.frame.width - self.collectionView!.contentInset.left - self.collectionView!.contentInset.right
+        let itemSpacing = self.collectionViewLayout!.minimumInteritemSpacing
 
         // Calculate how many cells could fit at the minimum width, rounding down (as we can't show a fractional cell)
         // We need to account for there being margin between cells, so there is 1 fewer margin than cell. We do this by
@@ -427,7 +427,7 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
         // Calculate how wide a cell can be. This can be larger than our minimum width because we
         // may have rounded down the number of cells. E.g. if we could have fit 1.5 minimum width
         // cells we will only show 1, but can make it 50% wider than minimum
-        let targetWidth = (availableWidth + itemSpacing) / CGFloat(cellsWhileMaintainingMinimumWidth) -  self.collectionViewLayout.minimumInteritemSpacing
+        let targetWidth = (availableWidth + itemSpacing) / CGFloat(cellsWhileMaintainingMinimumWidth) -  self.collectionViewLayout!.minimumInteritemSpacing
 
         return CGSize(width: targetWidth, height: 120)
     }
@@ -475,10 +475,10 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
     
     private func configureCollectionView() {
         self.collectionViewLayout = UICollectionViewFlowLayout()
-        self.collectionView = UICollectionView(frame: stackView.frame, collectionViewLayout: self.collectionViewLayout)
-        self.collectionView.backgroundColor = .systemBackground
-        self.collectionView.alwaysBounceVertical = true
-        self.collectionView.register(UICollectionReusableView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionFooter, withReuseIdentifier: "footer")
+        self.collectionView = UICollectionView(frame: stackView.frame, collectionViewLayout: self.collectionViewLayout!)
+        self.collectionView?.backgroundColor = .systemBackground
+        self.collectionView?.alwaysBounceVertical = true
+        self.collectionView?.register(UICollectionReusableView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionFooter, withReuseIdentifier: "footer")
     }
     
     private func configureDataSource() {
@@ -486,7 +486,7 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
             cell.configure(with: goal)
         }
         
-        self.dataSource = .init(collectionView: collectionView, cellProvider: { collectionView, indexPath, goal in
+        self.dataSource = .init(collectionView: collectionView!, cellProvider: { collectionView, indexPath, goal in
             collectionView.dequeueConfiguredReusableCell(using: cellRegistration,
                                                          for: indexPath,
                                                          item: goal)
@@ -494,7 +494,7 @@ class GalleryViewController: UIViewController, UICollectionViewDelegateFlowLayou
         dataSource.supplementaryViewProvider = { collectionView, kind, indexPath in
             collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: "footer", for: indexPath)
         }
-        self.collectionView.dataSource = dataSource
+        self.collectionView?.dataSource = dataSource
     }
     
     // MARK: - SFSafariViewControllerDelegate

--- a/BeeSwift/GoalCollectionViewCell.swift
+++ b/BeeSwift/GoalCollectionViewCell.swift
@@ -18,18 +18,6 @@ class GoalCollectionViewCell: UICollectionViewCell {
     let safesumLabel :BSLabel = BSLabel()
     let margin = 8
     
-    var goal: Goal? {
-        didSet {
-            self.thumbnailImageView.goal = goal
-            self.titleLabel.text = goal?.title
-            self.slugLabel.text = goal?.slug
-            self.titleLabel.isHidden = goal?.title == goal?.slug
-            self.todaytaLabel.text = goal?.todayta == true ? "✓" : ""
-            self.safesumLabel.text = goal?.capitalSafesum()
-            self.safesumLabel.textColor = goal?.countdownColor ?? UIColor.Beeminder.gray
-        }
-    }
-    
     override init(frame: CGRect) {
         super.init(frame: frame)
         
@@ -85,5 +73,27 @@ class GoalCollectionViewCell: UICollectionViewCell {
     
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        
+        self.thumbnailImageView.goal = nil
+        self.titleLabel.text = nil
+        self.slugLabel.text = nil
+        self.titleLabel.isHidden = true
+        self.todaytaLabel.text = nil
+        self.safesumLabel.text = nil
+        self.safesumLabel.textColor = UIColor.Beeminder.gray
+    }
+    
+    func configure(with goal: Goal) {
+        self.thumbnailImageView.goal = goal
+        self.titleLabel.text = goal.title
+        self.slugLabel.text = goal.slug
+        self.titleLabel.isHidden = goal.title == goal.slug
+        self.todaytaLabel.text = goal.todayta ? "✓" : ""
+        self.safesumLabel.text = goal.capitalSafesum()
+        self.safesumLabel.textColor = goal.countdownColor
     }
 }

--- a/BeeSwift/GoalCollectionViewCell.swift
+++ b/BeeSwift/GoalCollectionViewCell.swift
@@ -88,6 +88,6 @@ class GoalCollectionViewCell: UICollectionViewCell {
         self.titleLabel.isHidden = goal?.title == goal?.slug
         self.todaytaLabel.text = goal?.todayta == true ? "✓" : ""
         self.safesumLabel.text = goal?.capitalSafesum()
-        self.safesumLabel.textColor = goal?.countdownColor
+        self.safesumLabel.textColor = goal?.countdownColor ?? UIColor.Beeminder.gray
     }
 }

--- a/BeeSwift/GoalCollectionViewCell.swift
+++ b/BeeSwift/GoalCollectionViewCell.swift
@@ -78,22 +78,16 @@ class GoalCollectionViewCell: UICollectionViewCell {
     override func prepareForReuse() {
         super.prepareForReuse()
         
-        self.thumbnailImageView.goal = nil
-        self.titleLabel.text = nil
-        self.slugLabel.text = nil
-        self.titleLabel.isHidden = true
-        self.todaytaLabel.text = nil
-        self.safesumLabel.text = nil
-        self.safesumLabel.textColor = UIColor.Beeminder.gray
+        configure(with: nil)
     }
     
-    func configure(with goal: Goal) {
+    func configure(with goal: Goal?) {
         self.thumbnailImageView.goal = goal
-        self.titleLabel.text = goal.title
-        self.slugLabel.text = goal.slug
-        self.titleLabel.isHidden = goal.title == goal.slug
-        self.todaytaLabel.text = goal.todayta ? "✓" : ""
-        self.safesumLabel.text = goal.capitalSafesum()
-        self.safesumLabel.textColor = goal.countdownColor
+        self.titleLabel.text = goal?.title
+        self.slugLabel.text = goal?.slug
+        self.titleLabel.isHidden = goal?.title == goal?.slug
+        self.todaytaLabel.text = goal?.todayta == true ? "✓" : ""
+        self.safesumLabel.text = goal?.capitalSafesum()
+        self.safesumLabel.textColor = goal?.countdownColor
     }
 }


### PR DESCRIPTION
## Summary
Migrated the gallery's collection view to the more modern api, using diffable datasource and snapshots. See https://github.com/beeminder/BeeSwift/pull/607#discussion_r1904915913.

*For UI changes including screenshots of before and after is great.*
Transitions from one state to another (one set of goals to the next) is animated.

## Validation
ran app in simulator, both iPhone and iPad (easier to see multiple columns and animation, for example, when filtering)
rotated simulator
changed sort preference
filtered on gallery's goals
signed out
signed in
navigated from gallery to goal and back
assured that some goal's data changed (for example safeBuf and safeSum) and the effect was seen in the cell at the same position