### PR TITLE
Update freshness based on user last updated

### DIFF
--- a/BeeKit/Managers/CurrentUserManager.swift
+++ b/BeeKit/Managers/CurrentUserManager.swift
@@ -108,21 +108,6 @@ public actor CurrentUserManager {
         return user(context: modelContext)?.username
     }
 
-    public func refreshUser() async throws {
-        let response = try await requestManager.get(url: "api/v1/users/\(username!).json", parameters: [:])
-        let responseJSON = JSON(response!)
-
-        guard let user = self.user(context: modelContext) else { return }
-        modelContext.refresh(user, mergeChanges: false)
-        user.updateToMatch(json: responseJSON)
-        try modelContext.save()
-
-        await Task { @MainActor in
-            guard let user = self.user(context: modelContainer.viewContext) else { return }
-            modelContainer.viewContext.refresh(user, mergeChanges: false)
-        }.value
-    }
-
     private func deleteUser() throws {
         // Delete any existing users. We expect at most one, but delete all to be safe.
         modelContext.refreshAllObjects()

--- a/BeeKit/Managers/GoalManager.swift
+++ b/BeeKit/Managers/GoalManager.swift
@@ -26,8 +26,6 @@ public actor GoalManager {
     private let requestManager: RequestManager
     private nonisolated let currentUserManager: CurrentUserManager
 
-    public var goalsFetchedAt : Date? = nil
-
     private var queuedGoalsBackgroundTaskRunning : Bool = false
 
     init(requestManager: RequestManager, currentUserManager: CurrentUserManager, container: BeeminderPersistentContainer) {
@@ -110,7 +108,6 @@ public actor GoalManager {
 
         try modelContext.save()
 
-        self.goalsFetchedAt = Date()
         await performPostGoalUpdateBookkeeping()
     }
 
@@ -227,8 +224,6 @@ public actor GoalManager {
     }
 
     private func resetStateForSignOut() {
-        self.goalsFetchedAt = Date(timeIntervalSince1970: 0)
-
         // TODO: Delete from CoreData
     }
 }

--- a/BeeSwift/Gallery/GalleryViewController.swift
+++ b/BeeSwift/Gallery/GalleryViewController.swift
@@ -340,12 +340,10 @@ class GalleryViewController: UIViewController {
     }
     
     @objc func updateLastUpdatedLabel() {
-        let lastUpdated = self.lastUpdated ?? .distantPast
-        
+        let lastUpdated = currentUserManager.user(context: viewContext)?.lastModifiedLocal ?? .distantPast
         self.freshnessIndicator.update(with: lastUpdated)
     }
-    
-    
+
     func setupHealthKit() {
         Task { @MainActor in
             do {

--- a/BeeSwift/Gallery/GalleryViewController.swift
+++ b/BeeSwift/Gallery/GalleryViewController.swift
@@ -120,7 +120,6 @@ class GalleryViewController: UIViewController {
     
     private typealias GallerySnapshot = NSDiffableDataSourceSnapshot<GalleryViewController.Section, NSManagedObjectID>
     
-    private var lastUpdated: Date?
     private var dataSource: UICollectionViewDiffableDataSource<Section, NSManagedObjectID>!
     
     private let fetchedResultsController: NSFetchedResultsController<Goal>!
@@ -400,12 +399,8 @@ class GalleryViewController: UIViewController {
         self.collectionView.refreshControl?.endRefreshing()
         MBProgressHUD.hide(for: self.view, animated: true)
         self.updateDeadbeatVisibility()
-        
-        Task { [weak self] in
-            self?.lastUpdated = await self?.goalManager.goalsFetchedAt
-            self?.updateLastUpdatedLabel()
-        }
-        
+        self.updateLastUpdatedLabel()
+
         if self.filteredGoals.isEmpty {
             self.noGoalsLabel.isHidden = false
             self.collectionContainer.isHidden = true

--- a/BeeSwift/Settings/EditDefaultNotificationsViewController.swift
+++ b/BeeSwift/Settings/EditDefaultNotificationsViewController.swift
@@ -45,7 +45,7 @@ class EditDefaultNotificationsViewController: EditNotificationsViewController {
             let params = [ "default_leadtime" : leadtime ]
             do {
                 let _ = try await requestManager.put(url: "api/v1/users/{username}.json", parameters: params)
-                try await currentUserManager.refreshUser()
+                try await goalManager.refreshGoals()
             } catch {
                 logger.error("Error setting default leadtime: \(error)")
                 // show alert
@@ -65,7 +65,7 @@ class EditDefaultNotificationsViewController: EditNotificationsViewController {
                 let params = ["default_alertstart" : self.midnightOffsetFromTimePickerView()]
                 do {
                     let _ = try await requestManager.put(url: "api/v1/users/{username}.json", parameters: params)
-                    try await currentUserManager.refreshUser()
+                    try await goalManager.refreshGoals()
                 } catch {
                     logger.error("Error setting default alert start: \(error)")
                     //foo
@@ -76,7 +76,7 @@ class EditDefaultNotificationsViewController: EditNotificationsViewController {
                 let params = ["default_deadline" : self.midnightOffsetFromTimePickerView()]
                 do {
                     let _ = try await requestManager.put(url: "api/v1/users/{username}.json", parameters: params)
-                    try await currentUserManager.refreshUser()
+                    try await goalManager.refreshGoals()
                 } catch {
                     logger.error("Error setting default deadline: \(error)")
                     //foo

--- a/BeeSwift/Settings/EditGoalNotificationsViewController.swift
+++ b/BeeSwift/Settings/EditGoalNotificationsViewController.swift
@@ -141,7 +141,7 @@ class EditGoalNotificationsViewController : EditNotificationsViewController {
                     }
 
                     do {
-                        try await self.currentUserManager.refreshUser()
+                        try await self.goalManager.refreshGoals()
                     } catch {
                         self.logger.error("Error syncing notification defaults")
                         // TODO: Show UI failure

--- a/BeeSwift/Settings/SettingsViewController.swift
+++ b/BeeSwift/Settings/SettingsViewController.swift
@@ -114,8 +114,8 @@ class SettingsViewController: UIViewController {
     @objc private func fetchUser() {
         Task { @MainActor [weak self] in
             self?.tableView.isUserInteractionEnabled = false
-            try? await ServiceLocator.currentUserManager.refreshUser()
-            
+            try? await self?.goalManager.refreshGoals()
+
             self?.tableView.reloadData()
             self?.tableView.layoutIfNeeded()
             self?.tableView.refreshControl?.endRefreshing()


### PR DESCRIPTION
## Summary
We were fetching the last updated time for goals from a variable only stored in memory. This meant when launching the app it would show as 2024 years ago. Now we always update user every time we update goals, instead fetch the version we keep persisted on the user object.

We also replace all usages of refreshUser with refreshGoals so the two are always in sync.

## Validation
Hard quit the app. Launched and observed an appropriate value from a few seconds ago.