### PR TITLE
edit notification fixes: picker handles 24h and deadlines can be set

### DIFF
--- a/BeeSwift/Settings/EditDefaultNotificationsViewController.swift
+++ b/BeeSwift/Settings/EditDefaultNotificationsViewController.swift
@@ -72,8 +72,9 @@ class EditDefaultNotificationsViewController: EditNotificationsViewController {
                 }
             }
             if self.timePickerEditingMode == .deadline {
-                self.updateDeadlineLabel(self.midnightOffsetFromTimePickerView())
-                let params = ["default_deadline" : self.midnightOffsetFromTimePickerView()]
+                let deadline = self.deadlineFromTimePickerView
+                self.updateDeadlineLabel(deadline)
+                let params = ["default_deadline" : deadline]
                 do {
                     let _ = try await requestManager.put(url: "api/v1/users/{username}.json", parameters: params)
                     try await currentUserManager.refreshUser()

--- a/BeeSwift/Settings/EditGoalNotificationsViewController.swift
+++ b/BeeSwift/Settings/EditGoalNotificationsViewController.swift
@@ -107,9 +107,10 @@ class EditGoalNotificationsViewController : EditNotificationsViewController {
                 }
             }
             if self.timePickerEditingMode == .deadline {
-                self.updateDeadlineLabel(self.midnightOffsetFromTimePickerView())
+                let deadline = self.deadlineFromTimePickerView
+                self.updateDeadlineLabel(deadline)
                 do {
-                    let params = ["deadline" : self.midnightOffsetFromTimePickerView(), "use_defaults" : false]
+                    let params = ["deadline" : deadline, "use_defaults" : false]
                     let _ = try await self.requestManager.put(url: "api/v1/users/{username}/goals/\(self.goal.slug).json", parameters: params)
                     try await self.goalManager.refreshGoal(self.goal.objectID)
 

--- a/BeeSwift/Settings/EditNotificationsViewController.swift
+++ b/BeeSwift/Settings/EditNotificationsViewController.swift
@@ -160,29 +160,34 @@ class EditNotificationsViewController: UIViewController {
     func setTimePickerComponents(_ offsetFromMidnight : Int) {
         var hour = offsetFromMidnight / 3600
         var minute = (offsetFromMidnight % 3600) / 60
+        
+        // Normalize the time to ensure positive values
+        if hour < 0 || minute < 0 {
+            // For times like 23:59 which come in as -1 minutes before midnight
+            // we need to convert to the equivalent hour before midnight
+            let totalMinutes = hour * 60 + minute
+            let normalizedMinutes = (totalMinutes + 24 * 60) % (24 * 60)
+            hour = normalizedMinutes / 60
+            minute = normalizedMinutes % 60
+        }
+        
         if self.use24HourTime() {
-            if hour < 0 { hour = 25 + hour }
-            if minute < 0 { minute = 60 + minute }
             self.timePickerView.selectRow(hour, inComponent: 0, animated: true)
-            self.timePickerView.selectRow(minute, inComponent: 1, animated: true)
+        } else {
+            // Convert to 12-hour format
+            let isPM = hour >= 12
+            let displayHour = hour % 12
+            self.timePickerView.selectRow(displayHour == 0 ? 12 : displayHour, inComponent: 0, animated: true)
+            self.timePickerView.selectRow(isPM ? 1 : 0, inComponent: 2, animated: true)
         }
-        else {
-            if hour > 12 {
-                self.timePickerView.selectRow(1, inComponent: 2, animated: true)
-                self.timePickerView.selectRow(hour - 12, inComponent: 0, animated: true)
-            }
-            else {
-                self.timePickerView.selectRow(hour, inComponent: 0, animated: true)
-            }
-            self.timePickerView.selectRow(minute, inComponent: 1, animated: true)
-        }
+        self.timePickerView.selectRow(minute, inComponent: 1, animated: true)
     }
 }
 
 extension EditNotificationsViewController : UIPickerViewDataSource, UIPickerViewDelegate {
     func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
         if component == 0 {
-            return Bool(self.use24HourTime()) ? 24 : 12
+            return self.use24HourTime() ? 24 : 12
         }
         else if component == 1 {
             return 60
@@ -200,10 +205,19 @@ extension EditNotificationsViewController : UIPickerViewDataSource, UIPickerView
     // we're doing this instead of just using a UIDatePicker so that we can use the
     // Beeminder font in the picker instead of the system font
     func hourFromTimePicker() -> NSNumber {
-        if self.use24HourTime() || self.timePickerView.selectedRow(inComponent: 2) == 0 {
-            return NSNumber(value: self.timePickerView.selectedRow(inComponent: 0))
+        let selectedHour = self.timePickerView.selectedRow(inComponent: 0)
+        
+        if self.use24HourTime() {
+            return NSNumber(value: selectedHour)
+        } else {
+            // Handle 12-hour time conversion
+            let isPM = self.timePickerView.selectedRow(inComponent: 2) == 1
+            if selectedHour == 0 { // 12 AM/PM case
+                return NSNumber(value: isPM ? 12 : 0)
+            } else {
+                return NSNumber(value: isPM ? (selectedHour == 12 ? 12 : selectedHour + 12) : selectedHour)
+            }
         }
-        return NSNumber(value: self.timePickerView.selectedRow(inComponent: 0) + 12)
     }
     
     func numberOfComponents(in pickerView: UIPickerView) -> Int {

--- a/BeeSwift/Settings/EditNotificationsViewController.swift
+++ b/BeeSwift/Settings/EditNotificationsViewController.swift
@@ -125,13 +125,13 @@ class EditNotificationsViewController: UIViewController {
         self.deadlineLabel.text = "Goal deadline: \(self.stringFromMidnightOffset(deadline))"
     }
     
-    func stringFromMidnightOffset(_ offset : Int) -> NSString {
+    func stringFromMidnightOffset(_ offset : Int) -> String {
         let date = Date(timeInterval: Double(offset), since: Calendar.current.startOfDay(for: Date()))
         let dateFormatter = DateFormatter()
         dateFormatter.locale = Locale(identifier: self.use24HourTime() ? "en_UK" : "en_US")
         dateFormatter.timeStyle = DateFormatter.Style.short
         dateFormatter.dateStyle = DateFormatter.Style.none
-        return dateFormatter.string(from: date) as NSString
+        return dateFormatter.string(from: date)
     }
     
     func updateLeadTimeLabel() {
@@ -196,10 +196,10 @@ extension EditNotificationsViewController : UIPickerViewDataSource, UIPickerView
     }
     
     func midnightOffsetFromTimePickerView() -> Int {
-        let minute = NSNumber(value: self.timePickerView.selectedRow(inComponent: 1))
+        let minute = self.timePickerView.selectedRow(inComponent: 1)
         let hour = self.hour24FromPicker
         
-        return 3600*hour.intValue + 60*minute.intValue
+        return 3600*hour + 60*minute
     }
     
     // Convert to deadline format:

--- a/BeeSwift/Settings/EditNotificationsViewController.swift
+++ b/BeeSwift/Settings/EditNotificationsViewController.swift
@@ -218,8 +218,6 @@ extension EditNotificationsViewController : UIPickerViewDataSource, UIPickerView
         }
     }
     
-    // we're doing this instead of just using a UIDatePicker so that we can use the
-    // Beeminder font in the picker instead of the system font
     var hour24FromPicker: Int {
         let selectedHour = self.timePickerView.selectedRow(inComponent: 0)
         // 24h

--- a/BeeSwift/Settings/EditNotificationsViewController.swift
+++ b/BeeSwift/Settings/EditNotificationsViewController.swift
@@ -197,7 +197,7 @@ extension EditNotificationsViewController : UIPickerViewDataSource, UIPickerView
     
     func midnightOffsetFromTimePickerView() -> Int {
         let minute = NSNumber(value: self.timePickerView.selectedRow(inComponent: 1))
-        let hour = self.hourFromTimePicker()
+        let hour = self.hour24FromPicker
         
         return 3600*hour.intValue + 60*minute.intValue
     }
@@ -220,23 +220,6 @@ extension EditNotificationsViewController : UIPickerViewDataSource, UIPickerView
     
     // we're doing this instead of just using a UIDatePicker so that we can use the
     // Beeminder font in the picker instead of the system font
-    func hourFromTimePicker() -> NSNumber {
-        let selectedHour = self.timePickerView.selectedRow(inComponent: 0)
-        
-        if self.use24HourTime() {
-            return NSNumber(value: selectedHour)
-        } else {
-            // Handle 12-hour time conversion
-            let isPM = self.timePickerView.selectedRow(inComponent: 2) == 1
-            if selectedHour == 0 { // 12 AM/PM case
-                return NSNumber(value: isPM ? 12 : 0)
-            } else {
-                return NSNumber(value: isPM ? (selectedHour == 12 ? 12 : selectedHour + 12) : selectedHour)
-            }
-        }
-    }
-    
-    
     var hour24FromPicker: Int {
         let selectedHour = self.timePickerView.selectedRow(inComponent: 0)
         // 24h

--- a/BeeSwift/Settings/EditNotificationsViewController.swift
+++ b/BeeSwift/Settings/EditNotificationsViewController.swift
@@ -202,6 +202,22 @@ extension EditNotificationsViewController : UIPickerViewDataSource, UIPickerView
         return 3600*hour.intValue + 60*minute.intValue
     }
     
+    // Convert to deadline format:
+    // - Times from midnight to 6am (0-6) stay positive
+    // - Times from 7am to midnight (7-23) become negative offsets from next midnight
+    var deadlineFromTimePickerView: Int {
+        let hour24 = hour24FromPicker
+        let selectedMinute = self.timePickerView.selectedRow(inComponent: 1)
+        
+        let totalSeconds = 3600 * hour24 + 60 * selectedMinute
+        
+        if hour24 <= 6 {
+            return totalSeconds  // Keep positive for early morning hours
+        } else {
+            return totalSeconds - (24 * 3600)  // Convert to negative offset from next midnight
+        }
+    }
+    
     // we're doing this instead of just using a UIDatePicker so that we can use the
     // Beeminder font in the picker instead of the system font
     func hourFromTimePicker() -> NSNumber {
@@ -218,6 +234,19 @@ extension EditNotificationsViewController : UIPickerViewDataSource, UIPickerView
                 return NSNumber(value: isPM ? (selectedHour == 12 ? 12 : selectedHour + 12) : selectedHour)
             }
         }
+    }
+    
+    
+    var hour24FromPicker: Int {
+        let selectedHour = self.timePickerView.selectedRow(inComponent: 0)
+        // 24h
+        guard !self.use24HourTime() else { return selectedHour }
+        
+        // 12h am
+        guard self.timePickerView.selectedRow(inComponent: 2) == 1 else { return selectedHour }
+        
+        // 12h pm
+        return selectedHour == 12 ? 12 : selectedHour + 12
     }
     
     func numberOfComponents(in pickerView: UIPickerView) -> Int {


### PR DESCRIPTION
## Summary
Edit Notifications contained several logical errors around 12h / 24h mode conversions. In 24h mode, the picker could display the wrong values.
Furthermore, deadlines were being calculated incorrectly from the picker. The backend was rejected these, leaving the user with a mere 422 error message and unable to set the deadline to a range of deadlines in the app.
This Merge Request fixes these conversions and fixes the deadline calculation.


*For UI changes including screenshots of before and after is great.*

## before

## after


## Validation
Ran app in 12h and 24h modes in simulator.
Used the picker for before noon and after noon times and also times between 11pm and 12am.
Also, updated a goal's deadline both in 12h mode and in 24h.


## Note
This MR does not address several other issues with these edit notification screens: data shown can quickly become out of sync with UI components on the same screen, can also become out of sync with the values the backend has; Elsewhere the app uses goal.slug but notification uses the goal.title; general lack of feedback about data being sent/saved

related bug ticket: #172