### PR TITLE
Fix flaky SpotlightIndexer test by refreshing Core Data context

### DIFF
--- a/BeeSwiftTests/SpotlightIndexerTests.swift
+++ b/BeeSwiftTests/SpotlightIndexerTests.swift
@@ -202,6 +202,10 @@ final class SpotlightIndexerTests: XCTestCase {
     // Delete one goal
     container.viewContext.delete(goal1)
     try container.viewContext.save()
+    // Refresh all objects to ensure the User's goals relationship reflects the deletion.
+    // In production, this happens automatically via NSManagedObjectContextObjectsDidChange
+    // notifications, but in tests we call reindexAllGoals() directly.
+    container.viewContext.refreshAllObjects()
 
     // Second indexing
     await indexer.reindexAllGoals()


### PR DESCRIPTION
## Summary

- Fixes flaky `testDeletedGoalIsRemovedFromIndex` test that was intermittently failing in CI
- The test was failing because Core Data's relationship caching could return stale `user.goals` data after a goal deletion
- Adding `refreshAllObjects()` after save ensures the context reflects the persisted state

**Root cause:** After `delete()` + `save()`, the User object's `goals` relationship could still return cached/faulted data including the deleted goal. In production this isn't an issue because the indexer responds to `NSManagedObjectContextObjectsDidChange` notifications (which fire after Core Data updates its object graph), but the test bypassed this by calling `reindexAllGoals()` directly.

## Test plan

- [x] Ran the test 5 times consecutively - all passed
- [x] Verified the fix addresses the exact failure mode from CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)