### PR TITLE
Remove references to unused config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,9 +20,6 @@ xcuserdata/
 *.xcbkptlist
 /build
 BeeKit/Config.swift
-BeeSwift/Config.swift
-BeeSwift/GoogleService-Info.plist
-BeeSwift/Sentry.sh
 fastlane/test_output/*
 fastlane/report.xml
 # Fastlane app store api credentials

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -4,15 +4,11 @@ This is a guide to getting the Beeminder app running in your Xcode Simulator/tes
 
 #### Installation/Setup
 
-The file BeeSwift/Config.swift is ignored by git since it has sensitive info like keys in it. Copy BeeSwift/Config.sample.swift to BeeSwift/Config.swift and uncomment the struct it contains so that the project can reference the struct.
-
-You can also copy BeeKit/Config.sample.swift to BeeKit/Config.swift, or create the file BeeKit/Config.swift that at least contains:
+Copy BeeKit/Config.sample.swift to BeeKit/Config.swift, or create the file BeeKit/Config.swift that at least contains:
 
     public struct Config {
           public let baseURLString = "https://www.beeminder.com"
     }
-
-There's a Run Script build phase that references BeeSwift/Sentry.sh, which is also ignored by git since it has an auth token. Either create an empty shell script at that location (preferable) or delete the Run Script - Sentry build phase (if you do delete it, make sure not to check in the modified project.pbxproj file).
 
 The project should build at this point and run in the simulator.
 


### PR DESCRIPTION
## Summary

`BeeSwift/Config.swift`, `BeeSwift/GoogleService-Info.plist`, and `BeeSwift/Sentry.sh` are not referenced anywhere in `BeeSwift.xcodeproj/project.pbxproj` (there is no Sentry "Run Script" build phase), and the `Fastlane Tests` workflow builds the `BeeSwift` scheme with only `BeeKit/Config.swift` present. Their `.gitignore` entries and the `GETTING_STARTED.md` setup instructions are therefore stale and misleading to new contributors.

- Drop the three stale `.gitignore` entries.
- Remove the out-of-date `GETTING_STARTED.md` instructions (the `BeeSwift/Config.swift` copy step and the non-existent `Sentry.sh` Run Script build phase).
- The still-required `BeeKit/Config.swift` ignore entry and setup instruction are left untouched.

Scoped intentionally to *references*: the tracked `BeeSwift/Config.sample.swift` file and its `project.pbxproj` synchronized-group exception entry are left in place (removing them is a deeper, riskier change that can be done separately if desired).

## Test plan

- [ ] CI (`Fastlane Tests`, pre-commit, CodeQL) green — these are documentation/ignore-only changes with no build impact.
- [ ] Confirm a fresh clone following the updated `GETTING_STARTED.md` still builds.

https://claude.ai/code/session_016a6ivCc3wjKG8osTb4h8Fx

---
_Generated by [Claude Code](https://claude.ai/code/session_016a6ivCc3wjKG8osTb4h8Fx)_