### PR TITLE
notificationsVC could crash when group membership changed

### DIFF
--- a/BeeSwift/Settings/ConfigureNotificationsViewController.swift
+++ b/BeeSwift/Settings/ConfigureNotificationsViewController.swift
@@ -17,14 +17,16 @@ class ConfigureNotificationsViewController: UIViewController {
     private let logger = Logger(subsystem: "com.beeminder.beeminder", category: "ConfigureNotificationsViewController")
     
     private var lastFetched : Date?
-    fileprivate var goals : [Goal] = []
-    fileprivate var cellReuseIdentifier = "configureNotificationsTableViewCell"
     fileprivate var tableView = UITableView()
     fileprivate let settingsButton = BSButton()
     private let goalManager: GoalManager
     private let viewContext: NSManagedObjectContext
     private let currentUserManager: CurrentUserManager
     private let requestManager: RequestManager
+    
+    private lazy var dataSource: NotificationsTableViewDiffibleDataSource = {
+        NotificationsTableViewDiffibleDataSource(goals: [], tableView: tableView)
+    }()
     
     init(goalManager: GoalManager, viewContext: NSManagedObjectContext, currentUserManager: CurrentUserManager, requestManager: RequestManager) {
         self.goalManager = goalManager
@@ -65,21 +67,33 @@ class ConfigureNotificationsViewController: UIViewController {
         }
         self.tableView.isHidden = true
         self.tableView.delegate = self
-        self.tableView.dataSource = self
+        self.tableView.dataSource = self.dataSource
         self.tableView.refreshControl = {
             let refresh = UIRefreshControl()
             refresh.addTarget(self, action: #selector(fetchGoals), for: .valueChanged)
             return refresh
         }()
         self.tableView.tableFooterView = UIView()
-        self.tableView.register(SettingsTableViewCell.self, forCellReuseIdentifier: self.cellReuseIdentifier)
         self.fetchGoals()
         self.updateHiddenElements()
         NotificationCenter.default.addObserver(self, selector: #selector(self.foregroundEntered), name: UIApplication.willEnterForegroundNotification, object: nil)
     }
 
-    override func didReceiveMemoryWarning() {
-        super.didReceiveMemoryWarning()
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        self.applySnapshot()
+    }
+    
+    private func applySnapshot() {
+        guard lastFetched != nil else {
+            let snapshot = NSDiffableDataSourceSnapshot<NotificationsTableViewDiffibleDataSource.Section, String>()
+            dataSource.apply(snapshot)
+            return
+        }
+        
+        let snapshot = dataSource.makeSnapshot()
+        dataSource.apply(snapshot, animatingDifferences: true)
     }
     
     @objc func settingsButtonTapped() {
@@ -112,7 +126,7 @@ class ConfigureNotificationsViewController: UIViewController {
             MBProgressHUD.showAdded(to: self.view, animated: true)
             do {
                 try await self.goalManager.refreshGoals()
-                self.goals = self.goalManager.staleGoals(context: self.viewContext)?.sorted(by: { $0.slug < $1.slug }) ?? []
+                self.dataSource.goals = self.goalManager.staleGoals(context: self.viewContext)?.sorted(using: SortDescriptor(\.slug)) ?? []
                 self.lastFetched = Date()
                 MBProgressHUD.hide(for: self.view, animated: true)
             } catch {
@@ -125,12 +139,53 @@ class ConfigureNotificationsViewController: UIViewController {
                     self.present(alert, animated: true, completion: nil)
                 }
             }
-            self.tableView.reloadData()
+            self.applySnapshot()
         }
     }
 }
 
-private extension ConfigureNotificationsViewController {
+private class NotificationsTableViewDiffibleDataSource: UITableViewDiffableDataSource<NotificationsTableViewDiffibleDataSource.Section, String> {
+    static let cellReuseIdentifier = "configureNotificationsTableViewCell"
+    
+    var goals: [Goal]
+    
+    enum Section: Int, CaseIterable {
+        case defaultNotificationSettings = 0
+        case goalsUsingCustomSettings = 1
+        case goalsUsingDefaults = 2
+    }
+    
+    override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        guard let section = Section(rawValue: section) else { return nil }
+        
+        return switch section {
+        case .defaultNotificationSettings:
+            "Defaults"
+        case .goalsUsingDefaults where goalsUsingDefaultNotifications.isEmpty:
+            nil
+        case .goalsUsingCustomSettings where goalsUsingNonDefaultNotifications.isEmpty:
+            nil
+        case .goalsUsingDefaults:
+             "Using Defaults"
+        case .goalsUsingCustomSettings:
+             "Customized"
+        }
+    }
+    
+    init(goals: [Goal], tableView: UITableView) {
+        self.goals = goals
+        tableView.register(SettingsTableViewCell.self, forCellReuseIdentifier: Self.cellReuseIdentifier)
+        
+        super.init(tableView: tableView) { tableView, indexPath, title in
+            guard
+                let cell = tableView.dequeueReusableCell(withIdentifier: Self.cellReuseIdentifier, for: indexPath) as? SettingsTableViewCell
+            else { return UITableViewCell() }
+            
+            cell.title = title
+            return cell
+        }
+    }
+    
     var goalsUsingDefaultNotifications: [Goal] {
         self.goals.filter { $0.useDefaults }
     }
@@ -138,89 +193,74 @@ private extension ConfigureNotificationsViewController {
     var goalsUsingNonDefaultNotifications: [Goal] {
         self.goals.filter { !$0.useDefaults }
     }
+    
+    func makeSnapshot() -> NSDiffableDataSourceSnapshot<Section, String> {
+        var snapshot = NSDiffableDataSourceSnapshot<Section, String>()
+        
+        snapshot.appendSections([.defaultNotificationSettings])
+        snapshot.appendItems(["Default notification settings"],
+                             toSection: .defaultNotificationSettings)
 
+        snapshot.appendSections([.goalsUsingCustomSettings])
+        snapshot.appendItems(goalsUsingNonDefaultNotifications.map{ $0.slug },
+                             toSection: .goalsUsingCustomSettings)
+        
+        snapshot.appendSections([.goalsUsingDefaults])
+        snapshot.appendItems(goalsUsingDefaultNotifications.map{ $0.slug },
+                             toSection: .goalsUsingDefaults)
+
+        snapshot.reconfigureItems(goals.map({ $0.slug }))
+        
+        return snapshot
+    }
+    
+    func goalAtIndexPath(_ indexPath: IndexPath) -> Goal? {
+        guard
+            let section = NotificationsTableViewDiffibleDataSource.Section(rawValue: indexPath.section)
+        else {
+            return nil
+        }
+        
+        return switch section {
+        case .defaultNotificationSettings:
+            nil
+        case .goalsUsingCustomSettings:
+            indexPath.row < goalsUsingNonDefaultNotifications.count ? goalsUsingNonDefaultNotifications[indexPath.row] : nil
+        case .goalsUsingDefaults:
+            indexPath.row < goalsUsingDefaultNotifications.count ? goalsUsingDefaultNotifications[indexPath.row] : nil
+        }
+    }
 }
 
-extension ConfigureNotificationsViewController : UITableViewDataSource, UITableViewDelegate {
-    func numberOfSections(in tableView: UITableView) -> Int {
-        guard lastFetched != nil else { return 0 }
-        return 3
-    }
-    
-    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        switch section {
-        case 0:
-            return 1
-        case 1:
-            return self.goalsUsingDefaultNotifications.count
-        default:
-            return self.goalsUsingNonDefaultNotifications.count
-        }
-    }
-    
-    func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-        switch section {
-        case 0:
-            guard !goals.isEmpty else { return nil }
-            return "Defaults"
-        case 1:
-            guard !goalsUsingDefaultNotifications.isEmpty else { return nil }
-            return "Using Defaults"
-        default:
-            guard !goalsUsingNonDefaultNotifications.isEmpty else { return nil }
-            return "Customized"
-        }
-    }
-    
-    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: self.cellReuseIdentifier) as? SettingsTableViewCell else {
-            return UITableViewCell()
-        }
-        
-        switch indexPath.section {
-        case 0:
-            cell.title = "Default notification settings"
-            return cell
-        case 1:
-            let goal = self.goalsUsingDefaultNotifications[indexPath.row]
-            cell.title = goal.slug
-            return cell
-        default:
-            let goal = self.goalsUsingNonDefaultNotifications[indexPath.row]
-            cell.title = goal.slug
-            return cell
-        }
-    }
-    
+extension ConfigureNotificationsViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        let editNotificationsVC: UIViewController
+        self.tableView.deselectRow(at: indexPath, animated: true)
         
