### PR TITLE
Update Dependabot config for Swift packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,8 @@ updates:
     schedule:
       interval: "weekly"
 
+  # Maintain dependencies for Swift Package Manager
+  - package-ecosystem: "swift"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Enable automated dependency updates for Swift packages alongside existing GitHub Actions and Bundler updates.