### PR TITLE
user can provide timer comment

### DIFF
--- a/BeeSwift/GoalView/TimerViewController.swift
+++ b/BeeSwift/GoalView/TimerViewController.swift
@@ -52,6 +52,13 @@ class TimerViewController: UIViewController {
     view.setTitle("Add Datapoint to \(self.goal.slug)", for: .normal)
     return view
   }()
+  private lazy var resetButton: BSButton = {
+    let view = BSButton(type: .system)
+    view.configuration = .filled()
+    view.addTarget(self, action: #selector(self.resetButtonPressed), for: .touchUpInside)
+    view.setTitle("Reset", for: .normal)
+    return view
+  }()
 
   private lazy var exitButton: BSButton = {
     let view = BSButton(type: .system)
@@ -107,8 +114,6 @@ class TimerViewController: UIViewController {
       make.centerX.equalTo(self.view)
       make.height.equalTo(Constants.defaultTextFieldHeight)
     }
-    let resetButton = BSButton(type: .system)
-    resetButton.configuration = .filled()
     self.view.addSubview(resetButton)
     resetButton.snp.makeConstraints { (make) in
       make.left.equalTo(self.view.snp.centerX).offset(10)
@@ -116,8 +121,7 @@ class TimerViewController: UIViewController {
       make.bottom.equalTo(self.view.safeAreaLayoutGuide.snp.bottomMargin)
       make.height.equalTo(Constants.defaultTextFieldHeight)
     }
-    resetButton.addTarget(self, action: #selector(self.resetButtonPressed), for: .touchUpInside)
-    resetButton.setTitle("Reset", for: .normal)
+
     self.view.addSubview(self.commentTextField)
     self.commentTextField.snp.makeConstraints { (make) in
       make.top.equalTo(addDatapointButton.snp.bottom).offset(20)

--- a/BeeSwift/GoalView/TimerViewController.swift
+++ b/BeeSwift/GoalView/TimerViewController.swift
@@ -15,7 +15,13 @@ class TimerViewController: UIViewController {
   private enum TimerUnit { case hours, minutes }
 
   let timerLabel = BSLabel()
-  let startStopButton = BSButton(type: .system)
+  private lazy var startStopButton: BSButton = {
+    let view = BSButton(type: .system)
+    view.addTarget(self, action: #selector(self.startStopButtonPressed), for: .touchUpInside)
+    view.setTitle("Start", for: .normal)
+    view.configuration = .filled()
+    return view
+  }()
   private lazy var commentTextField: UITextField = {
     let view = UITextField()
     view.font = UIFont.beeminder.defaultFontPlain.withSize(16)
@@ -33,7 +39,6 @@ class TimerViewController: UIViewController {
     view.rightView = UIView(frame: CGRect(x: 0, y: 0, width: 10, height: 1))
     return view
   }()
-  
   private static let commentDefault = "Automatically entered from iOS timer interface"
 
   let goal: Goal
@@ -77,14 +82,11 @@ class TimerViewController: UIViewController {
     exitButton.addTarget(self, action: #selector(self.exitButtonPressed), for: .touchUpInside)
     exitButton.setTitle("Exit", for: .normal)
     self.view.addSubview(self.startStopButton)
-    startStopButton.configuration = .filled()
     self.startStopButton.snp.makeConstraints { (make) in
       make.top.equalTo(self.view.snp.centerY).offset(10)
       make.centerX.equalTo(self.view)
       make.height.equalTo(Constants.defaultTextFieldHeight)
     }
-    self.startStopButton.addTarget(self, action: #selector(self.startStopButtonPressed), for: .touchUpInside)
-    self.startStopButton.setTitle("Start", for: .normal)
     let addDatapointButton = BSButton(type: .system)
     addDatapointButton.configuration = .filled()
     self.view.addSubview(addDatapointButton)
@@ -106,7 +108,6 @@ class TimerViewController: UIViewController {
     }
     resetButton.addTarget(self, action: #selector(self.resetButtonPressed), for: .touchUpInside)
     resetButton.setTitle("Reset", for: .normal)
-    
     self.view.addSubview(self.commentTextField)
     self.commentTextField.snp.makeConstraints { (make) in
       make.top.equalTo(addDatapointButton.snp.bottom).offset(20)

--- a/BeeSwift/GoalView/TimerViewController.swift
+++ b/BeeSwift/GoalView/TimerViewController.swift
@@ -16,7 +16,23 @@ class TimerViewController: UIViewController {
 
   let timerLabel = BSLabel()
   let startStopButton = BSButton(type: .system)
-  let commentTextField = UITextField()
+  private lazy var commentTextField: UITextField = {
+    let view = UITextField()
+    view.font = UIFont.beeminder.defaultFontPlain.withSize(16)
+    view.leftViewMode = .always
+    view.rightViewMode = .always
+    view.tintColor = UIColor.Beeminder.gray
+    view.layer.borderColor = UIColor.Beeminder.gray.cgColor
+    view.layer.borderWidth = 1
+    view.layer.cornerRadius = 6
+    view.backgroundColor = UIColor(white: 0.15, alpha: 1.0)
+    view.textColor = .white
+    view.text = TimerViewController.commentDefault
+    view.clearsOnBeginEditing = true
+    view.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 10, height: 1))
+    view.rightView = UIView(frame: CGRect(x: 0, y: 0, width: 10, height: 1))
+    return view
+  }()
   
   private static let commentDefault = "Automatically entered from iOS timer interface"
 
@@ -92,19 +108,6 @@ class TimerViewController: UIViewController {
     resetButton.setTitle("Reset", for: .normal)
     
     self.view.addSubview(self.commentTextField)
-    self.commentTextField.font = UIFont.beeminder.defaultFontPlain.withSize(16)
-    self.commentTextField.leftViewMode = .always
-    self.commentTextField.rightViewMode = .always
-    self.commentTextField.tintColor = UIColor.Beeminder.gray
-    self.commentTextField.layer.borderColor = UIColor.Beeminder.gray.cgColor
-    self.commentTextField.layer.borderWidth = 1
-    self.commentTextField.layer.cornerRadius = 6
-    self.commentTextField.backgroundColor = UIColor(white: 0.15, alpha: 1.0)
-    self.commentTextField.textColor = .white
-    self.commentTextField.text = TimerViewController.commentDefault
-    self.commentTextField.clearsOnBeginEditing = true
-    self.commentTextField.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 10, height: 1))
-    self.commentTextField.rightView = UIView(frame: CGRect(x: 0, y: 0, width: 10, height: 1))
     self.commentTextField.snp.makeConstraints { (make) in
       make.top.equalTo(addDatapointButton.snp.bottom).offset(20)
       make.left.equalTo(self.view.safeAreaLayoutGuide.snp.leftMargin).offset(20)

--- a/BeeSwift/GoalView/TimerViewController.swift
+++ b/BeeSwift/GoalView/TimerViewController.swift
@@ -16,6 +16,10 @@ class TimerViewController: UIViewController {
 
   let timerLabel = BSLabel()
   let startStopButton = BSButton(type: .system)
+  let commentTextField = UITextField()
+  
+  private static let commentDefault = "Automatically entered from iOS timer interface"
+
   let goal: Goal
   var timingSince: Date?
   var timer: Timer?
@@ -86,6 +90,27 @@ class TimerViewController: UIViewController {
     }
     resetButton.addTarget(self, action: #selector(self.resetButtonPressed), for: .touchUpInside)
     resetButton.setTitle("Reset", for: .normal)
+    
+    self.view.addSubview(self.commentTextField)
+    self.commentTextField.font = UIFont.beeminder.defaultFontPlain.withSize(16)
+    self.commentTextField.leftViewMode = .always
+    self.commentTextField.rightViewMode = .always
+    self.commentTextField.tintColor = UIColor.Beeminder.gray
+    self.commentTextField.layer.borderColor = UIColor.Beeminder.gray.cgColor
+    self.commentTextField.layer.borderWidth = 1
+    self.commentTextField.layer.cornerRadius = 6
+    self.commentTextField.backgroundColor = UIColor(white: 0.15, alpha: 1.0)
+    self.commentTextField.textColor = .white
+    self.commentTextField.text = TimerViewController.commentDefault
+    self.commentTextField.clearsOnBeginEditing = true
+    self.commentTextField.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 10, height: 1))
+    self.commentTextField.rightView = UIView(frame: CGRect(x: 0, y: 0, width: 10, height: 1))
+    self.commentTextField.snp.makeConstraints { (make) in
+      make.top.equalTo(addDatapointButton.snp.bottom).offset(20)
+      make.left.equalTo(self.view.safeAreaLayoutGuide.snp.leftMargin).offset(20)
+      make.right.equalTo(self.view.safeAreaLayoutGuide.snp.rightMargin).offset(-20)
+      make.height.equalTo(Constants.defaultTextFieldHeight)
+    }
   }
   @objc func exitButtonPressed() { self.presentingViewController?.dismiss(animated: true, completion: nil) }
   func totalSeconds() -> Double {
@@ -129,6 +154,7 @@ class TimerViewController: UIViewController {
     self.timingSince = nil
     self.accumulatedSeconds = 0
     self.updateTimerLabel()
+    self.commentTextField.text = TimerViewController.commentDefault
   }
   func urtext() -> String {
     let urtextDaystamp = Daystamp.makeUrtextDaystamp(submissionDate: Date(), deadline: goal.deadline)
@@ -138,7 +164,7 @@ class TimerViewController: UIViewController {
     case .minutes: value = self.totalSeconds() / 60.0
     case .hours: value = self.totalSeconds() / 3600.0
     }
-    let comment = "Automatically entered from iOS timer interface"
+    let comment = self.commentTextField.text ?? ""
     return "\(urtextDaystamp) \(value) \"\(comment)\""
   }
   @objc func addDatapointButtonPressed() {

--- a/BeeSwift/GoalView/TimerViewController.swift
+++ b/BeeSwift/GoalView/TimerViewController.swift
@@ -14,7 +14,13 @@ import UIKit
 class TimerViewController: UIViewController {
   private enum TimerUnit { case hours, minutes }
 
-  let timerLabel = BSLabel()
+  private lazy var timerLabel: BSLabel = {
+    let view = BSLabel()
+    view.text = "00:00:00"
+    view.textColor = .white
+    view.font = UIFont.beeminder.defaultBoldFont.withSize(48)
+    return view
+  }()
   private lazy var startStopButton: BSButton = {
     let view = BSButton(type: .system)
     view.addTarget(self, action: #selector(self.startStopButtonPressed), for: .touchUpInside)
@@ -67,9 +73,6 @@ class TimerViewController: UIViewController {
       make.bottom.equalTo(self.view.snp.centerY).offset(-10)
       make.height.equalTo(Constants.defaultTextFieldHeight)
     }
-    self.timerLabel.text = "00:00:00"
-    self.timerLabel.textColor = .white
-    self.timerLabel.font = UIFont.beeminder.defaultBoldFont.withSize(48)
     let exitButton = BSButton(type: .system)
     exitButton.configuration = .filled()
     self.view.addSubview(exitButton)

--- a/BeeSwift/GoalView/TimerViewController.swift
+++ b/BeeSwift/GoalView/TimerViewController.swift
@@ -45,6 +45,14 @@ class TimerViewController: UIViewController {
     view.rightView = UIView(frame: CGRect(x: 0, y: 0, width: 10, height: 1))
     return view
   }()
+  private lazy var addDatapointButton: BSButton = {
+    let view = BSButton(type: .system)
+    view.configuration = .filled()
+    view.addTarget(self, action: #selector(self.addDatapointButtonPressed), for: .touchUpInside)
+    view.setTitle("Add Datapoint to \(self.goal.slug)", for: .normal)
+    return view
+  }()
+
   private lazy var exitButton: BSButton = {
     let view = BSButton(type: .system)
     view.configuration = .filled()
@@ -93,16 +101,12 @@ class TimerViewController: UIViewController {
       make.centerX.equalTo(self.view)
       make.height.equalTo(Constants.defaultTextFieldHeight)
     }
-    let addDatapointButton = BSButton(type: .system)
-    addDatapointButton.configuration = .filled()
     self.view.addSubview(addDatapointButton)
     addDatapointButton.snp.makeConstraints { (make) in
       make.top.equalTo(self.startStopButton.snp.bottom).offset(Constants.defaultTextFieldHeight)
       make.centerX.equalTo(self.view)
       make.height.equalTo(Constants.defaultTextFieldHeight)
     }
-    addDatapointButton.addTarget(self, action: #selector(self.addDatapointButtonPressed), for: .touchUpInside)
-    addDatapointButton.setTitle("Add Datapoint to \(self.goal.slug)", for: .normal)
     let resetButton = BSButton(type: .system)
     resetButton.configuration = .filled()
     self.view.addSubview(resetButton)

--- a/BeeSwift/GoalView/TimerViewController.swift
+++ b/BeeSwift/GoalView/TimerViewController.swift
@@ -45,6 +45,13 @@ class TimerViewController: UIViewController {
     view.rightView = UIView(frame: CGRect(x: 0, y: 0, width: 10, height: 1))
     return view
   }()
+  private lazy var exitButton: BSButton = {
+    let view = BSButton(type: .system)
+    view.configuration = .filled()
+    view.addTarget(self, action: #selector(self.exitButtonPressed), for: .touchUpInside)
+    view.setTitle("Exit", for: .normal)
+    return view
+  }()
   private static let commentDefault = "Automatically entered from iOS timer interface"
 
   let goal: Goal
@@ -73,8 +80,6 @@ class TimerViewController: UIViewController {
       make.bottom.equalTo(self.view.snp.centerY).offset(-10)
       make.height.equalTo(Constants.defaultTextFieldHeight)
     }
-    let exitButton = BSButton(type: .system)
-    exitButton.configuration = .filled()
     self.view.addSubview(exitButton)
     exitButton.snp.makeConstraints { (make) in
       make.left.equalTo(self.view.safeAreaLayoutGuide.snp.leftMargin).offset(10)
@@ -82,8 +87,6 @@ class TimerViewController: UIViewController {
       make.right.equalTo(self.view.snp.centerX).offset(-10)
       make.height.equalTo(Constants.defaultTextFieldHeight)
     }
-    exitButton.addTarget(self, action: #selector(self.exitButtonPressed), for: .touchUpInside)
-    exitButton.setTitle("Exit", for: .normal)
     self.view.addSubview(self.startStopButton)
     self.startStopButton.snp.makeConstraints { (make) in
       make.top.equalTo(self.view.snp.centerY).offset(10)

--- a/BeeSwift/GoalView/TimerViewController.swift
+++ b/BeeSwift/GoalView/TimerViewController.swift
@@ -19,6 +19,7 @@ class TimerViewController: UIViewController {
     view.text = "00:00:00"
     view.textColor = .white
     view.font = UIFont.beeminder.defaultBoldFont.withSize(48)
+    view.textAlignment = .center
     return view
   }()
   private lazy var startStopButton: BSButton = {
@@ -88,12 +89,6 @@ class TimerViewController: UIViewController {
     super.viewDidLoad()
     self.view.backgroundColor = .darkGray
 
-    self.view.addSubview(self.timerLabel)
-    self.timerLabel.snp.makeConstraints { (make) in
-      make.centerX.equalTo(self.view)
-      make.bottom.equalTo(self.view.snp.centerY).offset(-10)
-      make.height.equalTo(Constants.defaultTextFieldHeight)
-    }
     self.view.addSubview(exitButton)
     exitButton.snp.makeConstraints { (make) in
       make.left.equalTo(self.view.safeAreaLayoutGuide.snp.leftMargin).offset(10)
@@ -101,18 +96,7 @@ class TimerViewController: UIViewController {
       make.right.equalTo(self.view.snp.centerX).offset(-10)
       make.height.equalTo(Constants.defaultTextFieldHeight)
     }
-    self.view.addSubview(self.startStopButton)
-    self.startStopButton.snp.makeConstraints { (make) in
-      make.top.equalTo(self.view.snp.centerY).offset(10)
-      make.centerX.equalTo(self.view)
-      make.height.equalTo(Constants.defaultTextFieldHeight)
-    }
-    self.view.addSubview(addDatapointButton)
-    addDatapointButton.snp.makeConstraints { (make) in
-      make.top.equalTo(self.startStopButton.snp.bottom).offset(Constants.defaultTextFieldHeight)
-      make.centerX.equalTo(self.view)
-      make.height.equalTo(Constants.defaultTextFieldHeight)
-    }
+
     self.view.addSubview(resetButton)
     resetButton.snp.makeConstraints { (make) in
       make.left.equalTo(self.view.snp.centerX).offset(10)
@@ -121,12 +105,51 @@ class TimerViewController: UIViewController {
       make.height.equalTo(Constants.defaultTextFieldHeight)
     }
 
-    self.view.addSubview(self.commentTextField)
-    self.commentTextField.snp.makeConstraints { (make) in
-      make.top.equalTo(addDatapointButton.snp.bottom).offset(20)
+    let scrollView = UIScrollView()
+    self.view.addSubview(scrollView)
+    scrollView.snp.makeConstraints { (make) in
+      make.top.equalTo(self.view.safeAreaLayoutGuide.snp.topMargin)
       make.left.equalTo(self.view.safeAreaLayoutGuide.snp.leftMargin).offset(20)
       make.right.equalTo(self.view.safeAreaLayoutGuide.snp.rightMargin).offset(-20)
-      make.height.equalTo(Constants.defaultTextFieldHeight)
+      make.bottom.equalTo(self.exitButton.snp.top).offset(-10)
+    }
+
+    let containerView = UIView()
+    scrollView.addSubview(containerView)
+    containerView.snp.makeConstraints { (make) in
+      make.top.equalToSuperview().offset(10)
+      make.left.equalToSuperview()
+      make.right.equalToSuperview()
+      make.bottom.equalToSuperview().offset(-10)
+      make.width.equalToSuperview()
+      make.height.greaterThanOrEqualTo(scrollView.snp.height)
+    }
+
+    let contentStackView = UIStackView()
+    contentStackView.axis = .vertical
+    contentStackView.alignment = .center
+    contentStackView.distribution = .fill
+    contentStackView.spacing = 16
+    containerView.addSubview(contentStackView)
+    contentStackView.snp.makeConstraints { (make) in
+      make.centerX.equalToSuperview()
+      make.centerY.equalToSuperview()
+      make.left.equalToSuperview()
+      make.right.equalToSuperview()
+      make.width.equalToSuperview()
+    }
+
+    contentStackView.addArrangedSubview(self.timerLabel)
+    contentStackView.addArrangedSubview(self.startStopButton)
+    contentStackView.addArrangedSubview(self.addDatapointButton)
+    contentStackView.addArrangedSubview(self.commentTextField)
+
+    self.timerLabel.snp.makeConstraints { (make) in make.width.equalToSuperview() }
+    self.startStopButton.snp.makeConstraints { (make) in make.width.equalTo(200) }
+    self.addDatapointButton.snp.makeConstraints { (make) in make.width.equalTo(self.startStopButton) }
+    self.commentTextField.snp.makeConstraints { (make) in
+      make.width.equalToSuperview()
+      make.height.greaterThanOrEqualTo(Constants.defaultTextFieldHeight)
     }
   }
   @objc func exitButtonPressed() { self.presentingViewController?.dismiss(animated: true, completion: nil) }

--- a/BeeSwift/GoalView/TimerViewController.swift
+++ b/BeeSwift/GoalView/TimerViewController.swift
@@ -39,8 +39,7 @@ class TimerViewController: UIViewController {
     view.layer.cornerRadius = 6
     view.backgroundColor = UIColor(white: 0.15, alpha: 1.0)
     view.textColor = .white
-    view.text = TimerViewController.commentDefault
-    view.clearsOnBeginEditing = true
+    view.placeholder = TimerViewController.commentDefault
     view.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 10, height: 1))
     view.rightView = UIView(frame: CGRect(x: 0, y: 0, width: 10, height: 1))
     return view
@@ -172,7 +171,7 @@ class TimerViewController: UIViewController {
     self.timingSince = nil
     self.accumulatedSeconds = 0
     self.updateTimerLabel()
-    self.commentTextField.text = TimerViewController.commentDefault
+    self.commentTextField.text = nil
   }
   func urtext() -> String {
     let urtextDaystamp = Daystamp.makeUrtextDaystamp(submissionDate: Date(), deadline: goal.deadline)
@@ -182,7 +181,14 @@ class TimerViewController: UIViewController {
     case .minutes: value = self.totalSeconds() / 60.0
     case .hours: value = self.totalSeconds() / 3600.0
     }
-    let comment = self.commentTextField.text ?? ""
+    let comment = {
+      guard let commentText = self.commentTextField.text else {
+        return TimerViewController.commentDefault
+      }
+      return commentText.isEmpty
+      ? TimerViewController.commentDefault
+      : commentText
+    }()
     return "\(urtextDaystamp) \(value) \"\(comment)\""
   }
   @objc func addDatapointButtonPressed() {

--- a/BeeSwift/GoalView/TimerViewController.swift
+++ b/BeeSwift/GoalView/TimerViewController.swift
@@ -205,12 +205,8 @@ class TimerViewController: UIViewController {
     case .hours: value = self.totalSeconds() / 3600.0
     }
     let comment = {
-      guard let commentText = self.commentTextField.text else {
-        return TimerViewController.commentDefault
-      }
-      return commentText.isEmpty
-      ? TimerViewController.commentDefault
-      : commentText
+      guard let commentText = self.commentTextField.text else { return TimerViewController.commentDefault }
+      return commentText.isEmpty ? TimerViewController.commentDefault : commentText
     }()
     return "\(urtextDaystamp) \(value) \"\(comment)\""
   }


### PR DESCRIPTION
## Summary
Datapoints submitted via timer had a default comment that was not user-edible. This PR provides the interface such that the user may set the comment directly.

*For UI changes including screenshots of before and after is great.*
<img width="384" src="https://github.com/user-attachments/assets/d18ae2c3-650c-47fa-b39b-a54c0919b988" />

<img width="384" src="https://github.com/user-attachments/assets/6037d977-1957-4400-8375-b5064098c0b4" />


## Validation
ran app in simulator, used timer interface, submitted datapoints (both edited and not)

## Ticket
Implements / Fixes #627 
