### PR TITLE
Update data points based on requestId not date

### DIFF
--- a/BeeKit/Managers/DataPointManager.swift
+++ b/BeeKit/Managers/DataPointManager.swift
@@ -36,14 +36,14 @@ public actor DataPointManager {
         }
     }
 
-    private func updateDatapoint(goal : Goal, datapoint : DataPoint, datapointValue : NSNumber) async throws {
+    private func updateDatapoint(goal : Goal, datapoint : DataPoint, datapointValue : NSNumber, comment: String) async throws {
         let val = datapoint.value
-        if datapointValue == val {
+        if datapointValue == val && comment == datapoint.comment {
             return
         }
         let params = [
             "value": "\(datapointValue)",
-            "comment": "Auto-updated via Apple Health",
+            "comment": comment,
         ]
         let _ = try await requestManager.put(url: "api/v1/users/{username}/goals/\(goal.slug)/datapoints/\(datapoint.id).json", parameters: params)
     }
@@ -136,10 +136,10 @@ public actor DataPointManager {
                 try await deleteDatapoint(goal: goal, datapoint: datapoint)
             }
 
-            if !isApproximatelyEqual(firstDatapoint.value.doubleValue, newDataPoint.value.doubleValue) {
+            if !isApproximatelyEqual(firstDatapoint.value.doubleValue, newDataPoint.value.doubleValue) || firstDatapoint.comment != newDataPoint.comment {
                 logger.notice("Updating datapoint for \(goal.id) with requestId \(newDataPoint.requestid, privacy: .public) from \(firstDatapoint.value) to \(newDataPoint.value)")
 
-                try await updateDatapoint(goal: goal, datapoint: firstDatapoint, datapointValue: newDataPoint.value)
+                try await updateDatapoint(goal: goal, datapoint: firstDatapoint, datapointValue: newDataPoint.value, comment: newDataPoint.comment)
             }
         }
     }

--- a/BeeKit/Managers/DataPointManager.swift
+++ b/BeeKit/Managers/DataPointManager.swift
@@ -109,8 +109,47 @@ public actor DataPointManager {
         let datapoints = try await datapointsSince(goal: goal, daystamp: try! Daystamp(fromString: firstDaystamp.description))
         let realDatapoints = datapoints.filter{ !$0.isDummy && !$0.isInitial }
 
-        for newDataPoint in healthKitDataPoints {
-            try await self.updateToMatchDataPoint(goal: goal, newDataPoint: newDataPoint, recentDatapoints: realDatapoints)
+        // Group healthkit datapoints by day to handle deletion properly
+        let healthKitDataPointsByDay = Dictionary(grouping: healthKitDataPoints) { $0.daystamp }
+        
+        for (daystamp, dayDataPoints) in healthKitDataPointsByDay {
+            try await self.updateToMatchDataPointsForDay(goal: goal, daystamp: daystamp, newDataPoints: dayDataPoints, recentDatapoints: realDatapoints)
+        }
+    }
+
+    private func updateToMatchDataPointsForDay(goal: Goal, daystamp: Daystamp, newDataPoints: [BeeDataPoint], recentDatapoints: [DataPoint]) async throws {
+        let existingDatapointsForDay = datapointsMatchingDaystamp(datapoints: recentDatapoints, daystamp: daystamp)
+        var processedDatapoints: Set<String> = []
+        
+        // Process each new datapoint, matching by requestId if possible
+        for newDataPoint in newDataPoints {
+            if newDataPoint.daystamp < goal.initDaystamp {
+                continue
+            }
+            
+            let matchingDatapoint = existingDatapointsForDay.first { $0.requestid == newDataPoint.requestid }
+            
+            if let existingDatapoint = matchingDatapoint {
+                // Update existing datapoint if value or comment changed
+                if !isApproximatelyEqual(existingDatapoint.value.doubleValue, newDataPoint.value.doubleValue) || existingDatapoint.comment != newDataPoint.comment {
+                    logger.notice("Updating datapoint for \(goal.id) with requestId \(newDataPoint.requestid, privacy: .public) from \(existingDatapoint.value) to \(newDataPoint.value)")
+                    try await updateDatapoint(goal: goal, datapoint: existingDatapoint, datapointValue: newDataPoint.value, comment: newDataPoint.comment)
+                }
+                processedDatapoints.insert(existingDatapoint.requestid)
+            } else {
+                // Create new datapoint
+                let urText = "\(newDataPoint.daystamp.day) \(newDataPoint.value) \"\(newDataPoint.comment)\""
+                logger.notice("Creating new datapoint for \(goal.id, privacy: .public) with requestId \(newDataPoint.requestid, privacy: .public): \(newDataPoint.value, privacy: .private)")
+                try await postDatapoint(goal: goal, urText: urText, requestId: newDataPoint.requestid)
+            }
+        }
+        
+        // Delete any existing datapoints for this day that weren't matched
+        for existingDatapoint in existingDatapointsForDay {
+            if !processedDatapoints.contains(existingDatapoint.requestid) {
+                logger.notice("Deleting obsolete datapoint for \(goal.id) with requestId \(existingDatapoint.requestid, privacy: .public)")
+                try await deleteDatapoint(goal: goal, datapoint: existingDatapoint)
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
Previously when syncing HealthKit data points it was done based on the daystamp. However, we've been assigning unique requestIds for a while now, so switch to instead updating via dataPoint. 

## Validation
Updated unit tests