### PR TITLE
Gallery is only responsible for showing goals list

### DIFF
--- a/BeeKit/Managers/HealthStoreManager.swift
+++ b/BeeKit/Managers/HealthStoreManager.swift
@@ -34,12 +34,26 @@ import OSLog
   /// Protect concurrent modifications to the connections dictionary
   private nonisolated let monitorsSemaphore = DispatchSemaphore(value: 1)
 
+  private var lastSyncedMetricNames: Set<String>? = nil
+
   init(goalManager: GoalManager, container: NSPersistentContainer) {
     self.goalManager = goalManager
     self.modelContainer = container
     let context = container.newBackgroundContext()
     context.name = "HealthStoreManager"
     self.modelExecutor = .init(context: context)
+  }
+
+  public func listenForGoalChanges() async {
+    let objectsDidChange = NotificationCenter.default.notifications(
+      named: .NSManagedObjectContextObjectsDidChange,
+      object: modelContainer.viewContext,
+    )
+    for await _ in objectsDidChange {
+      do { try await ensureGoalsUpdateRegularly() } catch {
+        logger.error("Failed to ensure goals update regularly after goals changed: \(error)")
+      }
+    }
   }
 
   /// Request acess to HealthKit data for the supplied metric
@@ -69,10 +83,18 @@ import OSLog
       return
     }
     let metrics = goals.compactMap { $0.healthKitMetric }.filter { $0 != "" }
+    let metricSet = Set(metrics)
+
+    guard metricSet != lastSyncedMetricNames else { return }
     logger.notice(
       "ensureGoalsUpdateRegularly: Found \(goals.count, privacy: .public) goals, \(metrics.count, privacy: .public) with HealthKit metrics: \(metrics.joined(separator: ", "))"
     )
-    return try await ensureUpdatesRegularly(metricNames: metrics, removeMissing: true)
+    let previous = lastSyncedMetricNames
+    lastSyncedMetricNames = metricSet
+    do { try await ensureUpdatesRegularly(metricNames: metrics, removeMissing: true) } catch {
+      lastSyncedMetricNames = previous
+      throw error
+    }
   }
 
   /// Install observers for any goals we currently have permission to read

--- a/BeeSwift/AppDelegate.swift
+++ b/BeeSwift/AppDelegate.swift
@@ -46,6 +46,7 @@ import UIKit
       ServiceLocator.healthStoreManager.silentlyInstallObservers(
         context: ServiceLocator.persistentContainer.viewContext
       )
+      Task { await ServiceLocator.healthStoreManager.listenForGoalChanges() }
     }
     NetworkActivityIndicatorManager.shared.isEnabled = true
     UNUserNotificationCenter.current().delegate = self

--- a/BeeSwift/Gallery/GalleryViewController.swift
+++ b/BeeSwift/Gallery/GalleryViewController.swift
@@ -137,12 +137,6 @@ class GalleryViewController: UIViewController {
       name: UserDefaults.didChangeNotification,
       object: nil,
     )
