### PR TITLE
gallery not updating list based on sort

### DIFF
--- a/BeeSwift/Gallery/GalleryViewController.swift
+++ b/BeeSwift/Gallery/GalleryViewController.swift
@@ -398,8 +398,12 @@ class GalleryViewController: UIViewController {
         self.collectionView.refreshControl?.endRefreshing()
         MBProgressHUD.hide(for: self.view, animated: true)
         self.updateDeadbeatVisibility()
-        self.lastUpdated = Date()
-        self.updateLastUpdatedLabel()
+        
+        Task {
+            self.lastUpdated = await goalManager.goalsFetchedAt
+            self.updateLastUpdatedLabel()
+        }
+        
         if self.filteredGoals.isEmpty {
             self.noGoalsLabel.isHidden = false
             self.collectionContainer.isHidden = true

--- a/BeeSwift/Gallery/GalleryViewController.swift
+++ b/BeeSwift/Gallery/GalleryViewController.swift
@@ -308,7 +308,9 @@ class GalleryViewController: UIViewController {
     }
     
     @objc private func userDefaultsDidChange() {
-        self.updateGoals()
+        Task { @MainActor [weak self] in
+            self?.updateGoals()
+        }
     }
     
     @objc func handleSignIn() {
@@ -401,9 +403,9 @@ class GalleryViewController: UIViewController {
         MBProgressHUD.hide(for: self.view, animated: true)
         self.updateDeadbeatVisibility()
         
-        Task {
-            self.lastUpdated = await goalManager.goalsFetchedAt
-            self.updateLastUpdatedLabel()
+        Task { [weak self] in
+            self?.lastUpdated = await self?.goalManager.goalsFetchedAt
+            self?.updateLastUpdatedLabel()
         }
         
         if self.filteredGoals.isEmpty {

--- a/BeeSwift/Gallery/GalleryViewController.swift
+++ b/BeeSwift/Gallery/GalleryViewController.swift
@@ -275,11 +275,14 @@ class GalleryViewController: UIViewController {
     }
     
     override func viewDidAppear(_ animated: Bool) {
-        if !currentUserManager.signedIn(context: viewContext) {
+        guard currentUserManager.signedIn(context: viewContext) else {
             let signInVC = SignInViewController(currentUserManager: currentUserManager)
             signInVC.modalPresentationStyle = .fullScreen
             self.present(signInVC, animated: true, completion: nil)
+            return
         }
+        
+        self.updateGoals()
     }
     
     @objc func settingsButtonPressed() {

--- a/BeeSwift/Gallery/GalleryViewController.swift
+++ b/BeeSwift/Gallery/GalleryViewController.swift
@@ -157,6 +157,7 @@ class GalleryViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        NotificationCenter.default.addObserver(self, selector: #selector(self.userDefaultsDidChange), name: UserDefaults.didChangeNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(self.handleSignIn), name: CurrentUserManager.NotificationName.signedIn, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(self.handleSignOut), name: CurrentUserManager.NotificationName.signedOut, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(self.openGoalFromNotification(_:)), name: GalleryViewController.NotificationName.openGoal, object: nil)
@@ -281,8 +282,6 @@ class GalleryViewController: UIViewController {
             self.present(signInVC, animated: true, completion: nil)
             return
         }
-        
-        self.updateGoals()
     }
     
     @objc func settingsButtonPressed() {
@@ -307,6 +306,10 @@ class GalleryViewController: UIViewController {
         } else {
             self.searchBar.becomeFirstResponder()
         }
+    }
+    
+    @objc private func userDefaultsDidChange() {
+        self.updateGoals()
     }
     
     @objc func handleSignIn() {

--- a/BeeSwift/Gallery/GalleryViewController.swift
+++ b/BeeSwift/Gallery/GalleryViewController.swift
@@ -276,11 +276,10 @@ class GalleryViewController: UIViewController {
     }
     
     override func viewDidAppear(_ animated: Bool) {
-        guard currentUserManager.signedIn(context: viewContext) else {
+        if !currentUserManager.signedIn(context: viewContext) {
             let signInVC = SignInViewController(currentUserManager: currentUserManager)
             signInVC.modalPresentationStyle = .fullScreen
             self.present(signInVC, animated: true, completion: nil)
-            return
         }
     }
     


### PR DESCRIPTION
## Summary
Gallery was not updating how its list was sorted after the preference had been adjusted. Also, the gallery's last updated was meant to display when the goals were last fetched.


### 
The gallery was not monitoring for changes to the sorting preference. It needed a trigger to sort the list anew. This was removed in d181dba6da9a35b7b. 'Update goals' can stay, it is the fetch goals that was to be reduced. Furthermore, since gallery's last updated is meant to indicate how fresh the data is (when they were last fetched), gallery's setting this to now where it did does not necessarily coincide with fetching the goals anew. Instead, the goal manager already provides this nugget.


*For UI changes including screenshots of before and after is great.*

## Validation
Ran app in simulator. 
gallery -> settings -> sort pref, picked another, and back to gallery from settings
Noticed sort had taken effect.
Also noticed last updated seems much more up-to-date and less out of sync, as reported in #588.