### PR TITLE
some typos in logger

### DIFF
--- a/BeeKit/ServiceLocator.swift
+++ b/BeeKit/ServiceLocator.swift
@@ -10,7 +10,7 @@ import Foundation
 import OSLog
 
 public class ServiceLocator {
-  private static let logger = Logger(subsystem: "com.beeminder.beeminder", category: "ServiceLocationm")
+  private static let logger = Logger(subsystem: "com.beeminder.beeminder", category: "ServiceLocator")
 
   public static let persistentContainer = BeeminderPersistentContainer.create()
 

--- a/BeeSwift/Components/GoalImageView.swift
+++ b/BeeSwift/Components/GoalImageView.swift
@@ -8,7 +8,7 @@ import OSLog
 /// Handles placeholders for loading and queued states, and automatically updates when the goal changes
 class GoalImageView: UIView {
   private static let downloader = ImageDownloader(imageCache: AutoPurgingImageCache())
-  private let logger = Logger(subsystem: "com.beeminder.com", category: "GoalImageView")
+  private let logger = Logger(subsystem: "com.beeminder.beeminder", category: "GoalImageView")
 
   private let imageView = UIImageView()
   private let beeLemniscateView = BeeLemniscateView()

--- a/BeeSwift/GoalView/GoalViewController.swift
+++ b/BeeSwift/GoalView/GoalViewController.swift
@@ -23,7 +23,7 @@ class GoalViewController: UIViewController, UIScrollViewDelegate, DatapointTable
   let sideMargin = 10
   let buttonHeight = 42
 
-  private let logger = Logger(subsystem: "com.beeminder.com", category: "GoalViewController")
+  private let logger = Logger(subsystem: "com.beeminder.beeminder", category: "GoalViewController")
 
   let goal: Goal
   private let healthStoreManager: HealthStoreManager


### PR DESCRIPTION
## Summary
most loggers were subsystem: "com.beeminder.beeminder"
and ServiceLocation's logger had a typo in its category