### PR TITLE
Use incremental goal update

### DIFF
--- a/BeeKit/Managers/CurrentUserManager.swift
+++ b/BeeKit/Managers/CurrentUserManager.swift
@@ -75,6 +75,7 @@ public actor CurrentUserManager {
             username: userDefaults.object(forKey: CurrentUserManager.usernameKey) as! String,
             deadbeat: userDefaults.object(forKey: CurrentUserManager.deadbeatKey) != nil,
             timezone: userDefaults.object(forKey: CurrentUserManager.beemTZKey) as? String ?? "Unknown",
+            updatedAt: Date(timeIntervalSince1970: 0),
             defaultAlertStart: (userDefaults.object(forKey: CurrentUserManager.defaultAlertstartKey) ?? 0) as! Int,
             defaultDeadline: (userDefaults.object(forKey: CurrentUserManager.defaultDeadlineKey) ?? 0) as! Int,
             defaultLeadTime: (userDefaults.object(forKey: CurrentUserManager.defaultLeadtimeKey) ?? 0) as! Int

--- a/BeeKit/Managers/GoalManager.swift
+++ b/BeeKit/Managers/GoalManager.swift
@@ -86,7 +86,7 @@ public actor GoalManager {
 
         // The user may have logged out during the network operation. If so we have nothing to do
         modelContext.refreshAllObjects()
-        guard let user = self.currentUserManager.user(context: modelContext) else { return }
+        guard let user = modelContext.object(with: user.objectID) as? User else { return }
 
         user.updateToMatch(json: userResponse)
         self.updateGoalsFromJson(goalResponse)

--- a/BeeKit/Managers/GoalManager.swift
+++ b/BeeKit/Managers/GoalManager.swift
@@ -77,9 +77,8 @@ public actor GoalManager {
             deletedGoals = JSON(arrayLiteral: [])
         } else {
             // TODO: Use old data to find deleted goals
-            let fudgeFactor: Double = 3 * 30 * 24 * 60 * 60
             logger.notice("Doing incremental update since \(user.updatedAt, privacy: .public)")
-            userResponse = JSON(try await requestManager.get(url: "api/v1/users/{username}.json", parameters: ["diff_since": user.updatedAt.timeIntervalSince1970 + 1 - fudgeFactor])!)
+            userResponse = JSON(try await requestManager.get(url: "api/v1/users/{username}.json", parameters: ["diff_since": user.updatedAt.timeIntervalSince1970 + 1])!)
             goalResponse = userResponse["goals"]
 
             deleteMissingGoals = false

--- a/BeeKit/Model/BeeminderModel.xcdatamodeld/BeeminderModel.xcdatamodel/contents
+++ b/BeeKit/Model/BeeminderModel.xcdatamodeld/BeeminderModel.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22758" systemVersion="23G93" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23605" systemVersion="24B91" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="DataPoint" representedClassName="DataPoint" syncable="YES">
         <attribute name="comment" optional="YES" attributeType="String"/>
         <attribute name="daystampRaw" attributeType="String"/>
@@ -46,6 +46,7 @@
         <attribute name="defaultLeadTime" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="lastModifiedLocal" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="timezone" attributeType="String"/>
+        <attribute name="updatedAt" attributeType="Date" defaultDateTimeInterval="-978278400" usesScalarValueType="YES"/>
         <attribute name="username" attributeType="String"/>
         <relationship name="goals" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Goal" inverseName="owner" inverseEntity="Goal"/>
     </entity>

--- a/BeeKit/Model/User.swift
+++ b/BeeKit/Model/User.swift
@@ -8,6 +8,7 @@ public class User: NSManagedObject {
     @NSManaged public var username: String
     @NSManaged public var deadbeat: Bool
     @NSManaged public var timezone: String
+    @NSManaged public var updatedAt: Date
     @NSManaged public var defaultAlertStart: Int
     @NSManaged public var defaultDeadline: Int
     @NSManaged public var defaultLeadTime: Int
@@ -25,6 +26,7 @@ public class User: NSManagedObject {
                 username: String,
                 deadbeat: Bool,
                 timezone: String,
+                updatedAt: Date,
                 defaultAlertStart: Int,
                 defaultDeadline: Int,
                 defaultLeadTime: Int
@@ -34,6 +36,7 @@ public class User: NSManagedObject {
         self.username = username
         self.deadbeat = deadbeat
         self.timezone = timezone
+        self.updatedAt = updatedAt
         self.defaultAlertStart = defaultAlertStart
         self.defaultDeadline = defaultDeadline
         self.defaultLeadTime = defaultLeadTime
@@ -52,6 +55,7 @@ public class User: NSManagedObject {
         self.username = json["username"].string!
         self.deadbeat = json["deadbeat"].bool!
         self.timezone = json["timezone"].string!
+        self.updatedAt = Date(timeIntervalSince1970: json["updated_at"].double!)
         self.defaultAlertStart = json["default_alertstart"].int!
         self.defaultDeadline = json["default_deadline"].int!
         self.defaultLeadTime = json["default_leadtime"].int!

--- a/BeeKitTests/GoalManagerTests.swift
+++ b/BeeKitTests/GoalManagerTests.swift
@@ -51,11 +51,41 @@ class GoalManagerTests: XCTestCase {
     func testInitialGoalCreation() async throws {
         // Set up mock responses
         let userResponse = """
-        {"username":"theospears_test1","timezone":"America/Los_Angeles","goals":["deletable-goal"],"created_at":1740350064,"updated_at":1740350182,"urgency_load":0,"deadbeat":false,"has_authorized_fitbit":false,"default_leadtime":0,"default_alertstart":34200,"default_deadline":0,"subscription":null,"subs_downto":null,"subs_freq":null,"subs_lifetime":null,"remaining_subs_credit":0,"id":"67bba270d4865fb1a5f556dd"}
+        {
+            "username": "theospears_test1",
+            "timezone": "America/Los_Angeles",
+            "updated_at": 1740350182,
+            "deadbeat": false,
+            "default_leadtime": 0,
+            "default_alertstart": 34200,
+            "default_deadline": 0
+        }
         """
         
         let goalsResponse = """
-        [{"slug":"deletable-goal","title":"We will delete this","description":null,"goalval":null,"rate":1.0,"goaldate":4102444799,"svg_url":"https://cdn.beeminder.com/uploads/e2d311f3-be50-43d4-9210-fbc3d3c5068a.svg","graph_url":"https://cdn.beeminder.com/uploads/e2d311f3-be50-43d4-9210-fbc3d3c5068a.png","thumb_url":"https://cdn.beeminder.com/uploads/e2d311f3-be50-43d4-9210-fbc3d3c5068a-thumb.png","goal_type":"hustler","autodata":null,"healthkitmetric":"","autodata_config":{},"losedate":1740988799,"urgencykey":"FROx;PPRx;DL1740988799;P1000000000;deletable-goal","deadline":0,"leadtime":0,"alertstart":34200,"use_defaults":true,"id":"67bba2e4d4865fb1a5f556e0","ephem":false,"queued":false,"panic":54000,"updated_at":1740350182,"burner":"frontburner","yaw":1,"lane":6,"delta":0,"runits":"d","limsum":"+1 in 7 days","frozen":false,"lost":false,"won":false}]
+        [
+            {
+                "id": "67bba2e4d4865fb1a5f556e0",
+                "slug": "deletable-goal",
+                "title": "We will delete this",
+                "graph_url": "https://cdn.beeminder.com/uploads/e2d311f3-be50-43d4-9210-fbc3d3c5068a.png",
+                "thumb_url": "https://cdn.beeminder.com/uploads/e2d311f3-be50-43d4-9210-fbc3d3c5068a-thumb.png",
+                "healthkitmetric": "",
+                "urgencykey": "FROx;PPRx;DL1740988799;P1000000000;deletable-goal",
+                "deadline": 0,
+                "leadtime": 0,
+                "alertstart": 34200,
+                "use_defaults": true,
+                "queued": false,
+                "limsum": "+1 in 7 days",
+                "safesum": "7 days",
+                "last_touch": "2024-02-23",
+                "init_day": 1740350182,
+                "hhmmformat": false,
+                "won": false,
+                "y_axis": "hours"
+            }
+        ]
         """
         
         mockRequestManager.responses = [
@@ -84,7 +114,21 @@ class GoalManagerTests: XCTestCase {
         
         // Now simulate a deletion update
         let deletionResponse = """
-        {"username":"theospears_test1","timezone":"America/Los_Angeles","goals":[],"created_at":1740350064,"updated_at":1740350657,"urgency_load":0,"deadbeat":false,"has_authorized_fitbit":false,"default_leadtime":0,"default_alertstart":34200,"default_deadline":0,"subscription":null,"subs_downto":null,"subs_freq":null,"subs_lifetime":null,"remaining_subs_credit":0,"id":"67bba270d4865fb1a5f556dd","deleted_goals":[{"id":"67bba2e4d4865fb1a5f556e0","slug":"deletable-goal"}]}
+        {
+            "username": "theospears_test1",
+            "timezone": "America/Los_Angeles",
+            "updated_at": 1740350657,
+            "deadbeat": false,
+            "default_leadtime": 0,
+            "default_alertstart": 34200,
+            "default_deadline": 0,
+            "deleted_goals": [
+                {
+                    "id": "67bba2e4d4865fb1a5f556e0",
+                    "slug": "deletable-goal"
+                }
+            ]
+        }
         """
         
         mockRequestManager.responses = [

--- a/BeeKitTests/GoalManagerTests.swift
+++ b/BeeKitTests/GoalManagerTests.swift
@@ -28,10 +28,9 @@ class GoalManagerTests: XCTestCase {
         currentUserManager = CurrentUserManager(requestManager: mockRequestManager, container: container)
         goalManager = GoalManager(requestManager: mockRequestManager, currentUserManager: currentUserManager, container: container)
         
-        // Set up initial user
         let context = container.viewContext
         let user = User(context: context,
-                        username: "theospears_test1",
+                        username: "test_user",
                         deadbeat: false,
                         timezone: "America/Los_Angeles",
                         updatedAt: Date(timeIntervalSince1970: 1740350182),
@@ -49,10 +48,9 @@ class GoalManagerTests: XCTestCase {
     }
     
     func testInitialGoalCreation() async throws {
-        // Set up mock responses
         let userResponse = """
         {
-            "username": "theospears_test1",
+            "username": "test_user",
             "timezone": "America/Los_Angeles",
             "updated_at": 1740350182,
             "deadbeat": false,
@@ -93,10 +91,8 @@ class GoalManagerTests: XCTestCase {
             "api/v1/users/{username}/goals.json": try JSONSerialization.jsonObject(with: goalsResponse.data(using: .utf8)!, options: [])
         ]
         
-        // Execute refresh
         try await goalManager.refreshGoals()
         
-        // Verify results
         let context = container.viewContext
         context.refreshAllObjects()
         
@@ -109,13 +105,11 @@ class GoalManagerTests: XCTestCase {
     }
     
     func testGoalDeletion() async throws {
-        // First create a goal
         try await testInitialGoalCreation()
         
-        // Now simulate a deletion update
         let deletionResponse = """
         {
-            "username": "theospears_test1",
+            "username": "test_user",
             "timezone": "America/Los_Angeles",
             "updated_at": 1740350657,
             "deadbeat": false,
@@ -135,10 +129,8 @@ class GoalManagerTests: XCTestCase {
             "api/v1/users/{username}.json": try JSONSerialization.jsonObject(with: deletionResponse.data(using: .utf8)!, options: [])
         ]
         
-        // Execute refresh
         try await goalManager.refreshGoals()
         
-        // Verify results
         let context = container.viewContext
         context.refreshAllObjects()
         

--- a/BeeKitTests/GoalManagerTests.swift
+++ b/BeeKitTests/GoalManagerTests.swift
@@ -1,0 +1,104 @@
+import XCTest
+@testable import BeeKit
+import SwiftyJSON
+import CoreData
+import OrderedCollections
+
+class MockRequestManager: RequestManager {
+    var responses: [String: Any] = [:]
+    
+    override func get(url: String, parameters: [String : Any]? = nil) async throws -> Any? {
+        if let response = responses[url] {
+            return response
+        }
+        XCTFail("Unexpected URL requested: \(url)")
+        return nil
+    }
+}
+
+class GoalManagerTests: XCTestCase {
+    var container: BeeminderPersistentContainer!
+    var mockRequestManager: MockRequestManager!
+    var currentUserManager: CurrentUserManager!
+    var goalManager: GoalManager!
+    
+    override func setUpWithError() throws {
+        container = BeeminderPersistentContainer.createMemoryBackedForTests()
+        mockRequestManager = MockRequestManager()
+        currentUserManager = CurrentUserManager(requestManager: mockRequestManager, container: container)
+        goalManager = GoalManager(requestManager: mockRequestManager, currentUserManager: currentUserManager, container: container)
+        
+        // Set up initial user
+        let context = container.viewContext
+        let user = User(context: context,
+                        username: "theospears_test1",
+                        deadbeat: false,
+                        timezone: "America/Los_Angeles",
+                        updatedAt: Date(timeIntervalSince1970: 1740350182),
+                        defaultAlertStart: 34200,
+                        defaultDeadline: 0,
+                        defaultLeadTime: 0)
+        try context.save()
+    }
+    
+    override func tearDownWithError() throws {
+        container = nil
+        mockRequestManager = nil
+        currentUserManager = nil
+        goalManager = nil
+    }
+    
+    func testInitialGoalCreation() async throws {
+        // Set up mock responses
+        let userResponse = """
+        {"username":"theospears_test1","timezone":"America/Los_Angeles","goals":["deletable-goal"],"created_at":1740350064,"updated_at":1740350182,"urgency_load":0,"deadbeat":false,"has_authorized_fitbit":false,"default_leadtime":0,"default_alertstart":34200,"default_deadline":0,"subscription":null,"subs_downto":null,"subs_freq":null,"subs_lifetime":null,"remaining_subs_credit":0,"id":"67bba270d4865fb1a5f556dd"}
+        """
+        
+        let goalsResponse = """
+        [{"slug":"deletable-goal","title":"We will delete this","description":null,"goalval":null,"rate":1.0,"goaldate":4102444799,"svg_url":"https://cdn.beeminder.com/uploads/e2d311f3-be50-43d4-9210-fbc3d3c5068a.svg","graph_url":"https://cdn.beeminder.com/uploads/e2d311f3-be50-43d4-9210-fbc3d3c5068a.png","thumb_url":"https://cdn.beeminder.com/uploads/e2d311f3-be50-43d4-9210-fbc3d3c5068a-thumb.png","goal_type":"hustler","autodata":null,"healthkitmetric":"","autodata_config":{},"losedate":1740988799,"urgencykey":"FROx;PPRx;DL1740988799;P1000000000;deletable-goal","deadline":0,"leadtime":0,"alertstart":34200,"use_defaults":true,"id":"67bba2e4d4865fb1a5f556e0","ephem":false,"queued":false,"panic":54000,"updated_at":1740350182,"burner":"frontburner","yaw":1,"lane":6,"delta":0,"runits":"d","limsum":"+1 in 7 days","frozen":false,"lost":false,"won":false}]
+        """
+        
+        mockRequestManager.responses = [
+            "api/v1/users/{username}.json": try JSONSerialization.jsonObject(with: userResponse.data(using: .utf8)!, options: []),
+            "api/v1/users/{username}/goals.json": try JSONSerialization.jsonObject(with: goalsResponse.data(using: .utf8)!, options: [])
+        ]
+        
+        // Execute refresh
+        try await goalManager.refreshGoals()
+        
+        // Verify results
+        let context = container.viewContext
+        context.refreshAllObjects()
+        
+        let user = try XCTUnwrap(currentUserManager.user(context: context))
+        XCTAssertEqual(user.goals.count, 1)
+        
+        let goal = try XCTUnwrap(user.goals.first)
+        XCTAssertEqual(goal.slug, "deletable-goal")
+        XCTAssertEqual(goal.title, "We will delete this")
+    }
+    
+    func testGoalDeletion() async throws {
+        // First create a goal
+        try await testInitialGoalCreation()
+        
+        // Now simulate a deletion update
+        let deletionResponse = """
+        {"username":"theospears_test1","timezone":"America/Los_Angeles","goals":[],"created_at":1740350064,"updated_at":1740350657,"urgency_load":0,"deadbeat":false,"has_authorized_fitbit":false,"default_leadtime":0,"default_alertstart":34200,"default_deadline":0,"subscription":null,"subs_downto":null,"subs_freq":null,"subs_lifetime":null,"remaining_subs_credit":0,"id":"67bba270d4865fb1a5f556dd","deleted_goals":[{"id":"67bba2e4d4865fb1a5f556e0","slug":"deletable-goal"}]}
+        """
+        
+        mockRequestManager.responses = [
+            "api/v1/users/{username}.json": try JSONSerialization.jsonObject(with: deletionResponse.data(using: .utf8)!, options: [])
+        ]
+        
+        // Execute refresh
+        try await goalManager.refreshGoals()
+        
+        // Verify results
+        let context = container.viewContext
+        context.refreshAllObjects()
+        
+        let user = try XCTUnwrap(currentUserManager.user(context: context))
+        XCTAssertEqual(user.goals.count, 0, "All goals should be deleted")
+    }
+}

--- a/BeeKitTests/GoalManagerTests.swift
+++ b/BeeKitTests/GoalManagerTests.swift
@@ -29,7 +29,7 @@ class GoalManagerTests: XCTestCase {
         goalManager = GoalManager(requestManager: mockRequestManager, currentUserManager: currentUserManager, container: container)
         
         let context = container.viewContext
-        let user = User(context: context,
+        let _ = User(context: context,
                         username: "test_user",
                         deadbeat: false,
                         timezone: "America/Los_Angeles",

--- a/BeeSwift.xcodeproj/project.pbxproj
+++ b/BeeSwift.xcodeproj/project.pbxproj
@@ -136,6 +136,7 @@
 		E5F7C55026113C330095684F /* AddDataIntents.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = E540953B260FB6A100C30784 /* AddDataIntents.intentdefinition */; settings = {ATTRIBUTES = (codegen, ); }; };
 		E5FEFB3824E6FAC800A076BB /* BeeSwiftUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5FEFB3724E6FAC800A076BB /* BeeSwiftUITests.swift */; };
 		E5FEFB4124E6FAFC00A076BB /* LaunchScreenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5FEFB4024E6FAFC00A076BB /* LaunchScreenTests.swift */; };
+		E9D661EBFB2D8EEE8F8DEEA0 /* GoalManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E4BF1F79738C8EB7F63CD31 /* GoalManagerTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -216,6 +217,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0E4BF1F79738C8EB7F63CD31 /* GoalManagerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GoalManagerTests.swift; sourceTree = "<group>"; };
 		9B65F2312CFA6418009674A7 /* DeeplinkGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeeplinkGenerator.swift; sourceTree = "<group>"; };
 		9B8CA57C24B120CA009C86C2 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		9BFB27E82CFE770F0056D10D /* FreshnessIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreshnessIndicatorView.swift; sourceTree = "<group>"; };
@@ -660,6 +662,7 @@
 			isa = PBXGroup;
 			children = (
 				E45470292B60E25C00EE648B /* DaystampTests.swift */,
+				0E4BF1F79738C8EB7F63CD31 /* GoalManagerTests.swift */,
 				E57BE6F12655EBE000BA540B /* Info.plist */,
 			);
 			path = BeeKitTests;
@@ -1101,6 +1104,7 @@
 			files = (
 				E454702A2B60E25C00EE648B /* DaystampTests.swift in Sources */,
 				E4B0A33228C194CA00055EA7 /* AddDataIntents.intentdefinition in Sources */,
+				E9D661EBFB2D8EEE8F8DEEA0 /* GoalManagerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/BeeSwiftTests/GoalTests.swift
+++ b/BeeSwiftTests/GoalTests.swift
@@ -148,7 +148,7 @@ final class GoalTests: XCTestCase {
     }
 
     func createTestUser(context: NSManagedObjectContext) -> User {
-        return User(context: context, username: "test-user", deadbeat: false, timezone: "Etc/UTC", defaultAlertStart: 0, defaultDeadline: 0, defaultLeadTime: 0)
+        return User(context: context, username: "test-user", deadbeat: false, timezone: "Etc/UTC", updatedAt: Date(timeIntervalSince1970: 0), defaultAlertStart: 0, defaultDeadline: 0, defaultLeadTime: 0)
     }
 
 


### PR DESCRIPTION
## Summary
Previously the app would always fetch and update all goals on refresh. This was inefficient both in transfer time and amount of work the server needed to do, leading to slow updates for users with many goals. Now instead we ask the server only for updated goals, leading to a smaller diff.

## Validation
* Launched the app with a test account, loaded a goal, deleted it, confirmed it was gone
* Added unit tests to cover goal creation and deletion