### PR TITLE
goal not opened when tapping spotlight result

### DIFF
--- a/BeeSwift/AppDelegate.swift
+++ b/BeeSwift/AppDelegate.swift
@@ -176,17 +176,4 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     private func removeAllLocalNotifications() {
         UNUserNotificationCenter.current().removeAllPendingNotificationRequests()
     }
-    func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
-        if userActivity.activityType == CSSearchableItemActionType {
-            guard let goalIdentifier = userActivity.userInfo?[CSSearchableItemActivityIdentifier] as? String else { return false
-            }
-            NotificationCenter.default.post(name: GalleryViewController.NotificationName.openGoal, object: nil, userInfo: ["identifier": goalIdentifier])
-        } else if let intent = userActivity.interaction?.intent as? AddDataIntent {
-            guard let goalSlug = intent.goal else { return false }
-            NotificationCenter.default.post(name: GalleryViewController.NotificationName.openGoal, object: nil, userInfo: ["slug": goalSlug])
-        } else if let goalSlug = userActivity.userInfo?["slug"] {
-            NotificationCenter.default.post(name: GalleryViewController.NotificationName.openGoal, object: nil, userInfo: ["slug": goalSlug])
-        }
-        return true
-    }
 }

--- a/BeeSwift/SceneDelegate.swift
+++ b/BeeSwift/SceneDelegate.swift
@@ -1,17 +1,21 @@
 // Part of BeeSwift. Copyright Beeminder
 
+import CoreSpotlight
 import Foundation
+import OSLog
 import UIKit
 
 import BeeKit
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+    let logger = Logger(subsystem: "com.beeminder.beeminder", category: "SceneDelegate")
+    
     var window: UIWindow?
-
+    
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         windowScene.requestGeometryUpdate(.iOS(interfaceOrientations: .all))
-
+        
         let galleryVC = GalleryViewController(
             currentUserManager: ServiceLocator.currentUserManager,
             viewContext: ServiceLocator.persistentContainer.viewContext,
@@ -25,9 +29,40 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         navigationController.navigationBar.isTranslucent = false
         navigationController.navigationBar.barStyle = .black
         navigationController.navigationBar.tintColor = .white
-
+        
         window = UIWindow(windowScene: windowScene)
         window?.rootViewController = navigationController
         window?.makeKeyAndVisible()
+    }
+    
+    func scene(_ scene: UIScene, continue userActivity: NSUserActivity) {
+        logger.info("\(#function)")
+        
+        var userInfoOfGoalFromSpotlight: [AnyHashable : Any]? {
+            guard userActivity.activityType == CSSearchableItemActionType else { return nil }
+            guard let goalIdentifier = userActivity.userInfo?[CSSearchableItemActivityIdentifier] as? String else { return nil }
+            logger.info("\(#function): continuing from spotlight result, found goal with identifier: \(goalIdentifier)")
+            return ["identifier": goalIdentifier]
+        }
+        
+        var userInfoOfGoalFromIntent: [AnyHashable : Any]? {
+            guard let intent = userActivity.interaction?.intent as? AddDataIntent else { return nil }
+            guard let goalSlug = intent.goal else { return nil }
+            logger.info("\(#function): continuing from intent, found goal named: \(goalSlug)")
+            return ["slug": goalSlug]
+        }
+        
+        var userInfoOfGoalFrom: [AnyHashable : Any]? {
+            guard let goalname = userActivity.userInfo?["slug"] as? String else { return nil }
+            logger.info("\(#function): continuing, found goal named: \(goalname)")
+            return ["slug": goalname]
+        }
+        
+        if let userInfo = userInfoOfGoalFromSpotlight ?? userInfoOfGoalFromIntent ?? userInfoOfGoalFrom {
+            logger.info("\(#function): opening goal")
+            NotificationCenter.default.post(name: GalleryViewController.NotificationName.openGoal,
+                                            object: nil,
+                                            userInfo: userInfo)
+        }
     }
 }


### PR DESCRIPTION
## Summary
Tapping a spotlight result should open not only the beeminder app but also the corresponding goal in the app.

## Validation
Searched for the name of a goal. Tapped the Spotlight result corresponding to beeminder. Noted app was then opened to the goal.


This may have worked before and if so, my guess is that it broke with Commit 758d7fe.
Fixes #626
