### PR TITLE
Remove xcpretty specifier

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -44,6 +44,7 @@ platform :ios do
         include_simulator_logs: true,
         buildlog_path: "fastlane/test_output",
         ensure_devices_found: true,
+        xcodebuild_formatter: "xcbeautify --renderer github-actions",
     )
   end
   lane :build do


### PR DESCRIPTION
## Summary
Remove the explicit choice of xcpretty in fastlane. This should cause xcbeautify to be used by default, falling back to xcpretty if needed.

## Validation
Verify output in build logs
