### PR TITLE
Update fastlane CI simulator from iOS 26.0 to 26.1

### DIFF
--- a/.github/workflows/fastlane-tests.yml
+++ b/.github/workflows/fastlane-tests.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: latest-stable
+        xcode-version: '26.1'
     - uses: actions/checkout@v5
     - name: Use sample configuration
       run: cp BeeKit/Config.swift.sample BeeKit/Config.swift

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -33,12 +33,14 @@ platform :ios do
     sh("xcrun simctl list devicetypes")
     sh("xcrun simctl list runtimes")
     
-    sh("xcrun simctl create Test-iPhone com.apple.CoreSimulator.SimDeviceType.iPhone-17-Pro com.apple.CoreSimulator.SimRuntime.iOS-26-0")
+    sh("xcrun simctl create Test-iPhone com.apple.CoreSimulator.SimDeviceType.iPhone-17-Pro com.apple.CoreSimulator.SimRuntime.iOS-26-1")
     sleep 5
     sh("xcrun simctl list devices")
-    
+
     run_tests(
         scheme: "BeeSwift",
+        destination: "platform=iOS Simulator,name=Test-iPhone,OS=26.1",
+        prelaunch_simulator: true,
         reset_simulator: true,
         include_simulator_logs: true,
         buildlog_path: "fastlane/test_output",


### PR DESCRIPTION
## Summary
- Update simulator runtime from iOS-26-0 to iOS-26-1
- Add explicit destination to run_tests specifying name, platform, and OS version

## Test plan
- [ ] CI tests should pass with the new simulator version

🤖 Generated with [Claude Code](https://claude.com/claude-code)