### PR TITLE
Do not animate gallery updates

### DIFF
--- a/BeeSwift/Gallery/GalleryViewController.swift
+++ b/BeeSwift/Gallery/GalleryViewController.swift
@@ -478,7 +478,7 @@ class GalleryViewController: UIViewController {
 
 extension GalleryViewController: NSFetchedResultsControllerDelegate {
     func controller(_ controller: NSFetchedResultsController<any NSFetchRequestResult>, didChangeContentWith snapshot: NSDiffableDataSourceSnapshotReference) {
-        dataSource.apply(snapshot as GallerySnapshot, animatingDifferences: true)
+        dataSource.apply(snapshot as GallerySnapshot, animatingDifferences: false)
     }
 }
 


### PR DESCRIPTION
## Summary
Unfortunately `NSFetchedResultsController` does not provide a minimal diff when there are core data updates, instead it provides a snapshot which removes and re-adds all items. When combined with animating changes, this causes a flicker.

Turn off animation so updates are smooth.

## Validation
Ran on device, pulled to refresh on the gallery view, and observed there was not a flicker when data updated.