### PR TITLE
sort by recent data and by pledge like website

### DIFF
--- a/BeeSwift/Gallery/GalleryViewController.swift
+++ b/BeeSwift/Gallery/GalleryViewController.swift
@@ -552,7 +552,7 @@ private extension GalleryViewController {
             ]
         case Constants.pledgeGoalSortString:
             return [
-                NSSortDescriptor(keyPath: \Goal.pledge, ascending: true),
+                NSSortDescriptor(keyPath: \Goal.pledge, ascending: false),
                 NSSortDescriptor(keyPath: \Goal.urgencyKey, ascending: true)
             ]
         default:

--- a/BeeSwift/Gallery/GalleryViewController.swift
+++ b/BeeSwift/Gallery/GalleryViewController.swift
@@ -547,7 +547,7 @@ private extension GalleryViewController {
             ]
         case Constants.recentDataGoalSortString:
             return [
-                NSSortDescriptor(keyPath: \Goal.lastTouch, ascending: true),
+                NSSortDescriptor(keyPath: \Goal.lastTouch, ascending: false),
                 NSSortDescriptor(keyPath: \Goal.urgencyKey, ascending: true)
             ]
         case Constants.pledgeGoalSortString:


### PR DESCRIPTION
## Summary
When sorting the gallery by pledge or by recent data, the smallest pledges or least recently update goals were shown first. This is in contrast with what the website does and what the app previously did. The app currently does not provide for easily flipping the direction of these sorting tactics. 

## Validation
Compared the gallery's order on the website with the app.


Bug was introduced in [#607](https://github.com/beeminder/BeeSwift/pull/607/files#diff-a606a3bd59aa90e96475a1104ee2119968cb34b90d9fb33afd497f204dcb03e7L357-L363) where the two previously "reversed" criteria were changed to ascending.