### PR TITLE
Add RefreshGoalIntent for refreshing autodata via Shortcuts

### DIFF
--- a/BeeKit/Managers/RefreshManager.swift
+++ b/BeeKit/Managers/RefreshManager.swift
@@ -1,16 +1,47 @@
 // Part of BeeSwift. Copyright Beeminder
 
+import CoreData
 import Foundation
 import OSLog
+
+public enum RefreshError: Error {
+  case goalNotFound
+  case manualGoal
+}
 
 public class RefreshManager {
   private let logger = Logger(subsystem: "com.beeminder.beeminder", category: "RefreshManager")
   private let healthStoreManager: HealthStoreManager
   private let goalManager: GoalManager
-  public init(healthStoreManager: HealthStoreManager, goalManager: GoalManager) {
+  private let container: NSPersistentContainer
+
+  public init(healthStoreManager: HealthStoreManager, goalManager: GoalManager, container: NSPersistentContainer) {
     self.healthStoreManager = healthStoreManager
     self.goalManager = goalManager
+    self.container = container
   }
+
+  /// Refresh autodata for a single goal from Apple Health or server.
+  /// Throws RefreshError.manualGoal if the goal has no autodata source.
+  public func refreshGoalAutodata(_ goalID: NSManagedObjectID) async throws {
+    let context = container.viewContext
+    let (autodata, isHealthKit) = try await context.perform {
+      guard let goal = try? context.existingObject(with: goalID) as? Goal else { throw RefreshError.goalNotFound }
+      return (goal.autodata, goal.isLinkedToHealthKit)
+    }
+
+    guard let autodata, !autodata.isEmpty else { throw RefreshError.manualGoal }
+
+    if isHealthKit {
+      try await healthStoreManager.updateWithRecentData(goalID: goalID, days: 7)
+    } else {
+      // Server-side autodata (IFTTT, API, etc.)
+      let goal = try await context.perform { try context.existingObject(with: goalID) as! Goal }
+      try await goalManager.forceAutodataRefresh(goal)
+      try await goalManager.refreshGoal(goalID)
+    }
+  }
+
   @MainActor public func refreshGoalsAndHealthKitData() async {
     await withTaskGroup(of: Void.self) { group in
       group.addTask {

--- a/BeeKit/ServiceLocator.swift
+++ b/BeeKit/ServiceLocator.swift
@@ -28,5 +28,9 @@ public class ServiceLocator {
   public static let dataPointManager = DataPointManager(requestManager: requestManager, container: persistentContainer)
   public static let healthStoreManager = HealthStoreManager(goalManager: goalManager, container: persistentContainer)
   public static let versionManager = VersionManager(requestManager: requestManager)
-  public static let refreshManager = RefreshManager(healthStoreManager: healthStoreManager, goalManager: goalManager)
+  public static let refreshManager = RefreshManager(
+    healthStoreManager: healthStoreManager,
+    goalManager: goalManager,
+    container: persistentContainer
+  )
 }

--- a/BeeSwift/GoalViewController.swift
+++ b/BeeSwift/GoalViewController.swift
@@ -372,12 +372,8 @@ class GoalViewController: UIViewController, UIScrollViewDelegate, DatapointTable
   @objc func refreshButtonPressed() {
     Task { @MainActor in
       do {
-        if self.goal.isLinkedToHealthKit {
-          try await self.healthStoreManager.updateWithRecentData(goalID: self.goal.objectID, days: 7)
-        } else if goal.isDataProvidedAutomatically {
-          // Don't force a refresh for manual goals. While doing so is harmless, it queues the goal which means we show a
-          // lemniscate for a few seconds, making the refresh slower.
-          try await self.goalManager.forceAutodataRefresh(self.goal)
+        if goal.isDataProvidedAutomatically {
+          try await ServiceLocator.refreshManager.refreshGoalAutodata(self.goal.objectID)
         }
         try await self.updateGoalAndInterface()
       } catch {


### PR DESCRIPTION
## Summary
- Adds a new App Intent `RefreshGoalIntent` that refreshes a goal's automatic data
- For Apple Health goals: fetches recent data from HealthKit (7 days)
- For other autodata (IFTTT, API, etc.): triggers server-side refresh via `/refresh_graph.json`
- Returns user-friendly errors for manual goals or if refresh fails

## Usage in Shortcuts
Users can add a "Refresh Goal" action and select any goal with autodata. The intent will:
1. Check if the goal has autodata (error if manual)
2. Refresh via HealthKit or server as appropriate
3. Return a confirmation dialog or error message

## Test plan
- [ ] Build and run the app
- [ ] Open Shortcuts and create a shortcut with "Refresh Goal" action
- [ ] Test with an Apple Health goal → should fetch HealthKit data
- [ ] Test with an IFTTT/API goal → should trigger server refresh
- [ ] Test with a manual goal → should show error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)