### PR TITLE
Simulator Runtime 26.1 no longer available

### DIFF
--- a/.github/workflows/fastlane-tests.yml
+++ b/.github/workflows/fastlane-tests.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
     - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
       with:
-        xcode-version: '26.1'
+        xcode-version: '26.5'
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
     - name: Use sample configuration
       run: cp BeeKit/Config.swift.sample BeeKit/Config.swift

--- a/.github/workflows/testflight-weekly.yml
+++ b/.github/workflows/testflight-weekly.yml
@@ -54,7 +54,7 @@ jobs:
     steps:
     - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
       with:
-        xcode-version: '26.1'
+        xcode-version: '26.5'
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
     - name: Write BeeKit configuration
       env:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -36,13 +36,13 @@ platform :ios do
     sh("xcrun simctl list devicetypes")
     sh("xcrun simctl list runtimes")
     
-    sh("xcrun simctl create Test-iPhone com.apple.CoreSimulator.SimDeviceType.iPhone-17-Pro com.apple.CoreSimulator.SimRuntime.iOS-26-1")
+    sh("xcrun simctl create Test-iPhone com.apple.CoreSimulator.SimDeviceType.iPhone-17-Pro com.apple.CoreSimulator.SimRuntime.iOS-26-5")
     sleep 5
     sh("xcrun simctl list devices")
 
     run_tests(
         scheme: "BeeSwift",
-        destination: "platform=iOS Simulator,name=Test-iPhone,OS=26.1",
+        destination: "platform=iOS Simulator,name=Test-iPhone,OS=26.5",
         prelaunch_simulator: true,
         reset_simulator: true,
         include_simulator_logs: true,


### PR DESCRIPTION
bumped to iOS Simulator 26.5 and to Xcode 26.5.

addresses #787

## Summary
[runner macOS-26](https://github.com/actions/runner-images/blob/main/images/macos/macos-26-Readme.md) appears to no longer contain 26.1. Bumped the fastlane test target to use 26.5 instead.