### PR TITLE
Use app store connect API for fastlane

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ BeeSwift/GoogleService-Info.plist
 BeeSwift/Sentry.sh
 fastlane/test_output/*
 fastlane/report.xml
+# Fastlane app store api credentials
+fastlane/*.p8
 
 
 # Created by https://www.toptal.com/developers/gitignore/api/fastlane,xcode,macos,swift,ruby

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -53,6 +53,15 @@ platform :ios do
     # Ensure that your git status is not dirty
     ensure_git_status_clean
 
+    app_store_connect_api_key(
+      key_id: "DL3L84F9JY",
+      issuer_id: "69a6de78-3567-47e3-e053-5b8c7c11a4d1",
+      key_filepath: "fastlane/AuthKey_DL3L84F9JY.p8",
+      duration: 1200,
+      in_house: false
+    )
+
+
     # Increment the build number (not the version number)
     # Providing the xcodeproj is optional
     increment_build_number(


### PR DESCRIPTION
## Summary
Switch from username/password authentication to using a key for submitting app builds via fastlane. This stops me from being prompted for username and password multiple times every time I want to publish the app.

## Validation
Ran `bundle exec fastlane ios beta` and observed it could deploy without any prompts
