### PR TITLE
laying out the gallery in sync with the keyboard

### DIFF
--- a/BeeSwift/Gallery/GalleryViewController.swift
+++ b/BeeSwift/Gallery/GalleryViewController.swift
@@ -158,12 +158,14 @@ class GalleryViewController: UIViewController {
       self,
       selector: #selector(self.keyboardWillShow),
       name: UIResponder.keyboardWillShowNotification,
-      object: nil)
+      object: nil
+    )
     NotificationCenter.default.addObserver(
       self,
       selector: #selector(self.keyboardWillHide),
       name: UIResponder.keyboardWillHideNotification,
-      object: nil)
+      object: nil
+    )
     self.view.addSubview(self.stackView)
     stackView.snp.makeConstraints { (make) -> Void in
       make.top.left.right.equalToSuperview()
@@ -473,28 +475,21 @@ extension GalleryViewController {
   }
 }
 
-
-private extension GalleryViewController {
-  @objc func keyboardWillShow(_ notification: Notification) {
+extension GalleryViewController {
+  @objc fileprivate func keyboardWillShow(_ notification: Notification) {
     guard self.searchBar.searchTextField.isEditing else { return }
     moveViewWithKeyboard(notification: notification, keyboardWillShow: true)
   }
-  func moveViewWithKeyboard(notification: Notification, keyboardWillShow: Bool) {
+  fileprivate func moveViewWithKeyboard(notification: Notification, keyboardWillShow: Bool) {
     guard let userInfo = notification.userInfo else { return }
-    guard
-      let keyboardDuration = userInfo[UIResponder.keyboardAnimationDurationUserInfoKey] as? Double
-    else { return }
-    guard
-      let curve = userInfo[UIResponder.keyboardAnimationCurveUserInfoKey] as? UInt
-    else { return }
+    guard let keyboardDuration = userInfo[UIResponder.keyboardAnimationDurationUserInfoKey] as? Double else { return }
+    guard let curve = userInfo[UIResponder.keyboardAnimationCurveUserInfoKey] as? UInt else { return }
     let animationOptions = UIView.AnimationOptions(rawValue: curve)
-    UIView.animate(withDuration: keyboardDuration,
-                   delay: 0,
-                   options: animationOptions) { [weak self] in
+    UIView.animate(withDuration: keyboardDuration, delay: 0, options: animationOptions) { [weak self] in
       self?.view.layoutIfNeeded()
     }
   }
-  @objc func keyboardWillHide(_ notification: Notification) {
+  @objc fileprivate func keyboardWillHide(_ notification: Notification) {
     moveViewWithKeyboard(notification: notification, keyboardWillShow: false)
   }
 }


### PR DESCRIPTION
## Summary
When search and subsequently the keyboard were shown, the views of the gallery might jump. This was especially prevalent on an iPhone 15 Pro using the recent tag [6.8 (68)](https://github.com/beeminder/BeeSwift/releases/tag/builds%2Fiosbeta%2F68). With this Merge Request, the gallery updates its views in sync with the animation of the keyboard.


## Validation
ran the app in the simulator (iPhone 17 Pro Max, iOS 26.0)
observed toggling the searchbar's visibility, observed toggling the keyboard's visibility