### PR TITLE
Replace deprecated .dance with .socialDance and .cardioDance

### DIFF
--- a/BeeKit/HealthKit/WorkoutMinutesHealthKitMetric.swift
+++ b/BeeKit/HealthKit/WorkoutMinutesHealthKitMetric.swift
@@ -103,7 +103,19 @@ public struct WorkoutActivityTypeInfo {
       identifier: "mindAndBody",
       displayName: "Mind And Body",
       category: .mindBody
-    ), WorkoutActivityTypeInfo(activityType: .dance, identifier: "dance", displayName: "Dance", category: .mindBody),
+    ),
+    WorkoutActivityTypeInfo(
+      activityType: .socialDance,
+      identifier: "socialDance",
+      displayName: "Social Dance",
+      category: .mindBody
+    ),
+    WorkoutActivityTypeInfo(
+      activityType: .cardioDance,
+      identifier: "cardioDance",
+      displayName: "Cardio Dance",
+      category: .mindBody
+    ),
     WorkoutActivityTypeInfo(
       activityType: .cooldown,
       identifier: "cooldown",


### PR DESCRIPTION
The HKWorkoutActivityType.dance API was deprecated in iOS 18. Apple recommends using the more specific .socialDance (for ballroom, swing, salsa, etc.) and .cardioDance (for Zumba, aerobics dance, etc.) types instead.