-        switch indexPath.section {
-        case 0:
-            editNotificationsVC = EditDefaultNotificationsViewController(
-                currentUserManager: currentUserManager,
-                requestManager: requestManager,
-                goalManager: goalManager,
-                viewContext: viewContext)
-        case 1:
-            let goal = self.goalsUsingDefaultNotifications[indexPath.row]
-            editNotificationsVC = EditGoalNotificationsViewController(
-                goal: goal,
-                currentUserManager: currentUserManager,
-                requestManager: requestManager,
-                goalManager: goalManager,
-                viewContext: viewContext)
-        default:
-            let goal = self.goalsUsingNonDefaultNotifications[indexPath.row]
-            editNotificationsVC = EditGoalNotificationsViewController(
-                goal: goal,
-                currentUserManager: currentUserManager,
-                requestManager: requestManager,
-                goalManager: goalManager,
-                viewContext: viewContext)
+        guard let section = NotificationsTableViewDiffibleDataSource.Section(rawValue: indexPath.section) else {
+            return
         }
         
-        self.navigationController?.pushViewController(editNotificationsVC, animated: true)
-        self.tableView.deselectRow(at: indexPath, animated: true)
+        var editNotificationsVC: UIViewController? {
+            switch section {
+            case .defaultNotificationSettings:
+                return EditDefaultNotificationsViewController(
+                    currentUserManager: currentUserManager,
+                    requestManager: requestManager,
+                    goalManager: goalManager,
+                    viewContext: viewContext)
+            case .goalsUsingDefaults, .goalsUsingCustomSettings:
+                guard let goal = self.dataSource.goalAtIndexPath(indexPath) else { return nil }
+                return EditGoalNotificationsViewController(
+                    goal: goal,
+                    currentUserManager: currentUserManager,
+                    requestManager: requestManager,
+                    goalManager: goalManager,
+                    viewContext: viewContext)
+            }
+        }
+        
+        if let editNotificationsVC {
+            self.navigationController?.pushViewController(editNotificationsVC, animated: true)
+        }
     }
 }

