### PR TITLE
Update HealthKit goals and refresh from server in parallel

### DIFF
--- a/BeeKit/Managers/RefreshManager.swift
+++ b/BeeKit/Managers/RefreshManager.swift
@@ -1,0 +1,36 @@
+// Part of BeeSwift. Copyright Beeminder
+
+import Foundation
+import OSLog
+
+public class RefreshManager {
+    private let logger = Logger(subsystem: "com.beeminder.beeminder", category: "RefreshManager")
+    private let healthStoreManager: HealthStoreManager
+    private let goalManager: GoalManager
+    
+    public init(healthStoreManager: HealthStoreManager, goalManager: GoalManager) {
+        self.healthStoreManager = healthStoreManager
+        self.goalManager = goalManager
+    }
+    
+    @MainActor
+    public func refreshGoalsAndHealthKitData() async {
+        await withTaskGroup(of: Void.self) { group in
+            group.addTask {
+                do {
+                    let _ = try await self.healthStoreManager.updateAllGoalsWithRecentData(days: 7)
+                } catch {
+                    self.logger.error("Error updating from healthkit: \(error)")
+                }
+            }
+            
+            group.addTask {
+                do {
+                    try await self.goalManager.refreshGoals()
+                } catch {
+                    self.logger.error("Error refreshing goals: \(error)")
+                }
+            }
+        }
+    }
+}

--- a/BeeKit/ServiceLocator.swift
+++ b/BeeKit/ServiceLocator.swift
@@ -21,4 +21,5 @@ public class ServiceLocator {
     public static let dataPointManager = DataPointManager(requestManager: requestManager, container: persistentContainer)
     public static let healthStoreManager = HealthStoreManager(goalManager: goalManager, container: persistentContainer)
     public static let versionManager = VersionManager(requestManager: requestManager)
+    public static let refreshManager = RefreshManager(healthStoreManager: healthStoreManager, goalManager: goalManager)
 }

--- a/BeeSwift.xcodeproj/project.pbxproj
+++ b/BeeSwift.xcodeproj/project.pbxproj
@@ -111,6 +111,7 @@
 		E4D5BD5F2C6709060007B0BE /* BeeminderSpotlightDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4D5BD5E2C6709060007B0BE /* BeeminderSpotlightDelegate.swift */; };
 		E4E43D8829F39CE800697116 /* LogsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E43D8729F39CE800697116 /* LogsViewController.swift */; };
 		E4E63C6D2C3F9083005E00DA /* DataPointManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E63C6C2C3F9083005E00DA /* DataPointManager.swift */; };
+		E4E63C6F2C3F9086005E00DA /* RefreshManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E63C6E2C3F9085005E00DA /* RefreshManager.swift */; };
 		E4E63C732C5DDE98005E00DA /* GoalExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E63C722C5DDE98005E00DA /* GoalExtensions.swift */; };
 		E4E8DD3B2BE87F890059C64F /* Goal.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E8DD3A2BE87F890059C64F /* Goal.swift */; };
 		E4E8DD3D2BE881440059C64F /* DataPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E8DD3C2BE881440059C64F /* DataPoint.swift */; };
@@ -286,6 +287,7 @@
 		E4D5BD5E2C6709060007B0BE /* BeeminderSpotlightDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeeminderSpotlightDelegate.swift; sourceTree = "<group>"; };
 		E4E43D8729F39CE800697116 /* LogsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogsViewController.swift; sourceTree = "<group>"; };
 		E4E63C6C2C3F9083005E00DA /* DataPointManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataPointManager.swift; sourceTree = "<group>"; };
+		E4E63C6E2C3F9085005E00DA /* RefreshManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefreshManager.swift; sourceTree = "<group>"; };
 		E4E63C722C5DDE98005E00DA /* GoalExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalExtensions.swift; sourceTree = "<group>"; };
 		E4E6427B2910C3AB004F3EA9 /* HealthKitMetric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthKitMetric.swift; sourceTree = "<group>"; };
 		E4E6427F2910C3FB004F3EA9 /* QuantityHealthKitMetric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuantityHealthKitMetric.swift; sourceTree = "<group>"; };
@@ -389,6 +391,7 @@
 				E5C161932423CE9F0045C90D /* VersionManager.swift */,
 				E44CE782299338C500394E87 /* GoalManager.swift */,
 				E4E63C6C2C3F9083005E00DA /* DataPointManager.swift */,
+				E4E63C6E2C3F9085005E00DA /* RefreshManager.swift */,
 			);
 			path = Managers;
 			sourceTree = "<group>";
@@ -1030,6 +1033,7 @@
 				E4E63C732C5DDE98005E00DA /* GoalExtensions.swift in Sources */,
 				E458C8252AD11E01000DCA5C /* BSButton.swift in Sources */,
 				E4E63C6D2C3F9083005E00DA /* DataPointManager.swift in Sources */,
+				E4E63C6F2C3F9086005E00DA /* RefreshManager.swift in Sources */,
 				E458C8172AD11CA7000DCA5C /* TotalSleepMinutes.swift in Sources */,
 				E4E8DD3B2BE87F890059C64F /* Goal.swift in Sources */,
 				E458C80D2AD11C64000DCA5C /* Crypto.swift in Sources */,

--- a/BeeSwift/AppDelegate.swift
+++ b/BeeSwift/AppDelegate.swift
@@ -56,16 +56,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         // Refresh goals when receiving remote notification
         Task { @MainActor in
-            do {
-                let _ = try await ServiceLocator.healthStoreManager.updateAllGoalsWithRecentData(days: 7)
-            } catch {
-                logger.error("Error updating from healthkit: \(error)")
-            }
-            do {
-                try await ServiceLocator.goalManager.refreshGoals()
-            } catch {
-                logger.error("Error refreshing goals: \(error)")
-            }
+            await ServiceLocator.refreshManager.refreshGoalsAndHealthKitData()
         }
     }
 

--- a/BeeSwift/SceneDelegate.swift
+++ b/BeeSwift/SceneDelegate.swift
@@ -77,21 +77,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
     
     func sceneWillEnterForeground(_ scene: UIScene) {
-        refreshGoalsAndLogErrors()
-    }
-    
-    private func refreshGoalsAndLogErrors() {
+        logger.info("\(#function)")
         Task { @MainActor in
-            do {
-                let _ = try await ServiceLocator.healthStoreManager.updateAllGoalsWithRecentData(days: 7)
-            } catch {
-                logger.error("Error updating from healthkit: \(error)")
-            }
-            do {
-                try await ServiceLocator.goalManager.refreshGoals()
-            } catch {
-                logger.error("Error refreshing goals: \(error)")
-            }
+            await ServiceLocator.refreshManager.refreshGoalsAndHealthKitData()
         }
     }
 


### PR DESCRIPTION
## Summary
We were waiting for healthkit updates to complete before downloading refreshed data from the server. However, this update can be pretty slow, making the app feel unresponsive. Just do both in parallel.

## Validation
Launched the app and let it background
Waited a few minutes and relaunched, watched it quickly update.
