### PR TITLE
Clean up 6.8 changelog entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,19 +9,16 @@
  * Filter which workout types are included when syncing workout minutes from Apple Health (#709)
 
 🙌 Improvements
- * Move the gallery sort control onto the gallery screen itself, with a native menu and checkmark for the selected order (#616, #769, #771)
+ * Move the gallery sort control onto the gallery screen itself, with a native menu and checkmark for the selected order (#616, #769)
  * Show the full configuration preview when reconfiguring an Apple Health goal (#714)
  * Display Goal, Metric, and Unit info at the top of the HealthKit metric configuration screen (#712)
  * Datapoint list now uses three aligned columns (day, value, comment) (#713)
  * Set sensible default precision for Exercise Minutes, Workout Minutes, and Water (#668)
- * Refactor HealthKit authorization flow and improve error handling (#742)
  * Rename refresh descriptor to drop "Apple" (#721)
 
 🐛 Bugfix
  * Edit Notifications: 24h-mode picker now shows the right values, and deadlines can be set (#619)
  * Goal thumbnail border no longer breaks when the goal is in deadbeat state (#749)
- * Replace deprecated `.dance` workout type with `.socialDance` / `.cardioDance` for iOS 18 (#729)
- * Avoid focus warning by lazily initializing SKView (#715)
 
 ⚠️  API Changes
  * 
@@ -36,7 +33,7 @@
  * Fix project settings for distribution (#722)
  * Add an automated weekly TestFlight build via fastlane match (#776)
  * Pin GitHub Actions workflows to commit SHAs for supply-chain safety (#778)
- * Guard against incompatible Package.resolved pins in CI (#770)
+ * Fix incompatible Package.resolved pins and guard against them in CI (#770)
  * Update third-party package and rubygem versions (#732 plus numerous dependabot bumps)
 
 Others

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@
  * Fix project settings for distribution (#722)
  * Add an automated weekly TestFlight build via fastlane match (#776)
  * Pin GitHub Actions workflows to commit SHAs for supply-chain safety (#778)
- * Fix incompatible Package.resolved pins and guard against them in CI (#770)
+ * Guard against incompatible Package.resolved pins in CI (#770)
  * Update third-party package and rubygem versions (#732 plus numerous dependabot bumps)
 
 Others


### PR DESCRIPTION
Follow-up to the 6.8 CHANGELOG merged in #781. After @krugerk's review and a closer audit of each entry against its PR, this trims a few items that don't belong in a user-facing changelog comparing 6.8 to 6.7 — mainly intra-cycle churn (changes introduced and resolved within 6.8, so never shipped in 6.7) and internal-only refactors.

Documentation only; no code changes.

https://claude.ai/code/session_01PdrB3jRc94ZS4fBwVqJoRN