### PR TITLE
Add in-app Goal Settings page

### DIFF
--- a/BeeSwift/GoalView/GoalSettingsViewController.swift
+++ b/BeeSwift/GoalView/GoalSettingsViewController.swift
@@ -1,0 +1,167 @@
+// Part of BeeSwift. Copyright Beeminder
+
+import BeeKit
+import CoreData
+import Foundation
+import UIKit
+import UserNotifications
+
+class GoalSettingsViewController: UIViewController {
+  fileprivate var tableView = UITableView(frame: .zero, style: .insetGrouped)
+  fileprivate let cellReuseIdentifier = "goalSettingsTableViewCell"
+  let goal: Goal
+  private let currentUserManager: CurrentUserManager
+  private let requestManager: RequestManager
+  private let goalManager: GoalManager
+  private weak var coordinator: MainCoordinator?
+
+  private var notificationsAuthorized: Bool?
+
+  private enum Row {
+    case notifications
+    case dataSource
+  }
+
+  private var rows: [Row] { [.notifications, .dataSource] }
+
+  init(
+    goal: Goal,
+    currentUserManager: CurrentUserManager,
+    requestManager: RequestManager,
+    goalManager: GoalManager,
+    coordinator: MainCoordinator
+  ) {
+    self.goal = goal
+    self.currentUserManager = currentUserManager
+    self.requestManager = requestManager
+    self.goalManager = goalManager
+    self.coordinator = coordinator
+    super.init(nibName: nil, bundle: nil)
+  }
+
+  required init?(coder aDecoder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    self.title = "Goal Settings"
+    self.view.backgroundColor = .systemBackground
+
+    self.view.addSubview(self.tableView)
+
+    self.tableView.snp.makeConstraints { (make) -> Void in
+      make.left.equalTo(0)
+      make.right.equalTo(0)
+      make.top.equalTo(self.view.safeAreaLayoutGuide.snp.topMargin)
+      make.bottom.equalTo(self.view.snp.bottom)
+    }
+    self.tableView.delegate = self
+    self.tableView.dataSource = self
+    self.tableView.register(UITableViewCell.self, forCellReuseIdentifier: self.cellReuseIdentifier)
+  }
+
+  override func viewWillAppear(_ animated: Bool) {
+    super.viewWillAppear(animated)
+    updateNotificationStatus()
+    tableView.reloadData()
+  }
+
+  private func updateNotificationStatus() {
+    UNUserNotificationCenter.current().getNotificationSettings { [weak self] settings in
+      DispatchQueue.main.async {
+        self?.notificationsAuthorized = settings.authorizationStatus == .authorized
+        self?.tableView.reloadData()
+      }
+    }
+  }
+
+  private var isDataSourceRowTappable: Bool { goal.isLinkedToHealthKit || !goal.isDataProvidedAutomatically }
+
+  private var notificationsSummary: String {
+    guard notificationsAuthorized != false else { return "Disabled" }
+    if goal.useDefaults {
+      return "Using defaults"
+    } else {
+      let days = goal.leadTime
+      if days == 0 {
+        let hours = hoursUntilDeadline
+        if hours == 1 { return "1 hour before" } else { return "\(hours) hours before" }
+      } else if days == 1 {
+        return "1 day before"
+      } else {
+        return "\(days) days before"
+      }
+    }
+  }
+
+  private var hoursUntilDeadline: Int {
+    // alertStart is seconds from midnight (e.g., 8pm = 72000)
+    // deadline can be negative for times after 6am (e.g., 11pm = -3600)
+    // or positive for times 0-6am (e.g., 3am = 10800)
+    var deadlineSeconds = goal.deadline
+    if deadlineSeconds < 0 { deadlineSeconds += 24 * 3600 }
+
+    let alertStartSeconds = goal.alertStart
+
+    var diff = deadlineSeconds - alertStartSeconds
+    if diff <= 0 {
+      // Deadline is before or at alertStart, so it wraps to next day
+      diff += 24 * 3600
+    }
+
+    return diff / 3600
+  }
+
+  private var dataSourceSummary: String {
+    if goal.isLinkedToHealthKit {
+      return goal.humanizedAutodata ?? "Apple Health"
+    } else if !goal.isDataProvidedAutomatically {
+      return "Connect to Apple Health"
+    } else {
+      return goal.humanizedAutodata ?? goal.autodata?.capitalized ?? "Autodata"
+    }
+  }
+}
+
+extension GoalSettingsViewController: UITableViewDataSource, UITableViewDelegate {
+  func numberOfSections(in tableView: UITableView) -> Int { 1 }
+  func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int { rows.count }
+
+  func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+    let cell = UITableViewCell(style: .value1, reuseIdentifier: self.cellReuseIdentifier)
+
+    let row = rows[indexPath.row]
+    switch row {
+    case .notifications:
+      cell.textLabel?.text = "Notifications"
+      cell.detailTextLabel?.text = notificationsSummary
+      cell.accessoryType = .disclosureIndicator
+
+    case .dataSource:
+      cell.textLabel?.text = "Data source"
+      cell.detailTextLabel?.text = dataSourceSummary
+      if isDataSourceRowTappable {
+        cell.accessoryType = .disclosureIndicator
+      } else {
+        cell.accessoryType = .none
+        cell.selectionStyle = .none
+      }
+    }
+    return cell
+  }
+
+  func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+    tableView.deselectRow(at: indexPath, animated: true)
+    let row = rows[indexPath.row]
+    switch row {
+    case .notifications: coordinator?.showConfigureNotificationsForGoal(goal)
+
+    case .dataSource:
+      if goal.isLinkedToHealthKit {
+        coordinator?.showReconfigureHealthKitForGoal(goal)
+      } else if !goal.isDataProvidedAutomatically {
+        coordinator?.showAssociateHealthKitWithGoal(goal)
+      }
+    // Other autodata sources are not tappable
+    }
+  }
+}

