### PR TITLE
Remove "Apple" from the refresh descriptor

### DIFF
--- a/BeeSwift/Intents/RefreshGoalIntent.swift
+++ b/BeeSwift/Intents/RefreshGoalIntent.swift
@@ -22,7 +22,7 @@ enum RefreshGoalError: Error, CustomLocalizedStringResourceConvertible {
 struct RefreshGoalIntent: AppIntent {
   static var title: LocalizedStringResource = "Refresh Goal"
   static var description = IntentDescription(
-    "Refresh automatic data for a goal from Health or other connected services"
+    "Refresh automatic data for a goal from HealthKit or other connected services"
   )
 
   @Parameter(title: "Goal") var goal: GoalEntity


### PR DESCRIPTION
Apparently using the word Apple in this field is banned.