### PR TITLE
Support sandbox push notifications for local development

### DIFF
--- a/BeeSwift/AppDelegate.swift
+++ b/BeeSwift/AppDelegate.swift
@@ -126,6 +126,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
     
     private func isDevelopmentBuild() -> Bool {
+        // Simulator builds are always development builds
+        if ProcessInfo.processInfo.environment["SIMULATOR_DEVICE_NAME"] != nil {
+            return true
+        }
+
+        // Check for a mobile provision
         guard let resourcePath = Bundle.main.resourcePath else { return false }
         let provisionPath = (resourcePath as NSString).appendingPathComponent("embedded.mobileprovision")
         return FileManager.default.fileExists(atPath: provisionPath)


### PR DESCRIPTION
## Summary
Local and simulator builds use a different push notification server than production and testflight builds. Tell the beeminder server what type of build we are so it can use the right apns server.


## Validation
None. Looks like something is currently up with the server side part of this, but I want to confirm testflight does the expected thing.