### PR TITLE
Pin GitHub Actions workflows to commit SHAs

### DIFF
--- a/.github/workflows/fastlane-tests.yml
+++ b/.github/workflows/fastlane-tests.yml
@@ -16,20 +16,20 @@ jobs:
     timeout-minutes: 30
 
     steps:
-    - uses: maxim-lobanov/setup-xcode@v1
+    - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
       with:
         xcode-version: '26.1'
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
     - name: Use sample configuration
       run: cp BeeKit/Config.swift.sample BeeKit/Config.swift
-    - uses: actions/cache@v5
+    - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
       with:
         path: SPMCache
         key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
         restore-keys: |
           ${{ runner.os }}-spm-
     - name: Setup ruby and install gems
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@6aaa311d81eba98ae12eaffbcb63296ace0efcde # v1.307.0
       with:
         ruby-version: '3.3.5'
         bundler-cache: true
@@ -45,13 +45,13 @@ jobs:
           exit 1
         fi
     - name: Upload report
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       if: always() # always run even if the previous step fails
       with:
         name: test-output
         path: fastlane/test_output
     - name: Publish Test Report
-      uses: mikepenz/action-junit-report@v6
+      uses: mikepenz/action-junit-report@bccf2e31636835cf0874589931c4116687171386 # v6
       if: always() # always run even if the previous step fails
       with:
         report_paths: 'fastlane/test_output/report.junit'

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -16,12 +16,12 @@ jobs:
     runs-on: macos-15
 
     steps:
-    - uses: maxim-lobanov/setup-xcode@v1
+    - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
       with:
         xcode-version: latest-stable
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
       with:
         python-version: '3.x'
     - name: Install pre-commit


### PR DESCRIPTION
## Summary

Pins every third-party action in the existing workflows to a full commit SHA (with the version in a trailing comment) instead of a mutable tag. A floating tag (`@v1`, `@v6`, …) can be force-repointed by the upstream maintainer or an attacker who compromises the action, silently executing untrusted code in CI. SHA pinning makes each action immutable and upgrades explicit/reviewable.

Workflows updated (both on `master`):
- `.github/workflows/fastlane-tests.yml` — `setup-xcode`, `checkout`, `cache`, `setup-ruby`, `upload-artifact`, `action-junit-report`
- `.github/workflows/pre-commit.yml` — `setup-xcode`, `checkout`, `setup-python`

Notes:
- Only `uses:` lines changed (9 lines); no behavioural change.
- SHAs were resolved from the upstream tag refs. `maxim-lobanov/setup-xcode@v1` is an annotated tag, so its peeled commit is used. `ruby/setup-ruby@v1` is a branch (not a tag), so it is pinned to the equivalent release `v1.307.0` for precise tracking.
- `.github/dependabot.yml` already has the `github-actions` ecosystem, so Dependabot will keep these SHAs (and the version comments) current via reviewable PRs.

## Test plan

- [ ] CI green on this PR (`Fastlane Tests`, `Pre-commit Check`, CodeQL) — confirms every pinned SHA resolves and the actions behave identically.

https://claude.ai/code/session_016a6ivCc3wjKG8osTb4h8Fx

---
_Generated by [Claude Code](https://claude.ai/code/session_016a6ivCc3wjKG8osTb4h8Fx)_