### PR TITLE
Raise fastlane -showBuildSettings timeout in CI workflows

### DIFF
--- a/.github/workflows/fastlane-tests.yml
+++ b/.github/workflows/fastlane-tests.yml
@@ -36,6 +36,14 @@ jobs:
     - name: Enable Macros
       run: defaults write com.apple.dt.Xcode IDESkipMacroFingerprintValidation -bool YES
     - name: Run tests
+      env:
+        # Cold SPM cache (e.g. on a dependency-bump PR that changes
+        # Package.resolved and invalidates the cache key) makes
+        # `xcodebuild -showBuildSettings` block on package resolution
+        # longer than fastlane's default ~45s retry budget. Give it room
+        # instead of failing the test run.
+        FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: '180'
+        FASTLANE_XCODEBUILD_SETTINGS_RETRIES: '5'
       run: bundle exec fastlane ci
     - name: Verify Package.resolved is consistent
       run: |

--- a/.github/workflows/testflight-weekly.yml
+++ b/.github/workflows/testflight-weekly.yml
@@ -87,6 +87,12 @@ jobs:
         ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
         ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
         ASC_KEY_P8_BASE64: ${{ secrets.ASC_KEY_P8_BASE64 }}
+        # Cold SPM cache (e.g. after a dependency bump invalidates the
+        # Package.resolved cache key) makes `xcodebuild -showBuildSettings`
+        # block on package resolution longer than fastlane's default
+        # ~45s retry budget. Give it room instead of failing the build.
+        FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: '180'
+        FASTLANE_XCODEBUILD_SETTINGS_RETRIES: '5'
       run: bundle exec fastlane beta_ci
     - name: Update ci-latest pointer
       if: success()


### PR DESCRIPTION
## Problem

The [weekly TestFlight build failed](https://github.com/beeminder/BeeSwift/actions/runs/25948784618/job/76282381541) with:

\`\`\`
xcodebuild -showBuildSettings timed out after 4 retries with a base timeout of 3.
\`\`\`

This is **not a code issue**. Fastlane runs \`xcodebuild -showBuildSettings\` to read build settings, retrying with escalating timeouts (3 → 6 → 12 → 24s, ~45s total). All four attempts timed out.

**Root cause:** the recent Alamofire (#774) and swift-collections (#775) bumps changed \`Package.resolved\`, which invalidated the SPM cache key (\`hashFiles('**/Package.resolved')\`). The build then ran with a cold package graph — the log shows the \`swift-syntax\` macro prebuilt being downloaded mid-step — so \`-showBuildSettings\` blocked on package resolution longer than fastlane's default retry budget.

## Fix

Set \`FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT\` / \`FASTLANE_XCODEBUILD_SETTINGS_RETRIES\` (global fastlane env vars, honored by both \`gym\`/\`build_app\` and \`scan\`/\`run_tests\`) so cold-cache package resolution has room to complete.

Applied to **both** workflows:

- \`testflight-weekly.yml\` — where the failure occurred (runs weekly, most likely to hit a stale cache).
- \`fastlane-tests.yml\` — same SPM cache setup; lower-risk in practice (runs on every PR/push so the cache is usually warm via \`restore-keys\`), but a dependency-bump PR is exactly the cold-cache scenario you want to keep green.

No behavioral change when the cache is warm — the timeout only matters when \`-showBuildSettings\` is slow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)