### PR TITLE
Make freshness indicator a bit fuzzy

### DIFF
--- a/BeeSwift/Gallery/GalleryViewController.swift
+++ b/BeeSwift/Gallery/GalleryViewController.swift
@@ -181,7 +181,6 @@ class GalleryViewController: UIViewController {
         
         stackView.addArrangedSubview(self.freshnessIndicator)
         self.updateLastUpdatedLabel()
-        Timer.scheduledTimer(timeInterval: 60, target: self, selector: #selector(GalleryViewController.updateLastUpdatedLabel), userInfo: nil, repeats: true)
         
         stackView.addArrangedSubview(self.deadbeatView)
         updateDeadbeatVisibility()

--- a/BeeSwift/GoalViewController.swift
+++ b/BeeSwift/GoalViewController.swift
@@ -42,7 +42,6 @@ class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTabl
     fileprivate var valueStepper = UIStepper()
     fileprivate var valueDecimalRemnant : Double = 0.0
     fileprivate var goalImageScrollView = UIScrollView()
-    fileprivate var lastUpdatedTimer: Timer?
     fileprivate var countdownLabel = BSLabel()
     
     private lazy var deltasLabel: BSLabel = {
@@ -98,7 +97,6 @@ class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTabl
         }
         
         self.updateLastUpdatedLabel()
-        lastUpdatedTimer = Timer.scheduledTimer(timeInterval: 60, target: self, selector: #selector(GoalViewController.updateLastUpdatedLabel), userInfo: nil, repeats: true)
         
         self.view.addSubview(self.scrollView)
         self.scrollView.snp.makeConstraints { (make) -> Void in
@@ -345,8 +343,6 @@ class GoalViewController: UIViewController,  UIScrollViewDelegate, DatapointTabl
 
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
-        lastUpdatedTimer?.invalidate()
-        lastUpdatedTimer = nil
     }
 
     @objc func onGoalsUpdatedNotification() {


### PR DESCRIPTION
## Summary
The freshness indicator only updates from time to time, so showing a precise number of seconds is a bit misleading. It also leads to thrash when we update data a bunch of times in a row, each showing a slightly different value. Instead show an approximation of how long since last update.

## Validation
Loaded app on device, watched time slowly increase
