### PR TITLE
Update fastlane workflow to macOS 26

### DIFF
--- a/.github/workflows/fastlane-tests.yml
+++ b/.github/workflows/fastlane-tests.yml
@@ -9,7 +9,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: macos-15
+    runs-on: macos-26
     timeout-minutes: 30
 
     steps:


### PR DESCRIPTION
## Summary
- Updates the fastlane-tests GitHub workflow to use `macos-26` runner instead of `macos-15`

## Test plan
- [ ] Verify CI workflow runs successfully on the new macOS 26 runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)