### PR TITLE
bump IQKeyboardManager

### DIFF
--- a/BeeSwift.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/BeeSwift.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -37,7 +37,7 @@
         "version" : "0.4.2"
       }
     },
-{
+    {
       "identity" : "iqkeyboardcore",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/hackiftekhar/IQKeyboardCore.git",


### PR DESCRIPTION
## Summary

keeping up-to-date but also purposely pulling in fixes of the library when run on iOS 26, such as https://github.com/hackiftekhar/IQKeyboardToolbarManager/commit/831f41c9e8210dac7bf4af05385967a04e621050

