### PR TITLE
Add dietary fiber HealthKit metric

### DIFF
--- a/BeeKit/HeathKit/HealthKitConfig.swift
+++ b/BeeKit/HeathKit/HealthKitConfig.swift
@@ -120,6 +120,12 @@ public enum HealthKitConfig {
         hkQuantityTypeIdentifier: .dietaryFatTotal
       ),
       QuantityHealthKitMetric(
+        humanText: "Dietary fiber",
+        databaseString: "dietaryFiber",
+        category: .Nutrition,
+        hkQuantityTypeIdentifier: .dietaryFiber
+      ),
+      QuantityHealthKitMetric(
         humanText: "Dietary protein",
         databaseString: "dietaryProtein",
         category: .Nutrition,


### PR DESCRIPTION
Adds dietary fiber as a new Apple Health nutrition metric (following the existing pattern for other nutrition metrics).

Testing: Tested in simulator. Might be worth testing on a physical device first. (I'm not yet able to do that (sorry!) but will do so in the future, after I have the requestSigningKey and all that.)