### PR TITLE
Allow searching for goals by name in shortcuts

### DIFF
--- a/BeeSwift/Intents/AddDataPointIntent.swift
+++ b/BeeSwift/Intents/AddDataPointIntent.swift
@@ -8,7 +8,7 @@ struct AddDataPointIntent: AppIntent {
     static var title: LocalizedStringResource = "Add Data Point"
     static var description = IntentDescription("Add a data point to a Beeminder goal")
     
-    @Parameter(title: "Goal", optionsProvider: GoalOptionsProvider())
+    @Parameter(title: "Goal")
     var goal: GoalEntity
     
     @Parameter(title: "Value")
@@ -46,9 +46,4 @@ struct AddDataPointIntent: AppIntent {
         }
     }
     
-    private struct GoalOptionsProvider: DynamicOptionsProvider {
-        func results() async throws -> [GoalEntity] {
-            return try await GoalEntityQuery().suggestedEntities()
-        }
-    }
 }

--- a/BeeSwift/Intents/GoalEntityQuery.swift
+++ b/BeeSwift/Intents/GoalEntityQuery.swift
@@ -5,7 +5,7 @@ import AppIntents
 import CoreData
 import BeeKit
 
-struct GoalEntityQuery: EntityQuery {
+struct GoalEntityQuery: EntityStringQuery {
     func entities(for identifiers: [String]) async throws -> [GoalEntity] {
         let container = ServiceLocator.persistentContainer
         let context = container.viewContext
@@ -17,7 +17,7 @@ struct GoalEntityQuery: EntityQuery {
         return try await context.perform {
             let request = NSFetchRequest<Goal>(entityName: "Goal")
             request.predicate = NSPredicate(format: "owner == %@ AND id IN %@", currentUser, identifiers)
-            
+
             let goals = try context.fetch(request)
             return goals.map { GoalEntity(from: $0) }
         }
@@ -35,7 +35,6 @@ struct GoalEntityQuery: EntityQuery {
             let request = NSFetchRequest<Goal>(entityName: "Goal")
             request.predicate = NSPredicate(format: "owner == %@", currentUser)
             request.sortDescriptors = [NSSortDescriptor(key: "urgencyKey", ascending: true)]
-            request.fetchLimit = 20
             
             let goals = try context.fetch(request)
             return goals.map { GoalEntity(from: $0) }

--- a/BeeSwift/Intents/GoalEntityQuery.swift
+++ b/BeeSwift/Intents/GoalEntityQuery.swift
@@ -35,7 +35,8 @@ struct GoalEntityQuery: EntityStringQuery {
             let request = NSFetchRequest<Goal>(entityName: "Goal")
             request.predicate = NSPredicate(format: "owner == %@", currentUser)
             request.sortDescriptors = [NSSortDescriptor(key: "urgencyKey", ascending: true)]
-            
+            request.fetchLimit = 20
+
             let goals = try context.fetch(request)
             return goals.map { GoalEntity(from: $0) }
         }

--- a/BeeSwift/Intents/OpenGoalIntent.swift
+++ b/BeeSwift/Intents/OpenGoalIntent.swift
@@ -9,7 +9,7 @@ struct OpenGoalIntent: AppIntent {
     static var title: LocalizedStringResource = "Open Goal"
     static var description = IntentDescription("Open Beeminder app to view a specific goal or the goal gallery")
 
-    @Parameter(title: "Goal", optionsProvider: GoalOptionsProvider())
+    @Parameter(title: "Goal")
     var goal: GoalEntity?
     
     static var parameterSummary: some ParameterSummary {
@@ -40,11 +40,5 @@ struct OpenGoalIntent: AppIntent {
             }
         }
         return .result()
-    }
-    
-    private struct GoalOptionsProvider: DynamicOptionsProvider {
-        func results() async throws -> [GoalEntity] {
-            return try await GoalEntityQuery().suggestedEntities()
-        }
     }
 }


### PR DESCRIPTION
## Summary
This allows searching for goals by name when adding shortcuts in the shortcut app. Previously this behavior was suppressed by the custom options provider.

## Validation
Went to add a shortcut. Verified a search box appeared. Verified it supported search.
![IMG_1C373BFDA726-1](https://github.com/user-attachments/assets/72d35d0d-0fba-468f-a8e0-6731a2715b4a)
