### PR TITLE
Bump app version from 6.8 to 6.9

### DIFF
--- a/BeeKit/Info.plist
+++ b/BeeKit/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.8</string>
+	<string>6.9</string>
 	<key>CFBundleVersion</key>
 	<string>0</string>
 </dict>

--- a/BeeKitTests/Info.plist
+++ b/BeeKitTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.8</string>
+	<string>6.9</string>
 	<key>CFBundleVersion</key>
 	<string>0</string>
 </dict>

--- a/BeeSwift/Info.plist
+++ b/BeeSwift/Info.plist
@@ -38,7 +38,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.8</string>
+	<string>6.9</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/BeeSwiftTests/Info.plist
+++ b/BeeSwiftTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.8</string>
+	<string>6.9</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/BeeSwiftUITests/Info.plist
+++ b/BeeSwiftUITests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.8</string>
+	<string>6.9</string>
 	<key>CFBundleVersion</key>
 	<string>0</string>
 </dict>


### PR DESCRIPTION
Updates `CFBundleShortVersionString` from `6.8` to `6.9` across all five Info.plist files (BeeSwift, BeeKit, and the three test targets).

https://claude.ai/code/session_01GHwTMbtQNsszzjsLDQTg4t

---
_Generated by [Claude Code](https://claude.ai/code/session_01GHwTMbtQNsszzjsLDQTg4t)_