### PR TITLE
Add isDummy and isInitial attributes to DataPoint model

### DIFF
--- a/BeeKit/GoalExtensions.swift
+++ b/BeeKit/GoalExtensions.swift
@@ -80,7 +80,7 @@ extension Goal {
     /// A hint for the value the user is likely to enter, based on past data points
     public var suggestedNextValue: NSNumber? {
         let candidateDatapoints = self.recentData
-            .filter { !$0.isMeta }
+            .filter { !$0.isDummy }
             .sorted(using: [SortDescriptor(\.updatedAt, order: .reverse)])
         
         return candidateDatapoints.first?.value

--- a/BeeKit/Managers/DataPointManager.swift
+++ b/BeeKit/Managers/DataPointManager.swift
@@ -101,7 +101,7 @@ public actor DataPointManager {
         guard let firstDaystamp = healthKitDataPoints.map({ point in point.daystamp }).min() else { return }
 
         let datapoints = try await datapointsSince(goal: goal, daystamp: try! Daystamp(fromString: firstDaystamp.description))
-        let realDatapoints = datapoints.filter{ !$0.isMeta }
+        let realDatapoints = datapoints.filter{ !$0.isDummy && !$0.isInitial }
 
         for newDataPoint in healthKitDataPoints {
             try await self.updateToMatchDataPoint(goal: goal, newDataPoint: newDataPoint, recentDatapoints: realDatapoints)

--- a/BeeKit/Model/BeeminderModel.xcdatamodeld/BeeminderModel2.xcdatamodel/contents
+++ b/BeeKit/Model/BeeminderModel.xcdatamodeld/BeeminderModel2.xcdatamodel/contents
@@ -4,6 +4,8 @@
         <attribute name="comment" optional="YES" attributeType="String"/>
         <attribute name="daystampRaw" attributeType="String"/>
         <attribute name="id" attributeType="String"/>
+        <attribute name="isDummy" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="isInitial" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="lastUpdatedLocal" optional="YES" attributeType="Date" defaultDateTimeInterval="-978307200" usesScalarValueType="NO" elementID="lastUpdatedLocal">
             <userInfo>
                 <entry key="renamingIdentifier" value="lastModifiedLocal"/>

--- a/BeeKit/Model/DataPoint.swift
+++ b/BeeKit/Model/DataPoint.swift
@@ -19,13 +19,17 @@ public class DataPoint: NSManagedObject, BeeDataPoint {
     @NSManaged public var requestid: String
     // The value, e.g., how much you weighed on the day indicated by the timestamp.
     @NSManaged public var value: NSNumber
+    // Whether this is a dummy datapoint
+    @NSManaged public var isDummy: Bool
+    // Whether this is an initial datapoint
+    @NSManaged public var isInitial: Bool
 
     @NSManaged public var updatedAt: Int
 
     /// The last time this record in the CoreData store was updated
     @NSManaged public var lastUpdatedLocal: Date
 
-    public init(context: NSManagedObjectContext, goal: Goal, id: String, comment: String, daystamp: Daystamp, requestid: String, value: NSNumber, updatedAt: Int) {
+    public init(context: NSManagedObjectContext, goal: Goal, id: String, comment: String, daystamp: Daystamp, requestid: String, value: NSNumber, updatedAt: Int, isDummy: Bool = false, isInitial: Bool = false) {
         let entity = NSEntityDescription.entity(forEntityName: "DataPoint", in: context)!
         super.init(entity: entity, insertInto: context)
         self.goal = goal
@@ -35,6 +39,8 @@ public class DataPoint: NSManagedObject, BeeDataPoint {
         self.requestid = requestid
         self.value = value
         self.updatedAt = updatedAt
+        self.isDummy = isDummy
+        self.isInitial = isInitial
         lastUpdatedLocal = Date()
     }
 
@@ -83,6 +89,8 @@ public class DataPoint: NSManagedObject, BeeDataPoint {
         comment = json["comment"].stringValue
         requestid = json["requestid"].stringValue
         updatedAt = json["updated_at"].intValue
+        isDummy = json["is_dummy"].boolValue
+        isInitial = json["is_initial"].boolValue
         lastUpdatedLocal = Date()
     }
 


### PR DESCRIPTION
## Summary
- Add `isDummy` and `isInitial` boolean attributes to DataPoint Core Data model with default false values
- Update DataPoint Swift class with new @NSManaged properties and API deserialization
- Replace isMeta filtering with more granular isDummy/isInitial checks in HealthKit sync and value suggestions

## Test plan
- [ ] Verify Core Data model migration works correctly
- [ ] Test HealthKit sync excludes dummy and initial datapoints
- [ ] Test suggested next value excludes dummy datapoints but allows initial ones
- [ ] Verify API deserialization correctly reads is_dummy and is_initial fields

🤖 Generated with [Claude Code](https://claude.ai/code)