--- a/BeeSwift/Settings/EditDefaultNotificationsViewController.swift
+++ b/BeeSwift/Settings/EditDefaultNotificationsViewController.swift
@@ -60,27 +60,34 @@ class EditDefaultNotificationsViewController: EditNotificationsViewController {
     
     func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
         Task { @MainActor in
-            if self.timePickerEditingMode == .alertstart {
+            let hud = MBProgressHUD.showAdded(to: self.view, animated: true)
+            hud.mode = .indeterminate
+            
+            switch self.timePickerEditingMode {
+            case .alertstart:
                 self.updateAlertstartLabel(self.midnightOffsetFromTimePickerView())
                 let params = ["default_alertstart" : self.midnightOffsetFromTimePickerView()]
                 do {
                     let _ = try await requestManager.put(url: "api/v1/users/{username}.json", parameters: params)
                     try await currentUserManager.refreshUser()
+                    hud.hide(animated: true, afterDelay: 0.5)
                 } catch {
                     logger.error("Error setting default alert start: \(error)")
-                    //foo
+                    hud.hide(animated: true)
                 }
-            }
-            if self.timePickerEditingMode == .deadline {
+            case .deadline:
                 self.updateDeadlineLabel(self.midnightOffsetFromTimePickerView())
                 let params = ["default_deadline" : self.midnightOffsetFromTimePickerView()]
                 do {
                     let _ = try await requestManager.put(url: "api/v1/users/{username}.json", parameters: params)
                     try await currentUserManager.refreshUser()
+                    hud.hide(animated: true, afterDelay: 0.5)
                 } catch {
                     logger.error("Error setting default deadline: \(error)")
-                    //foo
+                    hud.hide(animated: true, afterDelay: 0.5)
                 }
+            case .none:
+                hud.hide(animated: true)
             }
         }
     }

--- a/BeeSwift/Settings/EditGoalNotificationsViewController.swift
+++ b/BeeSwift/Settings/EditGoalNotificationsViewController.swift
@@ -49,7 +49,7 @@ class EditGoalNotificationsViewController : EditNotificationsViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        self.title = "\(self.goal.title) Notifications"
+        self.title = self.goal.slug
         
         let useDefaultsLabel = BSLabel()
         useDefaultsLabel.text = "Use defaults"
@@ -93,6 +93,9 @@ class EditGoalNotificationsViewController : EditNotificationsViewController {
     
     func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
         Task { @MainActor in
+            let hud = MBProgressHUD.showAdded(to: self.view, animated: true)
+            hud.mode = .indeterminate
+            
             if self.timePickerEditingMode == .alertstart {
                 self.updateAlertstartLabel(self.midnightOffsetFromTimePickerView())
                 do {
@@ -101,9 +104,11 @@ class EditGoalNotificationsViewController : EditNotificationsViewController {
                     try await self.goalManager.refreshGoal(self.goal.objectID)
 
                     self.useDefaultsSwitch.isOn = false
+                    hud.hide(animated: true, afterDelay: 0.5)
                 } catch {
                     logger.error("Error setting alert start \(error)")
                     //foo
+                    hud.hide(animated: true)
                 }
             }
             if self.timePickerEditingMode == .deadline {
@@ -114,12 +119,14 @@ class EditGoalNotificationsViewController : EditNotificationsViewController {
                     try await self.goalManager.refreshGoal(self.goal.objectID)
 
                     self.useDefaultsSwitch.isOn = false
+                    hud.hide(animated: true, afterDelay: 0.5)
                 } catch {
                     let errorString = error.localizedDescription
                     MBProgressHUD.hide(for: self.view, animated: true)
                     let alert = UIAlertController(title: "Error saving to Beeminder", message: errorString, preferredStyle: .alert)
                     alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
                     self.present(alert, animated: true, completion: nil)
+                    hud.hide(animated: true)
                 }
             }
         }
@@ -127,24 +134,31 @@ class EditGoalNotificationsViewController : EditNotificationsViewController {
     
     @objc func useDefaultsSwitchValueChanged() {
         if self.useDefaultsSwitch.isOn {
-            let alertController = UIAlertController(title: "Confirm", message: "This will wipe out your current settings for this goal. Are you sure?", preferredStyle: .alert)
+            let alertController = UIAlertController(title: "Confirm", message: "This will set this goal's notification settings to your default ones. Are you sure?", preferredStyle: .alert)
             alertController.addAction(UIAlertAction(title: "Yes", style: .default, handler: { (action) -> Void in
                 Task { @MainActor in
+                    let hud = MBProgressHUD.showAdded(to: self.view, animated: true)
+                    hud.mode = .indeterminate
+                    
                     do {
                         let params = ["use_defaults" : true]
                         let _ = try await self.requestManager.put(url: "api/v1/users/{username}/goals/\(self.goal.slug).json", parameters: params)
                         try await self.goalManager.refreshGoal(self.goal.objectID)
+                        hud.hide(animated: true, afterDelay: 0.5)
                     } catch {
                         self.logger.error("Error setting goal to use defaults: \(error)")
                         // TODO: Show UI failure
+                        hud.hide(animated: true)
                         return
                     }
 
                     do {
                         try await self.currentUserManager.refreshUser()
+                        hud.hide(animated: true, afterDelay: 0.5)
                     } catch {
                         self.logger.error("Error syncing notification defaults")
                         // TODO: Show UI failure
+                        hud.hide(animated: true)
                         return
                     }
 
@@ -162,13 +176,18 @@ class EditGoalNotificationsViewController : EditNotificationsViewController {
         }
         else {
             Task { @MainActor in
+                let hud = MBProgressHUD.showAdded(to: self.view, animated: true)
+                hud.mode = .indeterminate
+                
                 do {
                     let params = ["use_defaults" : false]
                     let _ = try await self.requestManager.put(url: "api/v1/users/{username}/goals/\(self.goal.slug).json", parameters: params)
                     try await self.goalManager.refreshGoal(self.goal.objectID)
+                    hud.hide(animated: true, afterDelay: 0.5)
                 } catch {
                     logger.error("Error setting goal to NOT use defaults: \(error)")
                     // foo
+                    hud.hide(animated: true)
                 }
             }
         }


### PR DESCRIPTION
## Summary
NotificationsVC could crash when the underlying list of goals changed. The MR makes the code more robust by using a diffable datasource for the NotificationVC's TableView.

Also took the opportunity to add the HUD activity indicator when notification settings are being saved.

fixes #397

*For UI changes including screenshots of before and after is great.*

## Validation
Ran app in simulator.
Changed settings in goals. Returned from notification/goal screen back to notification goal list. Noticed goals were in their proper sections.
