### PR TITLE
Update iOS simulator runtime to 18.6 in CI tests

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -33,7 +33,7 @@ platform :ios do
     sh("xcrun simctl list devicetypes")
     sh("xcrun simctl list runtimes")
     
-    sh("xcrun simctl create Test-iPhone com.apple.CoreSimulator.SimDeviceType.iPhone-16-Pro com.apple.CoreSimulator.SimRuntime.iOS-18-0")
+    sh("xcrun simctl create Test-iPhone com.apple.CoreSimulator.SimDeviceType.iPhone-16-Pro com.apple.CoreSimulator.SimRuntime.iOS-18-6")
     sleep 5
     sh("xcrun simctl list devices")
     


### PR DESCRIPTION
## Summary
• Updates the Fastlane CI configuration to use iOS 18.6 instead of 18.0 for the test simulator
• This should resolve GitHub test failures by using a more current iOS runtime version

## Test plan
- [x] Updated the simulator runtime version in fastlane/Fastfile:36
- [x] Verify CI tests pass with the new iOS 18.6 runtime

🤖 Generated with [Claude Code](https://claude.ai/code)