### PR TITLE
goal not opened when app is opened with url beeminder://?slug=goalname

### DIFF
--- a/BeeSwift/AppDelegate.swift
+++ b/BeeSwift/AppDelegate.swift
@@ -85,32 +85,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         logger.notice("applicationWillTerminate")
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
     }
-
-    func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any]) -> Bool {
-        logger.notice("application:open:options")
-        if url.scheme == "beeminder" {
-            if let query = url.query {
-                let slugKeyIndex = query.components(separatedBy: "=").firstIndex(of: "slug")
-                let slug = query.components(separatedBy: "=")[(slugKeyIndex?.advanced(by: 1))!]
-
-                NotificationCenter.default.post(name: GalleryViewController.NotificationName.openGoal, object: nil, userInfo: ["slug": slug])
-            }
-        }
-        return true
-    }
-
-    func application(_ application: UIApplication, open url: URL, sourceApplication: String?, annotation: Any) -> Bool {
-        logger.notice("application:open:sourceApplication:annotation")
-        if url.scheme == "beeminder" {
-            if let query = url.query {
-                let slugKeyIndex = query.components(separatedBy: "=").firstIndex(of: "slug")
-                let slug = query.components(separatedBy: "=")[(slugKeyIndex?.advanced(by: 1))!]
-
-                NotificationCenter.default.post(name: GalleryViewController.NotificationName.openGoal, object: nil, userInfo: ["slug": slug])
-            }
-        }
-        return true
-    }
     
     func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
         logger.notice("application:didRegisterForRemoteNotificationsWithDeviceToken")

--- a/BeeSwift/SceneDelegate.swift
+++ b/BeeSwift/SceneDelegate.swift
@@ -65,4 +65,20 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                                             userInfo: userInfo)
         }
     }
+    
+    func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+        logger.info("\(#function)")
+        guard let url = URLContexts.first?.url else { return }
+        
+        logger.info("SceneDelegate: Received URL \(url)")
+        
+        guard
+            let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+            components.scheme == "beeminder",
+            let goalname = components.queryItems?.first(where: { $0.name == "slug" })?.value
+        else { return }
+        
+        NotificationCenter.default.post(name: GalleryViewController.NotificationName.openGoal, object: nil, userInfo: ["slug": goalname])
+    }
+
 }

--- a/BeeSwift/SceneDelegate.swift
+++ b/BeeSwift/SceneDelegate.swift
@@ -78,7 +78,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             let goalname = components.queryItems?.first(where: { $0.name == "slug" })?.value
         else { return }
         
-        NotificationCenter.default.post(name: GalleryViewController.NotificationName.openGoal, object: nil, userInfo: ["slug": goalname])
+        NotificationCenter.default.post(name: GalleryViewController.NotificationName.openGoal,
+                                        object: nil,
+                                        userInfo: ["slug": goalname])
     }
 
 }


### PR DESCRIPTION
## Summary
Opening a link in the format `beeminder://?slug=goalname` previously opened not only the beeminder app but also the corresponding goal in the app.

## Validation
Created text with the url and tapped it such that the app opened. Without the change the app is opened. With the change, the app is opened and the goal is opened within the app.


This worked before. My guess is that it broke with the transition to scene delegate, Commit 758d7fe.

Fixes #642.
