### PR TITLE
Swap slug and title in GoalEntity display representation

### DIFF
--- a/BeeSwift/Intents/GoalEntity.swift
+++ b/BeeSwift/Intents/GoalEntity.swift
@@ -12,15 +12,13 @@ struct GoalEntity: AppEntity, IndexedEntity, Equatable {
   @Property(title: "Slug") var slug: String
   @Property(title: "Title") var title: String
   var thumbUrl: String?
-  var displayRepresentation: DisplayRepresentation {
-    DisplayRepresentation(title: "\(displayTitle)", subtitle: "\(slug)")
-  }
-  var displayTitle: String { return title.isEmpty ? slug : title }
+  var displayRepresentation: DisplayRepresentation { DisplayRepresentation(title: "\(slug)", subtitle: "\(title)") }
+  var displayTitle: String { return slug }
 
   var attributeSet: CSSearchableItemAttributeSet {
     let attributes = defaultAttributeSet
     attributes.displayName = displayTitle
-    attributes.contentDescription = slug
+    attributes.contentDescription = title
     return attributes
   }
 


### PR DESCRIPTION
## Summary
- Show slug as the primary title (instead of title) in Spotlight search and App Intents
- Show title as the subtitle (instead of slug)
- Simplify `displayTitle` to always return slug
- Use title for Spotlight `contentDescription` instead of slug

## Test plan
- [x] All 29 unit tests pass
- [x] SpotlightIndexerTests specifically test GoalEntity indexing

🤖 Generated with [Claude Code](https://claude.com/claude-code)