### PR TITLE
polish after gallery sort - one less entry for settings

### DIFF
--- a/BeeSwift/Settings/SettingsViewController.swift
+++ b/BeeSwift/Settings/SettingsViewController.swift
@@ -120,7 +120,7 @@ extension SettingsViewController: UITableViewDataSource, UITableViewDelegate {
     CGFloat.leastNormalMagnitude
   }
   func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat { 20 }
-  func numberOfSections(in tableView: UITableView) -> Int { 5 }
+  func numberOfSections(in tableView: UITableView) -> Int { 4 }
   func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int { 1 }
   func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
     guard


### PR DESCRIPTION
## Summary
Settings has now up to 4 entries, after #616. Code was still drawing rows for 5.


