### PR TITLE
Specify destination for CI tests

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -43,6 +43,7 @@ platform :ios do
         include_simulator_logs: true,
         buildlog_path: "fastlane/test_output",
         xcodebuild_formatter: "xcpretty",
+	destination: "platform=iOS Simulator,name-Test-iPhone",
         ensure_devices_found: true,
     )
   end


### PR DESCRIPTION
## Summary
Fastlane tests in github are failing because now iOS 26 is released they were looking for an iOS26 test device and not finding it. Fix this by explicitly naming the simulator that the tests should run under to match the one we create.

## Validation
Verify this PR successfully runs tests
