### PR TITLE
Fix silent error dropping in DataPointManager task groups

### DIFF
--- a/BeeKit/Managers/DataPointManager.swift
+++ b/BeeKit/Managers/DataPointManager.swift
@@ -117,6 +117,7 @@ import SwiftyJSON
           )
         }
       }
+      try await group.waitForAll()
     }
   }
 
@@ -167,6 +168,7 @@ import SwiftyJSON
           }
         }
       }
+      try await group.waitForAll()
     }
   }
 


### PR DESCRIPTION
## Summary
- Add explicit `try await group.waitForAll()` calls at the end of each `withThrowingTaskGroup` block in DataPointManager

## The Problem

The CI build shows warnings:
> no calls to throwing functions occur within 'try' expression

More importantly, **this is actually a bug**: without explicitly calling `waitForAll()`, errors from child tasks are silently discarded when the task group exits.

## Behavior with `waitForAll()`

When one child task fails:
1. Other tasks continue to completion (no cancellation)
2. After ALL tasks finish, the first error is propagated to the caller

This is the correct behavior for DataPointManager - we want all datapoint operations to complete even if some fail, then report the error.

Reference: [Swift Forums discussion](https://forums.swift.org/t/withthrowingtaskgroup-no-calls-to-throwing-functions-occur-within-try-expression/53657)

## Test plan
- [x] Verified error propagation behavior with local test
- [x] Verified that failing tasks don't cancel siblings
- [ ] CI build passes without warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)