### PR TITLE
Fix race in SpotlightIndexer notification tests

### DIFF
--- a/BeeSwiftTests/SpotlightIndexerTests.swift
+++ b/BeeSwiftTests/SpotlightIndexerTests.swift
@@ -96,6 +96,7 @@ final class SpotlightIndexerTests: XCTestCase {
     try container.viewContext.save()
 
     let indexed = expectation(description: "Goals indexed")
+    indexed.assertForOverFulfill = false
     mockSearchableIndex.onIndex = { indexed.fulfill() }
 
     let indexer = SpotlightIndexer(
@@ -105,20 +106,28 @@ final class SpotlightIndexerTests: XCTestCase {
     )
     let listenerTask = Task { await indexer.listenForNotifications() }
 
-    // Post the notification on main thread
-    await MainActor.run {
-      NotificationCenter.default.post(name: .NSManagedObjectContextObjectsDidChange, object: container.viewContext)
+    // listenForNotifications subscribes asynchronously, so a single post can land before the
+    // listener is observing and be missed (flaky under load). Keep posting until it reacts.
+    let posterTask = Task {
+      while !Task.isCancelled {
+        await MainActor.run {
+          NotificationCenter.default.post(name: .NSManagedObjectContextObjectsDidChange, object: container.viewContext)
+        }
+        try? await Task.sleep(for: .milliseconds(20))
+      }
     }
 
-    await fulfillment(of: [indexed], timeout: 1.0)
+    await fulfillment(of: [indexed], timeout: 5.0)
+    posterTask.cancel()
     listenerTask.cancel()
 
-    XCTAssertEqual(mockSearchableIndex.indexedEntities.count, 1, "Should have indexed once")
+    XCTAssertGreaterThanOrEqual(mockSearchableIndex.indexedEntities.count, 1, "Should have indexed")
     XCTAssertEqual(mockSearchableIndex.indexedEntities.first?.first?.slug, "initial-goal")
   }
 
   func testClearIndexOnSignedOutNotification() async throws {
     let cleared = expectation(description: "Index cleared")
+    cleared.assertForOverFulfill = false
     mockSearchableIndex.onDeleteAll = { cleared.fulfill() }
 
     let indexer = SpotlightIndexer(
@@ -128,12 +137,19 @@ final class SpotlightIndexerTests: XCTestCase {
     )
     let listenerTask = Task { await indexer.listenForNotifications() }
 
-    // Post the notification on main thread
-    await MainActor.run {
-      NotificationCenter.default.post(name: CurrentUserManager.NotificationName.signedOut, object: nil)
+    // listenForNotifications subscribes asynchronously, so a single post can land before the
+    // listener is observing and be missed (flaky under load). Keep posting until it reacts.
+    let posterTask = Task {
+      while !Task.isCancelled {
+        await MainActor.run {
+          NotificationCenter.default.post(name: CurrentUserManager.NotificationName.signedOut, object: nil)
+        }
+        try? await Task.sleep(for: .milliseconds(20))
+      }
     }
 
-    await fulfillment(of: [cleared], timeout: 1.0)
+    await fulfillment(of: [cleared], timeout: 5.0)
+    posterTask.cancel()
     listenerTask.cancel()
 
     XCTAssertTrue(mockSearchableIndex.deleteAllSearchableItemsCalled, "Should clear index on sign out")


### PR DESCRIPTION
## Problem

`testReindexOnObjectsDidChangeNotification` and `testClearIndexOnSignedOutNotification` are flaky on CI, failing with *"Asynchronous wait failed: Exceeded timeout of 1 seconds."*

Both start the listener in an unstructured task and then post the notification once, immediately:

```swift
let listenerTask = Task { await indexer.listenForNotifications() }
await MainActor.run { NotificationCenter.default.post(name: …) }
await fulfillment(of: [expectation], timeout: 1.0)
```

`listenForNotifications()` subscribes to `NotificationCenter` **asynchronously** (when the merged async sequence first iterates). `NotificationCenter`'s async `.notifications` does not buffer events for a not-yet-subscribed observer, so if the post wins the race the event is dropped and the wait times out. On fast machines the task subscribes first; under CI load the post wins — these tests time out (and `SpotlightIndexerTests` has a history of CI flakiness, e.g. the segv in #789).

## Fix

Post the notification on a short retry loop until the listener has subscribed and reacted, with a generous timeout. Because more than one post may be delivered, allow over-fulfillment and assert the index updated **at least once** (with the expected goal) rather than exactly once.

Test-only change; no production code touched.

## Verification

`SpotlightIndexerTests` pass locally (7/7). CI is the real exercise of the race.

🤖 Generated with [Claude Code](https://claude.com/claude-code)