--- a/BeeSwift/GoalView/GoalViewController.swift
+++ b/BeeSwift/GoalView/GoalViewController.swift
@@ -323,7 +323,12 @@ class GoalViewController: UIViewController, UIScrollViewDelegate, DatapointTable
         make.right.equalTo(-sideMargin)
       }
     }
-    let menuBarItem = UIBarButtonItem(barButtonSystemItem: .action, target: nil, action: nil)
+    let menuBarItem = UIBarButtonItem(
+      image: UIImage(systemName: "ellipsis.circle"),
+      style: .plain,
+      target: nil,
+      action: nil
+    )
     menuBarItem.menu = createGoalMenu()
     self.navigationItem.rightBarButtonItems = [menuBarItem]
     if !self.goal.hideDataEntry {
@@ -598,6 +603,7 @@ extension DateFormatter {
 
 extension GoalViewController {
   fileprivate enum MenuAction {
+    case inAppSettings
     case goalCommitment
     case goalStop
     case goalData
@@ -607,6 +613,7 @@ extension GoalViewController {
       guard let accessToken = currentUserManager.accessToken else { return nil }
       let destinationUrl: URL
       switch self {
+      case .inAppSettings: return nil
       case .goalCommitment:
         destinationUrl = DeeplinkGenerator.generateDeepLinkToGoalCommitment(username: username, goalName: goalName)
       case .goalStop:
@@ -626,7 +633,7 @@ extension GoalViewController {
     let action: MenuAction
     let imageSystemName: String
   }
-  private func getMenuOptions() -> [MenuOption] {
+  private func getWebMenuOptions() -> [MenuOption] {
     [
       MenuOption(title: "Commitment", action: .goalCommitment, imageSystemName: "signature"),
       MenuOption(title: "Stop/Pause", action: .goalStop, imageSystemName: "pause.fill"),
@@ -636,8 +643,20 @@ extension GoalViewController {
     ]
   }
   private func createGoalMenu() -> UIMenu {
-    let options = getMenuOptions()
-    let actions = options.map { option in
+    // In-app settings action at the top
+    let settingsAction = UIAction(
+      title: "Goal Settings",
+      image: UIImage(systemName: "gearshape"),
+      handler: { [weak self] _ in
+        guard let self else { return }
+        self.coordinator?.showGoalSettings(self.goal)
+      }
+    )
+    let settingsMenu = UIMenu(title: "", options: .displayInline, children: [settingsAction])
+
+    // Web links section
+    let webOptions = getWebMenuOptions()
+    let webActions = webOptions.map { option in
       UIAction(
         title: option.title,
         image: UIImage(systemName: option.imageSystemName),
@@ -656,7 +675,13 @@ extension GoalViewController {
         }
       )
     }
-    return UIMenu(title: "bmndr.com/\(goal.owner.username)/\(goal.slug)", children: actions)
+    let webMenu = UIMenu(
+      title: "bmndr.com/\(goal.owner.username)/\(goal.slug)",
+      options: .displayInline,
+      children: webActions
+    )
+
+    return UIMenu(title: "", children: [settingsMenu, webMenu])
   }
 }
 

--- a/BeeSwift/MainCoordinator.swift
+++ b/BeeSwift/MainCoordinator.swift
@@ -159,6 +159,16 @@ class MainCoordinator {
     )
     navigationController.pushViewController(controller, animated: true)
   }
+  func showGoalSettings(_ goal: Goal) {
+    let controller = GoalSettingsViewController(
+      goal: goal,
+      currentUserManager: currentUserManager,
+      requestManager: requestManager,
+      goalManager: goalManager,
+      coordinator: self
+    )
+    navigationController.pushViewController(controller, animated: true)
+  }
   func showConfigureDefaultNotifications() {
     let controller = EditDefaultNotificationsViewController(
       currentUserManager: currentUserManager,

--- a/BeeSwift/Settings/ConfigureHKMetricViewController.swift
+++ b/BeeSwift/Settings/ConfigureHKMetricViewController.swift
@@ -167,9 +167,12 @@ class ConfigureHKMetricViewController: UIViewController {
     if hasData {
       noDataFoundLabel.snp.updateConstraints { make in make.height.equalTo(0) }
     } else {
-      previewDescriptionLabel.snp.updateConstraints { make in make.height.equalTo(0) }
       noDataFoundLabel.snp.remakeConstraints { make in
-        make.top.equalTo(datapointTableController.view.snp.bottom)
+        if let metricConfig = metricConfigViewController {
+          make.top.equalTo(metricConfig.view.snp.bottom).offset(Layout.componentMargin)
+        } else {
+          make.top.equalTo(self.view.safeAreaLayoutGuide.snp.topMargin).offset(Layout.componentMargin)
+        }
         make.left.equalTo(self.view.safeAreaLayoutGuide.snp.leftMargin).offset(Layout.componentMargin)
         make.right.equalTo(self.view.safeAreaLayoutGuide.snp.rightMargin).offset(-Layout.componentMargin)
       }


### PR DESCRIPTION
## Summary
- Adds a new Goal Settings page accessible from the goal view menu
- Provides quick access to notification settings and data source configuration without leaving the app
- Shows notification status (disabled/using defaults/X days or hours before)
- Shows data source (Apple Health metric, other autodata, or option to connect)
- Menu restructured with Goal Settings at top, web links below with URL header
- Menu icon changed from share icon to ellipsis.circle
- Fixes SnapKit constraint crash in ConfigureHKMetricViewController when no health data is available

## Test plan
- [ ] Navigate to any goal and tap the menu icon (ellipsis.circle)
- [ ] Verify "Goal Settings" appears at the top of the menu, above the URL section
- [ ] Tap "Goal Settings" and verify navigation to the new settings page
- [ ] Verify "Notifications" row shows correct status and navigates to notification settings
- [ ] For an Apple Health goal: verify data source shows the metric name and is tappable
- [ ] For a manual goal: verify data source shows "Connect to Apple Health" and is tappable
- [ ] For other autodata (Fitbit, API, etc.): verify data source shows the name and is NOT tappable
- [ ] Verify all existing web links in the menu still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)