### PR TITLE
Disable animation for goal thumbnails

### DIFF
--- a/BeeSwift/Components/GoalImageView.swift
+++ b/BeeSwift/Components/GoalImageView.swift
@@ -77,8 +77,13 @@ class GoalImageView : UIView {
 
     @MainActor
     private func showGraphImage(image: UIImage) {
+        // Animating the thumbnail view interacts badly with cell re-use in the gallery
+        // e.g. it would cause us to show the image from a different goal before animating
+        // to the corrent one.
+        let duration = isThumbnail ? 0 : 0.4
+
         UIView.transition(with: imageView,
-                          duration: 0.8,
+                          duration: duration,
                           options: .transitionCrossDissolve,
                           animations: { [weak self] in
             self?.imageView.image = image


### PR DESCRIPTION
## Summary
Animation of goal thumbnails in the gallery often had some unfortunate affects:
* Because gallery cells are re-used, on returning to the gallery from a goal the gallery entry for a goal would show the graph _for a different goal_ before fading to the right one
* Refreshing the gallery would cause images to flicker to slightly darker and back

It may be possible to more carefully choose when to animate to address these, but for now avoid the issue by not animating thumbnails.

## Validation
Loaded the app and navigated to a goal and back. Observed the gallery immediately showed the correct graphs.