### PR TITLE
A coordinator handles the app's navigation

### DIFF
--- a/BeeSwift.xcodeproj/project.pbxproj
+++ b/BeeSwift.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		8646D674ADB842B797E2F98D /* AddDataError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8646D674ADB842B797E2F98E /* AddDataError.swift */; };
 		9B65F2322CFA6427009674A7 /* DeeplinkGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B65F2312CFA6418009674A7 /* DeeplinkGenerator.swift */; };
 		9B8CA57D24B120CA009C86C2 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9B8CA57C24B120CA009C86C2 /* LaunchScreen.storyboard */; };
+		9BD4C4E82D45A09F00B03E99 /* MainCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BD4C4E72D45A09F00B03E99 /* MainCoordinator.swift */; };
 		9BFB27E92CFE770F0056D10D /* FreshnessIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BFB27E82CFE770F0056D10D /* FreshnessIndicatorView.swift */; };
 		A10D4E931B07948500A72D29 /* DatapointsTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10D4E921B07948500A72D29 /* DatapointsTableView.swift */; };
 		A10DC2DF207BFCBA00FB7B3A /* RemoveHKMetricViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10DC2DE207BFCBA00FB7B3A /* RemoveHKMetricViewController.swift */; };
@@ -202,6 +203,7 @@
 		8646D674ADB842B797E2F98E /* AddDataError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddDataError.swift; sourceTree = "<group>"; };
 		9B65F2312CFA6418009674A7 /* DeeplinkGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeeplinkGenerator.swift; sourceTree = "<group>"; };
 		9B8CA57C24B120CA009C86C2 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
+		9BD4C4E72D45A09F00B03E99 /* MainCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainCoordinator.swift; sourceTree = "<group>"; };
 		9BFB27E82CFE770F0056D10D /* FreshnessIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreshnessIndicatorView.swift; sourceTree = "<group>"; };
 		A10D4E921B07948500A72D29 /* DatapointsTableView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatapointsTableView.swift; sourceTree = "<group>"; };
 		A10DC2DE207BFCBA00FB7B3A /* RemoveHKMetricViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoveHKMetricViewController.swift; sourceTree = "<group>"; };
@@ -445,6 +447,7 @@
 		A196CB161AE4142E00B90A3E /* BeeSwift */ = {
 			isa = PBXGroup;
 			children = (
+				9BD4C4E72D45A09F00B03E99 /* MainCoordinator.swift */,
 				9B65F2312CFA6418009674A7 /* DeeplinkGenerator.swift */,
 				A1E618E51E79E01900D8ED93 /* Cells */,
 				E46071002B43DA7100305DB4 /* Gallery */,
@@ -955,6 +958,7 @@
 				A10DC2DF207BFCBA00FB7B3A /* RemoveHKMetricViewController.swift in Sources */,
 				E412DAE12B86A8F70099E483 /* GoalImageView.swift in Sources */,
 				A1619EA41BEECC1500E14B3A /* EditDefaultNotificationsViewController.swift in Sources */,
+				9BD4C4E82D45A09F00B03E99 /* MainCoordinator.swift in Sources */,
 				A149B3701AEF528C00F19A09 /* SettingsViewController.swift in Sources */,
 				E46DC80F2AA58DF20059FDFE /* PullToRefreshHint.swift in Sources */,
 				A1E618E21E78158700D8ED93 /* HealthKitConfigViewController.swift in Sources */,

--- a/BeeSwift/GoalViewController.swift
+++ b/BeeSwift/GoalViewController.swift
@@ -31,6 +31,7 @@ class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTabl
     private let requestManager: RequestManager
     private let currentUserManager: CurrentUserManager
     private let viewContext: NSManagedObjectContext
+    private weak var coordinator: MainCoordinator?
     
     private let timeElapsedView = FreshnessIndicatorView()
     fileprivate var goalImageView = GoalImageView(isThumbnail: false)
@@ -64,13 +65,15 @@ class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTabl
          goalManager: GoalManager,
          requestManager: RequestManager,
          currentUserManager: CurrentUserManager,
-         viewContext: NSManagedObjectContext) {
+         viewContext: NSManagedObjectContext,
+         coordinator: MainCoordinator) {
         self.goal = goal
         self.healthStoreManager = healthStoreManager
         self.goalManager = goalManager
         self.requestManager = requestManager
         self.currentUserManager = currentUserManager
         self.viewContext = viewContext
+        self.coordinator = coordinator
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -361,9 +364,7 @@ class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTabl
     }
     
     @objc func timerButtonPressed() {
-        let controller = TimerViewController(goal: self.goal, requestManager: self.requestManager)
-        controller.modalPresentationStyle = .fullScreen
-        self.present(controller, animated: true, completion: nil)
+        coordinator?.showTimerForGoal(goal)
     }
     
     @objc func refreshButtonPressed() {
@@ -401,10 +402,7 @@ class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTabl
         guard !self.goal.hideDataEntry else { return }
         guard let existingDatapoint = datapoint as? DataPoint else { return }
 
-        let editDatapointViewController = EditDatapointViewController(goal: goal, datapoint: existingDatapoint, requestManager: self.requestManager, goalManager: self.goalManager)
-        let navigationController = UINavigationController(rootViewController: editDatapointViewController)
-        navigationController.modalPresentationStyle = .formSheet
-        self.present(navigationController, animated: true, completion: nil)
+        coordinator?.showEditDatapointForGoal(goal: goal, datapoint: existingDatapoint)
     }
 
     @objc func dateStepperValueChanged() {

--- a/BeeSwift/MainCoordinator.swift
+++ b/BeeSwift/MainCoordinator.swift
@@ -1,0 +1,240 @@
+import UIKit
+import BeeKit
+import CoreData
+
+class MainCoordinator {
+    private let navigationController: UINavigationController
+    private let currentUserManager: CurrentUserManager
+    private let viewContext: NSManagedObjectContext
+    private let versionManager: VersionManager
+    private let goalManager: GoalManager
+    private let healthStoreManager: HealthStoreManager
+    private let requestManager: RequestManager
+    
+    init(navigationController: UINavigationController,
+         currentUserManager: CurrentUserManager,
+         viewContext: NSManagedObjectContext,
+         versionManager: VersionManager,
+         goalManager: GoalManager,
+         healthStoreManager: HealthStoreManager,
+         requestManager: RequestManager) {
+        self.navigationController = navigationController
+        self.currentUserManager = currentUserManager
+        self.viewContext = viewContext
+        self.versionManager = versionManager
+        self.goalManager = goalManager
+        self.healthStoreManager = healthStoreManager
+        self.requestManager = requestManager
+        
+        setUpNotifications()
+    }
+    
+    private func setUpNotifications() {
+        NotificationCenter.default.addObserver(self, 
+                                             selector: #selector(handleSignIn),
+                                             name: CurrentUserManager.NotificationName.signedIn, 
+                                             object: nil)
+        NotificationCenter.default.addObserver(self,
+                                             selector: #selector(handleSignOut),
+                                             name: CurrentUserManager.NotificationName.signedOut,
+                                             object: nil)
+        NotificationCenter.default.addObserver(self,
+                                             selector: #selector(openGoalFromNotification(_:)),
+                                             name: GalleryViewController.NotificationName.openGoal,
+                                             object: nil)
+    }
+    
+    func start() {
+        let galleryVC = GalleryViewController(
+            currentUserManager: currentUserManager,
+            viewContext: viewContext,
+            versionManager: versionManager,
+            goalManager: goalManager,
+            healthStoreManager: healthStoreManager,
+            requestManager: requestManager,
+            coordinator: self
+        )
+        
+        navigationController.setViewControllers([galleryVC], animated: false)
+        navigationController.navigationBar.isTranslucent = false
+        navigationController.navigationBar.barStyle = .black
+        navigationController.navigationBar.tintColor = .white
+        
+        if !currentUserManager.signedIn(context: viewContext) {
+            showSignIn()
+        }
+    }
+    
+    func showGoal(_ goal: Goal) {
+        let goalViewController = GoalViewController(
+            goal: goal,
+            healthStoreManager: healthStoreManager,
+            goalManager: goalManager,
+            requestManager: requestManager,
+            currentUserManager: currentUserManager,
+            viewContext: viewContext,
+            coordinator: self)
+        navigationController.pushViewController(goalViewController, animated: true)
+    }
+    
+    func showSettings() {
+        let settingsVC = SettingsViewController(
+            currentUserManager: currentUserManager,
+            viewContext: viewContext,
+            goalManager: goalManager,
+            requestManager: requestManager,
+            coordinator: self)
+        navigationController.pushViewController(settingsVC, animated: true)
+    }
+    
+    func showSignIn() {
+        let signInVC = SignInViewController(currentUserManager: currentUserManager, coordinator: self)
+        signInVC.modalPresentationStyle = .fullScreen
+        navigationController.present(signInVC, animated: true)
+    }
+    
+    func showTimerForGoal(_ goal: Goal) {
+        let controller = TimerViewController(goal: goal, requestManager: requestManager)
+        controller.modalPresentationStyle = .fullScreen
+        navigationController.present(controller, animated: true, completion: nil)
+    }
+    
+    func showChooseGallerySortAlgorithm() {
+        let controller = ChooseGoalSortViewController()
+        
+        navigationController.pushViewController(controller,
+                                                animated: true)
+    }
+    
+    func showConfigureNotifications() {
+        let controller = ConfigureNotificationsViewController(
+            goalManager: goalManager,
+            viewContext: viewContext,
+            currentUserManager: currentUserManager,
+            requestManager: requestManager,
+            coordinator: self)
+        
+        navigationController.pushViewController(controller,
+                                                animated: true)
+    }
+    
+    func showConfigureHealthKitIntegration() {
+        let controller = HealthKitConfigViewController(
+            goalManager: goalManager,
+            viewContext: viewContext,
+            healthStoreManager: ServiceLocator.healthStoreManager,
+            requestManager: requestManager,
+            coordinator: self)
+        
+        navigationController.pushViewController(controller,
+                                                animated: true)
+    }
+    
+    func showRemoveHealthKitIntegrationFromGoal(_ goal: Goal) {
+        let controller = RemoveHKMetricViewController(
+            goal: goal,
+            requestManager: requestManager,
+            goalManager: goalManager)
+        
+        navigationController.pushViewController(controller,
+                                                animated: true)
+    }
+    
+    func showAssociateHealthKitWithGoal(_ goal: Goal) {
+        let chooseHKMetricViewController = ChooseHKMetricViewController(
+            goal: goal,
+            healthStoreManager: healthStoreManager,
+            requestManager: requestManager,
+            coordinator: self)
+        
+        navigationController.pushViewController(chooseHKMetricViewController,
+                                                animated: true)
+    }
+    
+    func showConfigureNotificationsForGoal(_ goal: Goal) {
+        let controller = EditGoalNotificationsViewController(
+            goal: goal,
+            currentUserManager: currentUserManager,
+            requestManager: requestManager,
+            goalManager: goalManager,
+            viewContext: viewContext)
+        
+        navigationController.pushViewController(controller,
+                                                animated: true)
+    }
+    
+    func showConfigureDefaultNotifications() {
+        let controller = EditDefaultNotificationsViewController(
+            currentUserManager: currentUserManager,
+            requestManager: requestManager,
+            goalManager: goalManager,
+            viewContext: viewContext)
+        
+        navigationController.pushViewController(controller,
+                                                animated: true)
+    }
+    
+    func showConfigureHKMetricForGoal(_ goal: Goal, _ metric: HealthKitMetric) {
+        let controller = ConfigureHKMetricViewController(
+            goal: goal,
+            metric: metric,
+            healthStoreManager: healthStoreManager,
+            requestManager: requestManager
+        )
+        
+        navigationController.pushViewController(controller,
+                                                animated: true)
+    }
+    
+    func showEditDatapointForGoal(goal: Goal, datapoint: DataPoint) {
+        let editDatapointViewController = EditDatapointViewController(goal: goal,
+                                                                      datapoint: datapoint,
+                                                                      requestManager: self.requestManager,
+                                                                      goalManager: self.goalManager)
+
+        let navigationController = UINavigationController(rootViewController: editDatapointViewController)
+        navigationController.modalPresentationStyle = .formSheet
+        self.navigationController.present(navigationController, animated: true, completion: nil)
+    }
+    
+    func showLogs() {
+        let controller = LogsViewController()
+        navigationController.pushViewController(controller,
+                                                animated: true)
+    }
+    
+    @objc private func handleSignIn() {
+        navigationController.dismiss(animated: true)
+        navigationController.popToRootViewController(animated: true)
+        start()
+    }
+    
+    @objc private func handleSignOut() {
+        navigationController.popToRootViewController(animated: true)
+        showSignIn()
+    }
+    
+    @objc private func openGoalFromNotification(_ notification: Notification) {
+        var goalFromID: Goal? {
+            guard let identifier = notification.userInfo?["identifier"] as? String else { return nil }
+            guard
+                let url = URL(string: identifier),
+                let objectID = viewContext.persistentStoreCoordinator?.managedObjectID(forURIRepresentation: url)
+            else { return nil }
+            return viewContext.object(with: objectID) as? Goal
+        }
+        
+        var goalFromSlug: Goal? {
+            guard
+                let slug = notification.userInfo?["slug"] as? String,
+                let user = currentUserManager.user(context: viewContext)
+            else { return nil }
+            return user.goals.first { $0.slug == slug }
+        }
+        
+        if let goal = goalFromID ?? goalFromSlug {
+            navigationController.popToRootViewController(animated: false)
+            showGoal(goal)
+        }
+    }
+}

--- a/BeeSwift/SceneDelegate.swift
+++ b/BeeSwift/SceneDelegate.swift
@@ -12,11 +12,15 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     
     var window: UIWindow?
     
+    private var coordinator: MainCoordinator?
+
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         windowScene.requestGeometryUpdate(.iOS(interfaceOrientations: .all))
-        
-        let galleryVC = GalleryViewController(
+
+        let navigationController = UINavigationController()
+        self.coordinator = MainCoordinator(
+            navigationController: navigationController,
             currentUserManager: ServiceLocator.currentUserManager,
             viewContext: ServiceLocator.persistentContainer.viewContext,
             versionManager: ServiceLocator.versionManager,
@@ -25,14 +29,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             requestManager: ServiceLocator.requestManager
         )
         
-        let navigationController = UINavigationController(rootViewController: galleryVC)
-        navigationController.navigationBar.isTranslucent = false
-        navigationController.navigationBar.barStyle = .black
-        navigationController.navigationBar.tintColor = .white
-        
         window = UIWindow(windowScene: windowScene)
         window?.rootViewController = navigationController
         window?.makeKeyAndVisible()
+        
+        coordinator?.start()
     }
     
     func scene(_ scene: UIScene, continue userActivity: NSUserActivity) {

--- a/BeeSwift/Settings/ChooseHKMetricViewController.swift
+++ b/BeeSwift/Settings/ChooseHKMetricViewController.swift
@@ -19,11 +19,13 @@ class ChooseHKMetricViewController: UIViewController {
     let goal: Goal
     private let healthStoreManager: HealthStoreManager
     private let requestManager: RequestManager
+    private weak var coordinator: MainCoordinator?
     
-    init(goal: Goal, healthStoreManager: HealthStoreManager, requestManager: RequestManager) {
+    init(goal: Goal, healthStoreManager: HealthStoreManager, requestManager: RequestManager, coordinator: MainCoordinator) {
         self.goal = goal
         self.healthStoreManager = healthStoreManager
         self.requestManager = requestManager
+        self.coordinator = coordinator
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -142,14 +144,7 @@ extension ChooseHKMetricViewController : UITableViewDelegate, UITableViewDataSou
                 return
             }
 
-            self.navigationController?.pushViewController(
-                ConfigureHKMetricViewController(
-                    goal: self.goal,
-                    metric: metric,
-                    healthStoreManager: self.healthStoreManager,
-                    requestManager: self.requestManager
-                ),
-                animated: true)
+            coordinator?.showConfigureHKMetricForGoal(goal, metric)
         }
     }
     

--- a/BeeSwift/Settings/ConfigureNotificationsViewController.swift
+++ b/BeeSwift/Settings/ConfigureNotificationsViewController.swift
@@ -23,16 +23,22 @@ class ConfigureNotificationsViewController: UIViewController {
     private let viewContext: NSManagedObjectContext
     private let currentUserManager: CurrentUserManager
     private let requestManager: RequestManager
+    private weak var coordinator: MainCoordinator?
     
     private lazy var dataSource: NotificationsTableViewDiffibleDataSource = {
         NotificationsTableViewDiffibleDataSource(goals: [], tableView: tableView)
     }()
     
-    init(goalManager: GoalManager, viewContext: NSManagedObjectContext, currentUserManager: CurrentUserManager, requestManager: RequestManager) {
+    init(goalManager: GoalManager,
+         viewContext: NSManagedObjectContext,
+         currentUserManager: CurrentUserManager,
+         requestManager: RequestManager,
+         coordinator: MainCoordinator) {
         self.goalManager = goalManager
         self.viewContext = viewContext
         self.currentUserManager = currentUserManager
         self.requestManager = requestManager
+        self.coordinator = coordinator
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -240,27 +246,12 @@ extension ConfigureNotificationsViewController: UITableViewDelegate {
             return
         }
         
-        var editNotificationsVC: UIViewController? {
-            switch section {
-            case .defaultNotificationSettings:
-                return EditDefaultNotificationsViewController(
-                    currentUserManager: currentUserManager,
-                    requestManager: requestManager,
-                    goalManager: goalManager,
-                    viewContext: viewContext)
-            case .goalsUsingDefaults, .goalsUsingCustomSettings:
-                guard let goal = self.dataSource.goalAtIndexPath(indexPath) else { return nil }
-                return EditGoalNotificationsViewController(
-                    goal: goal,
-                    currentUserManager: currentUserManager,
-                    requestManager: requestManager,
-                    goalManager: goalManager,
-                    viewContext: viewContext)
-            }
-        }
-        
-        if let editNotificationsVC {
-            self.navigationController?.pushViewController(editNotificationsVC, animated: true)
+        switch section {
+        case .defaultNotificationSettings:
+            coordinator?.showConfigureDefaultNotifications()
+        case .goalsUsingDefaults, .goalsUsingCustomSettings:
+            guard let goal = self.dataSource.goalAtIndexPath(indexPath) else { return }
+            coordinator?.showConfigureNotificationsForGoal(goal)
         }
     }
 }

--- a/BeeSwift/Settings/HealthKitConfigViewController.swift
+++ b/BeeSwift/Settings/HealthKitConfigViewController.swift
@@ -27,15 +27,18 @@ class HealthKitConfigViewController: UIViewController {
     private let viewContext: NSManagedObjectContext
     private let healthStoreManager: HealthStoreManager
     private let requestManager: RequestManager
+    private weak var coordinator: MainCoordinator?
     
     init(goalManager: GoalManager,
          viewContext: NSManagedObjectContext,
          healthStoreManager: HealthStoreManager,
-         requestManager: RequestManager) {
+         requestManager: RequestManager,
+         coordinator: MainCoordinator) {
         self.goalManager = goalManager
         self.viewContext = viewContext
         self.healthStoreManager = healthStoreManager
         self.requestManager = requestManager
+        self.coordinator = coordinator
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -166,17 +169,9 @@ extension HealthKitConfigViewController: UITableViewDelegate, UITableViewDataSou
         let goal = self.goalAt(indexPath)
         
         if !goal.isDataProvidedAutomatically {
-            let chooseHKMetricViewController = ChooseHKMetricViewController(
-                goal: goal,
-                healthStoreManager: healthStoreManager,
-                requestManager: requestManager)
-            self.navigationController?.pushViewController(chooseHKMetricViewController, animated: true)
+            coordinator?.showAssociateHealthKitWithGoal(goal)
         } else if goal.autodata == "apple" {
-            let controller = RemoveHKMetricViewController(
-                goal: goal,
-                requestManager: requestManager,
-                goalManager: goalManager)
-            self.navigationController?.pushViewController(controller, animated: true)
+            coordinator?.showRemoveHealthKitIntegrationFromGoal(goal)
         } else {
             let alert: UIAlertController = {
                 let alert = UIAlertController(title: "Autodata Goal", message: "At the moment we don't have a way for you to swap data sources here yourself for autodata goals", preferredStyle: .alert)

--- a/BeeSwift/SignInViewController.swift
+++ b/BeeSwift/SignInViewController.swift
@@ -21,9 +21,13 @@ class SignInViewController : UIViewController, UITextFieldDelegate {
     var signInButton = BSButton()
     var divider = UIView()
     private let currentUserManager: CurrentUserManager
+    private weak var coordinator: MainCoordinator?
     
-    init(currentUserManager: CurrentUserManager) {
+    init(currentUserManager: CurrentUserManager,
+         coordinator: MainCoordinator?) {
         self.currentUserManager = currentUserManager
+        self.coordinator = coordinator
+        
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -129,15 +133,20 @@ class SignInViewController : UIViewController, UITextFieldDelegate {
         return lackOfCredentials
     }
     
+    private var couldNotSignInAlertController: UIAlertController {
+        let controller = UIAlertController(title: "Could not sign in", message: "Invalid credentials", preferredStyle: .alert)
+        controller.addAction(UIAlertAction(title: "OK", style: .cancel, handler: nil))
+        return controller
+    }
+    
     @objc func handleFailedSignIn(_ notification : Notification) {
-        let failureAC = UIAlertController(title: "Could not sign in", message: "Invalid credentials", preferredStyle: .alert)
-        failureAC.addAction(UIAlertAction(title: "OK", style: .cancel, handler: nil))
-        self.present(failureAC, animated: true, completion: nil)
+        self.present(couldNotSignInAlertController, animated: true, completion: nil)
         MBProgressHUD.hide(for: self.view, animated: true)
     }
     
     @objc func handleSignedIn(_ notification : Notification) {
         MBProgressHUD.hide(for: self.view, animated: true)
+        coordinator?.start()
     }
     
     @objc func signInButtonPressed() {


### PR DESCRIPTION
## Summary
Navigation was somewhat scattered throughout the app and the gallery had a central role. This merge request introduces a class for handling the app's navigation. Eventually it could also help with scenarios like starting the app from cold start with the running timer for a particular goal shown.

*For UI changes including screenshots of before and after is great.*

## Validation
Running the app in the simulator.
Navigating around:
- signing in
- signing out
- viewing gallery
- opening goal from gallery
- opening edit datapoint
- canceling edit datapoint
- opening settings and its children
- opening goal from spotlight result tap
- opening app from tapping notification

Fixes #622


Other Locations:
- [ ] EditDatapointVC dismisses directly upon deleting a datapoint
- [ ] EditDatapointVC dismisses directly upon successfully updating a datapoint
- [ ] AlertVC are still handled around where they are displayed
- [ ] GoalVC shows the SafariVC
- [ ] TimerVC dismisses itself (indirectly)