### PR TITLE
Fix incompatible Package.resolved pins and add CI guard

### DIFF
--- a/.github/workflows/fastlane-tests.yml
+++ b/.github/workflows/fastlane-tests.yml
@@ -37,6 +37,13 @@ jobs:
       run: defaults write com.apple.dt.Xcode IDESkipMacroFingerprintValidation -bool YES
     - name: Run tests
       run: bundle exec fastlane ci
+    - name: Verify Package.resolved is consistent
+      run: |
+        if ! git diff --quiet BeeSwift.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved; then
+          echo "::error::Package.resolved was modified during build. This means the checked-in versions are incompatible with the project's dependency constraints. Diff:"
+          git diff BeeSwift.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+          exit 1
+        fi
     - name: Upload report
       uses: actions/upload-artifact@v7
       if: always() # always run even if the previous step fails

--- a/BeeSwift.xcodeproj/project.pbxproj
+++ b/BeeSwift.xcodeproj/project.pbxproj
@@ -1077,7 +1077,7 @@
 			repositoryURL = "https://github.com/evgenyneu/keychain-swift";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 20.0.0;
+				minimumVersion = 24.0.0;
 			};
 		};
 		E462BA3429AC44EA00E80EF0 /* XCRemoteSwiftPackageReference "Alamofire" */ = {

--- a/BeeSwift.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/BeeSwift.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -159,8 +159,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
-        "revision" : "9de99a78f099e59caf2b2beec65a4c45d54b2081",
-        "version" : "603.0.1"
+        "revision" : "2b59c0c741e9184ab057fd22950b491076d42e91",
+        "version" : "603.0.0"
       }
     },
     {

--- a/BeeSwift.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/BeeSwift.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -159,8 +159,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
-        "revision" : "2b59c0c741e9184ab057fd22950b491076d42e91",
-        "version" : "603.0.0"
+        "revision" : "4799286537280063c85a32f09884cfbca301b1a1",
+        "version" : "602.0.0"
       }
     },
     {


### PR DESCRIPTION
## Summary
- Revert swift-syntax from 603.0.1 to 602.0.0 — CoreDataEvolution constrains it to `<603.0.0`, so 603.x was never valid
- Bump keychain-swift project constraint from `upToNextMajorVersion: 20.0.0` (allows 20.x only) to `24.0.0` to match the Dependabot pin
- Add CI check that fails if Package.resolved is modified during build, catching future incompatible Dependabot bumps

Both issues caused Xcode to silently re-resolve to different package versions on every build, producing spurious local diffs.

## Test plan
- [x] Open project in Xcode — verify no Package.resolved changes on resolve
- [x] Build succeeds
- [x] CI check passes (Package.resolved unchanged after build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)