-    NotificationCenter.default.addObserver(
-      self,
-      selector: #selector(self.handleSignIn),
-      name: CurrentUserManager.NotificationName.signedIn,
-      object: nil,
-    )
     self.view.addSubview(self.stackView)
     stackView.snp.makeConstraints { (make) -> Void in make.edges.equalToSuperview() }
     NotificationCenter.default.addObserver(
@@ -206,16 +200,13 @@ class GalleryViewController: UIViewController {
     }()
     self.updateGoals()
     self.fetchGoals()
-    if currentUserManager.signedIn(context: viewContext) {
-      UNUserNotificationCenter.current().requestAuthorization(
-        options: UNAuthorizationOptions([.alert, .badge, .sound])
-      ) { [weak self] (success, error) in
-        self?.logger.info(
-          "Requested person’s authorization at GalleryVC load to allow local and remote notifications; successful? \(success)"
-        )
-        guard success else { return }
-        DispatchQueue.main.async { UIApplication.shared.registerForRemoteNotifications() }
-      }
+    UNUserNotificationCenter.current().requestAuthorization(options: UNAuthorizationOptions([.alert, .badge, .sound])) {
+      [weak self] (success, error) in
+      self?.logger.info(
+        "Requested person’s authorization at GalleryVC load to allow local and remote notifications; successful? \(success)"
+      )
+      guard success else { return }
+      DispatchQueue.main.async { UIApplication.shared.registerForRemoteNotifications() }
     }
     Task { @MainActor in
       do {
@@ -256,15 +247,6 @@ class GalleryViewController: UIViewController {
     }
   }
   @objc private func userDefaultsDidChange() { Task { @MainActor [weak self] in self?.updateGoals() } }
-  @objc func handleSignIn() {
-    self.fetchGoals()
-    UNUserNotificationCenter.current().requestAuthorization(options: UNAuthorizationOptions([.alert, .badge, .sound])) {
-      [weak self] (success, error) in
-      self?.logger.info(
-        "Requested person's authorization upon signin to allow local and remote notifications; successful? \(success)"
-      )
-    }
-  }
   func updateDeadbeatVisibility() { self.deadbeatView.isHidden = !isUserKnownDeadbeat }
   private var isUserKnownDeadbeat: Bool { currentUserManager.user(context: viewContext)?.deadbeat == true }
   @objc func updateLastUpdatedLabel() {

--- a/BeeSwift/Gallery/GalleryViewController.swift
+++ b/BeeSwift/Gallery/GalleryViewController.swift
@@ -28,7 +28,6 @@ class GalleryViewController: UIViewController {
   private let viewContext: NSManagedObjectContext
   private let versionManager: VersionManager
   private let goalManager: GoalManager
-  private let healthStoreManager: HealthStoreManager
   private let requestManager: RequestManager
   private lazy var stackView: UIStackView = {
     let stackView = UIStackView()
@@ -105,7 +104,6 @@ class GalleryViewController: UIViewController {
     viewContext: NSManagedObjectContext,
     versionManager: VersionManager,
     goalManager: GoalManager,
-    healthStoreManager: HealthStoreManager,
     requestManager: RequestManager,
     coordinator: MainCoordinator,
   ) {
@@ -113,7 +111,6 @@ class GalleryViewController: UIViewController {
     self.viewContext = viewContext
     self.versionManager = versionManager
     self.goalManager = goalManager
-    self.healthStoreManager = healthStoreManager
     self.requestManager = requestManager
     self.coordinator = coordinator
     let fetchRequest = Goal.fetchRequest() as! NSFetchRequest<Goal>
@@ -200,14 +197,6 @@ class GalleryViewController: UIViewController {
     }()
     self.updateGoals()
     self.fetchGoals()
-    UNUserNotificationCenter.current().requestAuthorization(options: UNAuthorizationOptions([.alert, .badge, .sound])) {
-      [weak self] (success, error) in
-      self?.logger.info(
-        "Requested person’s authorization at GalleryVC load to allow local and remote notifications; successful? \(success)"
-      )
-      guard success else { return }
-      DispatchQueue.main.async { UIApplication.shared.registerForRemoteNotifications() }
-    }
     Task { @MainActor in
       do {
         let updateState = try await versionManager.updateState()
@@ -253,15 +242,6 @@ class GalleryViewController: UIViewController {
     let lastUpdated = currentUserManager.user(context: viewContext)?.lastUpdatedLocal ?? .distantPast
     self.freshnessIndicator.update(with: lastUpdated)
   }
-  func setupHealthKit() {
-    Task { @MainActor in
-      logger.notice("setupHealthKit: Starting HealthKit setup")
-      do {
-        try await healthStoreManager.ensureGoalsUpdateRegularly()
-        logger.notice("setupHealthKit: HealthKit setup completed successfully")
-      } catch { logger.error("setupHealthKit: Failed to setup HealthKit: \(error)") }
-    }
-  }
   @objc func fetchGoals() {
     Task { @MainActor in
       if self.filteredGoals.isEmpty { MBProgressHUD.showAdded(to: self.view, animated: true) }
@@ -301,7 +281,6 @@ class GalleryViewController: UIViewController {
   }
   private var filteredGoals: [Goal] { fetchedResultsController.fetchedObjects ?? [] }
   @objc func didUpdateGoals() {
-    self.setupHealthKit()
     self.collectionView.refreshControl?.endRefreshing()
     MBProgressHUD.hide(for: self.view, animated: true)
     self.updateDeadbeatVisibility()

--- a/BeeSwift/Gallery/GalleryViewController.swift
+++ b/BeeSwift/Gallery/GalleryViewController.swift
@@ -99,6 +99,7 @@ class GalleryViewController: UIViewController {
   private var dataSource: UICollectionViewDiffableDataSource<Section, NSManagedObjectID>!
   private let fetchedResultsController: NSFetchedResultsController<Goal>!
   private var fetchRequest: NSFetchRequest<Goal>?
+  private var hasCompletedInitialFetch = false
   init(
     currentUserManager: CurrentUserManager,
     viewContext: NSManagedObjectContext,
@@ -247,6 +248,7 @@ class GalleryViewController: UIViewController {
       if self.filteredGoals.isEmpty { MBProgressHUD.showAdded(to: self.view, animated: true) }
       do {
         try await goalManager.refreshGoals()
+        self.hasCompletedInitialFetch = true
         self.updateGoals()
       } catch {
         if UIApplication.shared.applicationState == .active {
@@ -295,6 +297,12 @@ class GalleryViewController: UIViewController {
   }
   private func updateEmptyStateBackground() {
     guard self.filteredGoals.isEmpty else {
+      self.collectionView.backgroundView = nil
+      return
+    }
+
+    let isSearching = !(searchBar.text ?? "").isEmpty
+    guard hasCompletedInitialFetch || isSearching else {
       self.collectionView.backgroundView = nil
       return
     }

--- a/BeeSwift/MainCoordinator.swift
+++ b/BeeSwift/MainCoordinator.swift
@@ -49,6 +49,12 @@ class MainCoordinator {
     )
   }
   func start() {
+    navigationController.navigationBar.isTranslucent = false
+    navigationController.navigationBar.barStyle = .black
+    navigationController.navigationBar.tintColor = .white
+    if currentUserManager.signedIn(context: viewContext) { showGallery() } else { showSignIn() }
+  }
+  private func showGallery() {
     let galleryVC = GalleryViewController(
       currentUserManager: currentUserManager,
       viewContext: viewContext,
@@ -58,11 +64,8 @@ class MainCoordinator {
       requestManager: requestManager,
       coordinator: self,
     )
+    navigationController.setNavigationBarHidden(false, animated: false)
     navigationController.setViewControllers([galleryVC], animated: false)
-    navigationController.navigationBar.isTranslucent = false
-    navigationController.navigationBar.barStyle = .black
-    navigationController.navigationBar.tintColor = .white
-    if !currentUserManager.signedIn(context: viewContext) { showSignIn() }
   }
   func showGoal(_ goal: Goal) {
     let goalViewController = GoalViewController(
@@ -87,9 +90,9 @@ class MainCoordinator {
     navigationController.pushViewController(settingsVC, animated: true)
   }
   func showSignIn() {
-    let signInVC = SignInViewController(currentUserManager: currentUserManager, coordinator: self)
-    signInVC.modalPresentationStyle = .fullScreen
-    navigationController.present(signInVC, animated: true)
+    let signInVC = SignInViewController(currentUserManager: currentUserManager)
+    navigationController.setNavigationBarHidden(true, animated: false)
+    navigationController.setViewControllers([signInVC], animated: false)
   }
   func showTimerForGoal(_ goal: Goal) {
     let controller = TimerViewController(goal: goal, requestManager: requestManager)
@@ -195,13 +198,12 @@ class MainCoordinator {
     navigationController.pushViewController(controller, animated: true)
   }
   @objc private func handleSignIn() {
-    navigationController.dismiss(animated: true)
-    navigationController.popToRootViewController(animated: true)
+    navigationController.dismiss(animated: false)
     start()
   }
   @objc private func handleSignOut() {
-    navigationController.popToRootViewController(animated: true)
-    showSignIn()
+    navigationController.dismiss(animated: false)
+    start()
   }
   @objc private func openGoalFromNotification(_ notification: Notification) {
     var goalFromID: Goal? {

--- a/BeeSwift/MainCoordinator.swift
+++ b/BeeSwift/MainCoordinator.swift
@@ -10,6 +10,7 @@ class MainCoordinator {
   private let goalManager: GoalManager
   private let healthStoreManager: HealthStoreManager
   private let requestManager: RequestManager
+  private let sessionStartup: SessionStartup
   init(
     navigationController: UINavigationController,
     currentUserManager: CurrentUserManager,
@@ -26,6 +27,7 @@ class MainCoordinator {
     self.goalManager = goalManager
     self.healthStoreManager = healthStoreManager
     self.requestManager = requestManager
+    self.sessionStartup = SessionStartup(healthStoreManager: healthStoreManager)
     setUpNotifications()
   }
   private func setUpNotifications() {
@@ -60,12 +62,12 @@ class MainCoordinator {
       viewContext: viewContext,
       versionManager: versionManager,
       goalManager: goalManager,
-      healthStoreManager: healthStoreManager,
       requestManager: requestManager,
       coordinator: self,
     )
     navigationController.setNavigationBarHidden(false, animated: false)
     navigationController.setViewControllers([galleryVC], animated: false)
+    sessionStartup.run()
   }
   func showGoal(_ goal: Goal) {
     let goalViewController = GoalViewController(

--- a/BeeSwift/SessionStartup.swift
+++ b/BeeSwift/SessionStartup.swift
@@ -1,0 +1,63 @@
+// Part of BeeSwift. Copyright Beeminder
+
+import BeeKit
+import OSLog
+import UIKit
+
+/// Runs the side effects that should happen once each time an authenticated
+/// session becomes active — i.e. when the app launches already signed in, or the
+/// user signs in during the session.
+///
+/// These are *session-start* tasks: they need a signed-in user and may prompt or
+/// make authenticated calls (requesting notification permission, registering for
+/// remote notifications, ensuring HealthKit goals update in the background). They
+/// are distinct from *app-start* tasks (e.g. `silentlyInstallObservers`), which
+/// run once per process and never prompt.
+///
+/// `run()` is guarded so the work happens at most once per session; signing out
+/// resets it so the next sign-in runs it again.
+class SessionStartup {
+  private let logger = Logger(subsystem: "com.beeminder.beeminder", category: "SessionStartup")
+  private let healthStoreManager: HealthStoreManager
+  private var hasRun = false
+
+  init(healthStoreManager: HealthStoreManager) {
+    self.healthStoreManager = healthStoreManager
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(handleSignOut),
+      name: CurrentUserManager.NotificationName.signedOut,
+      object: nil,
+    )
+  }
+
+  /// Run the session-start tasks unless they have already run for this session.
+  func run() {
+    guard !hasRun else { return }
+    hasRun = true
+
+    requestNotificationAuthorization()
+    setupHealthKit()
+  }
+
+  @objc private func handleSignOut() { hasRun = false }
+
+  private func requestNotificationAuthorization() {
+    UNUserNotificationCenter.current().requestAuthorization(options: UNAuthorizationOptions([.alert, .badge, .sound])) {
+      [weak self] (success, error) in
+      self?.logger.info("Requested notification authorization on session start; successful? \(success)")
+      guard success else { return }
+      DispatchQueue.main.async { UIApplication.shared.registerForRemoteNotifications() }
+    }
+  }
+
+  private func setupHealthKit() {
+    Task { @MainActor in
+      logger.notice("setupHealthKit: Starting HealthKit setup")
+      do {
+        try await healthStoreManager.ensureGoalsUpdateRegularly()
+        logger.notice("setupHealthKit: HealthKit setup completed successfully")
+      } catch { logger.error("setupHealthKit: Failed to setup HealthKit: \(error)") }
+    }
+  }
+}

--- a/BeeSwift/SessionStartup.swift
+++ b/BeeSwift/SessionStartup.swift
@@ -4,18 +4,6 @@ import BeeKit
 import OSLog
 import UIKit
 
-/// Runs the side effects that should happen once each time an authenticated
-/// session becomes active — i.e. when the app launches already signed in, or the
-/// user signs in during the session.
-///
-/// These are *session-start* tasks: they need a signed-in user and may prompt or
-/// make authenticated calls (requesting notification permission, registering for
-/// remote notifications, ensuring HealthKit goals update in the background). They
-/// are distinct from *app-start* tasks (e.g. `silentlyInstallObservers`), which
-/// run once per process and never prompt.
-///
-/// `run()` is guarded so the work happens at most once per session; signing out
-/// resets it so the next sign-in runs it again.
 class SessionStartup {
   private let logger = Logger(subsystem: "com.beeminder.beeminder", category: "SessionStartup")
   private let healthStoreManager: HealthStoreManager
@@ -31,7 +19,6 @@ class SessionStartup {
     )
   }
 
-  /// Run the session-start tasks unless they have already run for this session.
   func run() {
     guard !hasRun else { return }
     hasRun = true

--- a/BeeSwift/SignInViewController.swift
+++ b/BeeSwift/SignInViewController.swift
@@ -19,10 +19,8 @@ class SignInViewController: UIViewController, UITextFieldDelegate {
   var signInButton = BSButton()
   var divider = UIView()
   private let currentUserManager: CurrentUserManager
-  private weak var coordinator: MainCoordinator?
-  init(currentUserManager: CurrentUserManager, coordinator: MainCoordinator?) {
+  init(currentUserManager: CurrentUserManager) {
     self.currentUserManager = currentUserManager
-    self.coordinator = coordinator
     super.init(nibName: nil, bundle: nil)
   }
   required init?(coder aDecoder: NSCoder) { fatalError("init(coder:) has not been implemented") }
@@ -141,10 +139,7 @@ class SignInViewController: UIViewController, UITextFieldDelegate {
     self.present(couldNotSignInAlertController, animated: true, completion: nil)
     MBProgressHUD.hide(for: self.view, animated: true)
   }
-  @objc func handleSignedIn(_ notification: Notification) {
-    MBProgressHUD.hide(for: self.view, animated: true)
-    coordinator?.start()
-  }
+  @objc func handleSignedIn(_ notification: Notification) { MBProgressHUD.hide(for: self.view, animated: true) }
   @objc func signInButtonPressed() {
     Task { @MainActor in
       guard let email = self.emailTextField.text?.trimmingCharacters(in: .whitespaces),


### PR DESCRIPTION
## Summary
Previously the gallery handled a range of functions, including setup and the login screen. Move all of that elsewhere, and also only render the gallery when the user is logged in, so its only role is showing a list of goals.

## Validation
* [x] Launch the app in simulator and observe it loads