### PR TITLE
Render goal graphs from SVG with a dark-mode theme

### DIFF
--- a/BeeKit/GoalExtensions.swift
+++ b/BeeKit/GoalExtensions.swift
@@ -40,6 +40,11 @@ extension Goal {
     return cacheBuster(graphUrlStr)
   }
 
+  public var cacheBustingSvgUrl: String {
+    let svgUrlStr = self.svgUrl
+    return cacheBuster(svgUrlStr)
+  }
+
   private func cacheBuster(_ originUrlStr: String) -> String {
     let queryCharacter = originUrlStr.range(of: "&") == nil ? "?" : "&"
 

--- a/BeeKit/GoalExtensions.swift
+++ b/BeeKit/GoalExtensions.swift
@@ -30,16 +30,6 @@ extension Goal {
     return try! Daystamp(fromString: dateString)
   }
 
-  public var cacheBustingThumbUrl: String {
-    let thumbUrlStr = self.thumbUrl
-    return cacheBuster(thumbUrlStr)
-  }
-
-  public var cacheBustingGraphUrl: String {
-    let graphUrlStr = self.graphUrl
-    return cacheBuster(graphUrlStr)
-  }
-
   public var cacheBustingSvgUrl: String {
     let svgUrlStr = self.svgUrl
     return cacheBuster(svgUrlStr)

--- a/BeeKit/Model/BeeminderModel.xcdatamodeld/.xccurrentversion
+++ b/BeeKit/Model/BeeminderModel.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>BeeminderModel3.xcdatamodel</string>
+	<string>BeeminderModel4.xcdatamodel</string>
 </dict>
 </plist>

--- a/BeeKit/Model/BeeminderModel.xcdatamodeld/BeeminderModel3.xcdatamodel/contents
+++ b/BeeKit/Model/BeeminderModel.xcdatamodeld/BeeminderModel3.xcdatamodel/contents
@@ -41,6 +41,7 @@
         <attribute name="safeBuf" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="safeSum" attributeType="String"/>
         <attribute name="slug" attributeType="String" spotlightIndexingEnabled="YES"/>
+        <attribute name="svgUrl" attributeType="String" defaultValueString=""/>
         <attribute name="thumbUrl" attributeType="String"/>
         <attribute name="title" attributeType="String" spotlightIndexingEnabled="YES"/>
         <attribute name="todayta" attributeType="Boolean" usesScalarValueType="YES"/>

--- a/BeeKit/Model/BeeminderModel.xcdatamodeld/BeeminderModel4.xcdatamodel/contents
+++ b/BeeKit/Model/BeeminderModel.xcdatamodeld/BeeminderModel4.xcdatamodel/contents
@@ -41,6 +41,7 @@
         <attribute name="safeBuf" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="safeSum" attributeType="String"/>
         <attribute name="slug" attributeType="String" spotlightIndexingEnabled="YES"/>
+        <attribute name="svgUrl" attributeType="String" defaultValueString=""/>
         <attribute name="thumbUrl" attributeType="String"/>
         <attribute name="title" attributeType="String" spotlightIndexingEnabled="YES"/>
         <attribute name="todayta" attributeType="Boolean" usesScalarValueType="YES"/>

--- a/BeeKit/Model/Goal.swift
+++ b/BeeKit/Model/Goal.swift
@@ -15,6 +15,8 @@ import SwiftyJSON
   @NSManaged public var deadline: Int
   /// URL for the goal's graph image. E.g., "http://static.beeminder.com/alice/weight.png".
   @NSManaged public var graphUrl: String
+  /// URL for the goal's graph SVG. E.g., "http://static.beeminder.com/alice/weight.svg".
+  @NSManaged public var svgUrl: String
   /// The internal app identifier for the healthkit metric to sync to this goal
   @NSManaged public var healthKitMetric: String?
   @NSManaged public var autodataConfig: [String: Any]
@@ -73,6 +75,7 @@ import SwiftyJSON
     autodata: String?,
     deadline: Int,
     graphUrl: String,
+    svgUrl: String,
     healthKitMetric: String,
     hhmmFormat: Bool,
     initDay: Int,
@@ -100,6 +103,7 @@ import SwiftyJSON
     self.autodata = autodata
     self.deadline = deadline
     self.graphUrl = graphUrl
+    self.svgUrl = svgUrl
     self.healthKitMetric = healthKitMetric
     self.hhmmFormat = hhmmFormat
     self.initDay = initDay
@@ -151,6 +155,7 @@ import SwiftyJSON
     self.autodataConfig = json["autodata_config"].dictionaryObject ?? [:]
     self.deadline = json["deadline"].intValue
     self.graphUrl = json["graph_url"].stringValue
+    self.svgUrl = json["svg_url"].stringValue
     self.healthKitMetric = json["healthkitmetric"].string
     self.hhmmFormat = json["hhmmformat"].boolValue
     self.initDay = json["initday"].intValue

--- a/BeeKitTests/MigrationTests.swift
+++ b/BeeKitTests/MigrationTests.swift
@@ -138,11 +138,9 @@ class MigrationTests: XCTestCase {
       )
     }
   }
-  // Shipped model versions must never be edited in place: Core Data locates a store's source model by
-  // matching its version hashes against the bundled versions, so changing a shipped version means
-  // existing stores no longer match anything and `loadPersistentStores` fails ("Can't find model for
-  // source store"). Schema changes go in a new version. These checksums are the ones Xcode prints at
-  // build time (they are what `GoalManager` compares to force a full refresh after a model change).
+  // Core Data finds a store's source model by matching version hashes against the bundled versions, so
+  // editing a shipped version in place leaves existing stores with no source model and they fail to
+  // open. Schema changes go in a new version. Checksums are as Xcode prints them at build time.
   func testShippedModelVersionsAreUnchanged() throws {
     let shippedChecksums = [
       "BeeminderModel": "Z6+a9G/hRxFiCm6y8ogfqoWpYvVUbDA7WmLpeKtwD00=",
@@ -162,8 +160,7 @@ class MigrationTests: XCTestCase {
       )
     }
   }
-  // Model version 3 shipped (6.8 stores were created with it), so the current model must be reachable
-  // from it by lightweight migration, with the new `svgUrl` attribute taking its default.
+  // Version 3 shipped in 6.8, so the current model must be reachable from it by lightweight migration.
   func testMigrationFromModelVersion3() throws {
     DueByTableValueTransformer.register()
 

--- a/BeeKitTests/MigrationTests.swift
+++ b/BeeKitTests/MigrationTests.swift
@@ -22,8 +22,10 @@ class MigrationTests: XCTestCase {
       }
     }
   }
-  // Creates a CoreData store with the old model version (v1)
-  private func createStoreWithOldModel() -> URL {
+  // Creates a CoreData store with an old model version (defaults to v1, "BeeminderModel")
+  private func createStoreWithOldModel(version: String = "BeeminderModel") -> URL {
+    // v1 named the local-modification timestamp `lastModifiedLocal`; it was renamed in v2.
+    let lastUpdatedKey = version == "BeeminderModel" ? "lastModifiedLocal" : "lastUpdatedLocal"
     let storeURL = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(
       "TestMigration_\(UUID().uuidString).sqlite"
     )
@@ -32,11 +34,8 @@ class MigrationTests: XCTestCase {
     // Load the old model version
     let bundle = Bundle(for: BeeminderPersistentContainer.self)
     guard
-      let oldVersionURL = bundle.url(
-        forResource: "BeeminderModel",
-        withExtension: "mom",
-        subdirectory: "BeeminderModel.momd",
-      ), let oldModel = NSManagedObjectModel(contentsOf: oldVersionURL)
+      let oldVersionURL = bundle.url(forResource: version, withExtension: "mom", subdirectory: "BeeminderModel.momd"),
+      let oldModel = NSManagedObjectModel(contentsOf: oldVersionURL)
     else {
       XCTFail("Failed to load old data model")
       fatalError()
@@ -53,7 +52,7 @@ class MigrationTests: XCTestCase {
       user.setValue("America/Los_Angeles", forKey: "timezone")
       user.setValue(false, forKey: "deadbeat")
       user.setValue(Date(), forKey: "updatedAt")
-      user.setValue(TestData.userLastModified, forKey: "lastModifiedLocal")
+      user.setValue(TestData.userLastModified, forKey: lastUpdatedKey)
 
       // Create goal with minimal required fields
       let goal = NSEntityDescription.insertNewObject(forEntityName: "Goal", into: context)
@@ -69,14 +68,14 @@ class MigrationTests: XCTestCase {
       }
       for field in ["hhmmFormat", "queued", "todayta", "useDefaults", "won"] { goal.setValue(false, forKey: field) }
       goal.setValue(DueByDictionary(), forKey: "dueBy")
-      goal.setValue(TestData.goalLastModified, forKey: "lastModifiedLocal")
+      goal.setValue(TestData.goalLastModified, forKey: lastUpdatedKey)
       goal.setValue(user, forKey: "owner")
       // Create datapoint
       let dataPoint = NSEntityDescription.insertNewObject(forEntityName: "DataPoint", into: context)
       dataPoint.setValue("dp1", forKey: "id")
       dataPoint.setValue("20230101", forKey: "daystampRaw")
       dataPoint.setValue(NSDecimalNumber(value: 1.0), forKey: "value")
-      dataPoint.setValue(TestData.dataPointLastModified, forKey: "lastModifiedLocal")
+      dataPoint.setValue(TestData.dataPointLastModified, forKey: lastUpdatedKey)
       dataPoint.setValue(goal, forKey: "goal")
       try context.save()
       return storeURL
@@ -138,6 +137,54 @@ class MigrationTests: XCTestCase {
         "DataPoint date value should be preserved during migration",
       )
     }
+  }
+  // Shipped model versions must never be edited in place: Core Data locates a store's source model by
+  // matching its version hashes against the bundled versions, so changing a shipped version means
+  // existing stores no longer match anything and `loadPersistentStores` fails ("Can't find model for
+  // source store"). Schema changes go in a new version. These checksums are the ones Xcode prints at
+  // build time (they are what `GoalManager` compares to force a full refresh after a model change).
+  func testShippedModelVersionsAreUnchanged() throws {
+    let shippedChecksums = [
+      "BeeminderModel": "Z6+a9G/hRxFiCm6y8ogfqoWpYvVUbDA7WmLpeKtwD00=",
+      "BeeminderModel2": "0LI7wEnFZnYJFWYS3TGErsHhIZofUp7xrJ/1pg7XQvE=",
+      "BeeminderModel3": "DS6ijiKCKtwHb87IGYWZDkBXvlu0COQmp0MUhjFWWkI=",
+    ]
+    let bundle = Bundle(for: BeeminderPersistentContainer.self)
+    for (version, checksum) in shippedChecksums {
+      let url = try XCTUnwrap(
+        bundle.url(forResource: version, withExtension: "mom", subdirectory: "BeeminderModel.momd")
+      )
+      let model = try XCTUnwrap(NSManagedObjectModel(contentsOf: url))
+      XCTAssertEqual(
+        model.versionChecksum,
+        checksum,
+        "\(version) has shipped and must not change; add a new model version for schema changes",
+      )
+    }
+  }
+  // Model version 3 shipped (6.8 stores were created with it), so the current model must be reachable
+  // from it by lightweight migration, with the new `svgUrl` attribute taking its default.
+  func testMigrationFromModelVersion3() throws {
+    DueByTableValueTransformer.register()
+
+    let storeURL = createStoreWithOldModel(version: "BeeminderModel3")
+    let container = BeeminderPersistentContainer(name: "BeeminderModel")
+    let description = NSPersistentStoreDescription(url: storeURL)
+    container.persistentStoreDescriptions = [description]
+    let expectation = XCTestExpectation(description: "Load store")
+    var loadError: Error?
+    container.loadPersistentStores { _, error in
+      loadError = error
+      expectation.fulfill()
+    }
+    wait(for: [expectation], timeout: 5.0)
+    XCTAssertNil(loadError, "Migration from model version 3 should succeed")
+    let context = container.viewContext
+    let goals = try context.fetch(NSFetchRequest<Goal>(entityName: "Goal"))
+    XCTAssertEqual(goals.count, 1, "Should have one goal after migration")
+    let goal: Goal! = goals.first
+    XCTAssertEqual(goal.slug, "test-goal")
+    XCTAssertEqual(goal.svgUrl, "", "svgUrl should default to empty for migrated goals")
   }
   func testAutodataConfigMigration() throws {
     DueByTableValueTransformer.register()

--- a/BeeSwift.xcodeproj/project.pbxproj
+++ b/BeeSwift.xcodeproj/project.pbxproj
@@ -23,7 +23,6 @@
 		E458C8352AD1266B000DCA5C /* SwiftyJSON in Frameworks */ = {isa = PBXBuildFile; productRef = E458C8342AD1266B000DCA5C /* SwiftyJSON */; };
 		E458C8372AD12671000DCA5C /* KeychainSwift in Frameworks */ = {isa = PBXBuildFile; productRef = E458C8362AD12671000DCA5C /* KeychainSwift */; };
 		E462BA3629AC44EA00E80EF0 /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = E462BA3529AC44EA00E80EF0 /* Alamofire */; };
-		E462BA3929AC450000E80EF0 /* AlamofireImage in Frameworks */ = {isa = PBXBuildFile; productRef = E462BA3829AC450000E80EF0 /* AlamofireImage */; };
 		E462BA3C29AC453D00E80EF0 /* AlamofireNetworkActivityIndicator in Frameworks */ = {isa = PBXBuildFile; productRef = E462BA3B29AC453D00E80EF0 /* AlamofireNetworkActivityIndicator */; };
 		E462BA3F29AC456500E80EF0 /* SwiftyJSON in Frameworks */ = {isa = PBXBuildFile; productRef = E462BA3E29AC456500E80EF0 /* SwiftyJSON */; };
 		E462BA4229AC458B00E80EF0 /* MBProgressHUD in Frameworks */ = {isa = PBXBuildFile; productRef = E462BA4129AC458B00E80EF0 /* MBProgressHUD */; };
@@ -183,7 +182,6 @@
 				A1B6723E1B0989DF00584782 /* Foundation.framework in Frameworks */,
 				A17E930C1B09032F0098FCA0 /* QuartzCore.framework in Frameworks */,
 				E462BA3629AC44EA00E80EF0 /* Alamofire in Frameworks */,
-				E462BA3929AC450000E80EF0 /* AlamofireImage in Frameworks */,
 				E462BA4229AC458B00E80EF0 /* MBProgressHUD in Frameworks */,
 				A12BA94E1AFF202200AFEF32 /* SystemConfiguration.framework in Frameworks */,
 				A158DDB61E46EEA10031BD4F /* HealthKit.framework in Frameworks */,
@@ -307,7 +305,6 @@
 			name = BeeSwift;
 			packageProductDependencies = (
 				E462BA3529AC44EA00E80EF0 /* Alamofire */,
-				E462BA3829AC450000E80EF0 /* AlamofireImage */,
 				E462BA3B29AC453D00E80EF0 /* AlamofireNetworkActivityIndicator */,
 				E462BA3E29AC456500E80EF0 /* SwiftyJSON */,
 				E462BA4129AC458B00E80EF0 /* MBProgressHUD */,
@@ -489,7 +486,6 @@
 			mainGroup = A196CB0B1AE4142E00B90A3E;
 			packageReferences = (
 				E462BA3429AC44EA00E80EF0 /* XCRemoteSwiftPackageReference "Alamofire" */,
-				E462BA3729AC450000E80EF0 /* XCRemoteSwiftPackageReference "AlamofireImage" */,
 				E462BA3A29AC453D00E80EF0 /* XCRemoteSwiftPackageReference "AlamofireNetworkActivityIndicator" */,
 				E462BA3D29AC456500E80EF0 /* XCRemoteSwiftPackageReference "SwiftyJSON" */,
 				E462BA4029AC458B00E80EF0 /* XCRemoteSwiftPackageReference "MBProgressHUD" */,
@@ -1088,14 +1084,6 @@
 				minimumVersion = 5.12.0;
 			};
 		};
-		E462BA3729AC450000E80EF0 /* XCRemoteSwiftPackageReference "AlamofireImage" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/Alamofire/AlamofireImage";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 4.4.0;
-			};
-		};
 		E462BA3A29AC453D00E80EF0 /* XCRemoteSwiftPackageReference "AlamofireNetworkActivityIndicator" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Alamofire/AlamofireNetworkActivityIndicator";
@@ -1199,11 +1187,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = E462BA3429AC44EA00E80EF0 /* XCRemoteSwiftPackageReference "Alamofire" */;
 			productName = Alamofire;
-		};
-		E462BA3829AC450000E80EF0 /* AlamofireImage */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = E462BA3729AC450000E80EF0 /* XCRemoteSwiftPackageReference "AlamofireImage" */;
-			productName = AlamofireImage;
 		};
 		E462BA3B29AC453D00E80EF0 /* AlamofireNetworkActivityIndicator */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/BeeSwift.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/BeeSwift.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -11,15 +11,6 @@
       }
     },
     {
-      "identity" : "alamofireimage",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/Alamofire/AlamofireImage",
-      "state" : {
-        "revision" : "4cf73d601c482b7d77bae47de3ef1b8bcf328ec1",
-        "version" : "4.4.0"
-      }
-    },
-    {
       "identity" : "alamofirenetworkactivityindicator",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Alamofire/AlamofireNetworkActivityIndicator",

--- a/BeeSwift/Cells/GoalCollectionViewCell.swift
+++ b/BeeSwift/Cells/GoalCollectionViewCell.swift
@@ -49,11 +49,10 @@ class GoalCollectionViewCell: UICollectionViewCell {
     }
     self.todaytaLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
 
+    // GoalImageView owns its own (fixed) thumbnail size; the cell only positions it.
     self.thumbnailImageView.snp.makeConstraints { (make) -> Void in
       make.left.equalTo(0).offset(self.margin)
       make.top.equalTo(self.slugLabel.snp.bottom).offset(5)
-      make.height.equalTo(Constants.thumbnailHeight)
-      make.width.equalTo(Constants.thumbnailWidth)
     }
 
     self.safesumLabel.textAlignment = NSTextAlignment.center

--- a/BeeSwift/Cells/GoalCollectionViewCell.swift
+++ b/BeeSwift/Cells/GoalCollectionViewCell.swift
@@ -13,7 +13,7 @@ class GoalCollectionViewCell: UICollectionViewCell {
   let slugLabel: BSLabel = BSLabel()
   let titleLabel: BSLabel = BSLabel()
   let todaytaLabel: BSLabel = BSLabel()
-  let thumbnailImageView = GoalImageView(isThumbnail: true)
+  let thumbnailImageView = GoalThumbnailView()
   let safesumLabel: BSLabel = BSLabel()
   let margin = 8
   override init(frame: CGRect) {
@@ -49,7 +49,7 @@ class GoalCollectionViewCell: UICollectionViewCell {
     }
     self.todaytaLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
 
-    // GoalImageView owns its own (fixed) thumbnail size; the cell only positions it.
+    // GoalThumbnailView has a fixed size of its own; the cell only positions it.
     self.thumbnailImageView.snp.makeConstraints { (make) -> Void in
       make.left.equalTo(0).offset(self.margin)
       make.top.equalTo(self.slugLabel.snp.bottom).offset(5)

--- a/BeeSwift/Cells/GoalCollectionViewCell.swift
+++ b/BeeSwift/Cells/GoalCollectionViewCell.swift
@@ -49,7 +49,7 @@ class GoalCollectionViewCell: UICollectionViewCell {
     }
     self.todaytaLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
 
-    // GoalThumbnailView has a fixed size of its own; the cell only positions it.
+    // The view sizes itself; only position it here.
     self.thumbnailImageView.snp.makeConstraints { (make) -> Void in
       make.left.equalTo(0).offset(self.margin)
       make.top.equalTo(self.slugLabel.snp.bottom).offset(5)

--- a/BeeSwift/Components/GoalGraphView.swift
+++ b/BeeSwift/Components/GoalGraphView.swift
@@ -4,10 +4,8 @@ import OSLog
 import UIKit
 import WebKit
 
-/// Live, zoomable graph for the goal-detail screen.
-///
-/// Unlike the gallery thumbnails, this hosts the SVG in a web view so that pinch and double-tap zoom
-/// re-rasterize the vector rather than upscaling a bitmap.
+/// Live, zoomable graph for the goal-detail screen. Hosts the SVG in a web view so that pinch and
+/// double-tap zoom re-rasterize the vector.
 @MainActor final class GoalGraphView: UIView {
   private let logger = Logger(subsystem: "com.beeminder.beeminder", category: "GoalGraphView")
 
@@ -58,8 +56,8 @@ import WebKit
     addSubview(webView)
     webView.snp.makeConstraints { (make) in make.edges.equalToSuperview() }
 
-    // Replaces WebKit's double-tap zoom, which zooms to the SVG's top-left rather than the tapped
-    // point. The document disables the built-in one via touch-action.
+    // Double-tap zooms to the tapped point. WebKit's own double-tap zoom (which targets the SVG's
+    // top-left) is disabled by the document's touch-action rule.
     let doubleTap = UITapGestureRecognizer(target: self, action: #selector(handleDoubleTap(_:)))
     doubleTap.numberOfTapsRequired = 2
     webView.addGestureRecognizer(doubleTap)
@@ -128,7 +126,7 @@ import WebKit
     <meta name="color-scheme" content="light dark">
     <style>
       :root { color-scheme: light dark; }
-      /* Allows pan and pinch-zoom but not WebKit's double-tap zoom, which is replaced natively. */
+      /* Allows pan and pinch-zoom; double-tap is left to the native gesture recognizer. */
       html, body { margin: 0; padding: 0; background: #ffffff; touch-action: manipulation; }
       svg { display: block; width: 100%; height: auto; touch-action: manipulation; }
       @media (prefers-color-scheme: dark) {

--- a/BeeSwift/Components/GoalGraphView.swift
+++ b/BeeSwift/Components/GoalGraphView.swift
@@ -1,0 +1,153 @@
+import BeeKit
+import Foundation
+import OSLog
+import UIKit
+import WebKit
+
+/// Live, zoomable graph for the goal-detail screen.
+///
+/// Unlike the gallery thumbnails (`GoalThumbnailView`, which snapshots the SVG to a `UIImage`), this
+/// hosts the SVG in a live `WKWebView`, so pinch- and double-tap-zoom re-rasterize the vector
+/// crisply rather than upscaling a bitmap. Light/dark is handled natively via a
+/// `@media (prefers-color-scheme: dark)` query (WebKit re-themes when the trait collection flips,
+/// in step with the rest of the UI — no JavaScript round-trip), reusing the exact same theme and
+/// download cache as `SVGImageRenderer`.
+@MainActor final class GoalGraphView: UIView {
+  private let logger = Logger(subsystem: "com.beeminder.beeminder", category: "GoalGraphView")
+
+  private let webView: WKWebView
+
+  /// The graph URL currently loaded, to avoid redundant reloads.
+  private var loadedURL: String?
+
+  var goal: Goal? {
+    didSet {
+      if goal?.id != oldValue?.id { loadedURL = nil }
+      refresh()
+    }
+  }
+
+  override init(frame: CGRect) {
+    webView = WKWebView(frame: .zero, configuration: Self.makeConfiguration())
+    super.init(frame: frame)
+    setupView()
+  }
+
+  required init?(coder: NSCoder) {
+    webView = WKWebView(frame: .zero, configuration: Self.makeConfiguration())
+    super.init(coder: coder)
+    setupView()
+  }
+
+  /// The graph is static markup — nothing in it needs to run script — so content JavaScript is off.
+  /// (The SVG is fetched from the CDN, so this also limits what a tampered asset could do.) Zooming is
+  /// handled by the web view's scroll view natively and does not depend on script.
+  private static func makeConfiguration() -> WKWebViewConfiguration {
+    let configuration = WKWebViewConfiguration()
+    configuration.defaultWebpagePreferences.allowsContentJavaScript = false
+    return configuration
+  }
+
+  private func setupView() {
+    webView.isOpaque = false
+    webView.backgroundColor = .clear
+    webView.scrollView.backgroundColor = .systemBackground  // matches the graph's themed canvas
+    webView.scrollView.bounces = false
+    webView.scrollView.isDirectionalLockEnabled = false  // allow free (diagonal) panning when zoomed
+    webView.scrollView.showsHorizontalScrollIndicator = false
+    webView.scrollView.showsVerticalScrollIndicator = false
+    webView.scrollView.contentInsetAdjustmentBehavior = .never
+    webView.scrollView.minimumZoomScale = 1
+    webView.scrollView.maximumZoomScale = Self.maxZoom
+
+    addSubview(webView)
+    webView.snp.makeConstraints { (make) in make.edges.equalToSuperview() }
+
+    // Our own double-tap zoom. WebKit's built-in one is disabled from the document side with
+    // `touch-action: manipulation` (see htmlDocument) because it zooms to the top-left of an SVG
+    // rather than to the tapped point.
+    let doubleTap = UITapGestureRecognizer(target: self, action: #selector(handleDoubleTap(_:)))
+    doubleTap.numberOfTapsRequired = 2
+    webView.addGestureRecognizer(doubleTap)
+
+    // Reload when the goal's data changes (e.g. a new datapoint regenerates the graph, changing its
+    // cache-busting URL). refresh() is a no-op when nothing relevant changed. (Light/dark needs no
+    // handling here — the @media query re-themes natively.)
+    NotificationCenter.default.addObserver(
+      forName: .NSManagedObjectContextObjectsDidChange,
+      object: ServiceLocator.persistentContainer.viewContext,
+      queue: OperationQueue.main,
+    ) { [weak self] _ in DispatchQueue.main.async { self?.refresh() } }
+  }
+
+  private func refresh() {
+    guard let goal else { return }
+    let urlString = goal.cacheBustingSvgUrl
+    guard !urlString.isEmpty, urlString != loadedURL else { return }
+
+    loadedURL = urlString
+    Task { [weak self] in
+      guard let self else { return }
+      do {
+        let data = try await SVGImageRenderer.shared.svgData(for: urlString)
+        // A newer goal may have been set while we were downloading.
+        guard urlString == self.loadedURL else { return }
+        let svg = String(decoding: data, as: UTF8.self)
+        self.webView.loadHTMLString(Self.htmlDocument(svg: svg), baseURL: nil)
+      } catch {
+        self.logger.error("Error loading goal graph: \(error)")
+        if urlString == self.loadedURL { self.loadedURL = nil }
+      }
+    }
+  }
+
+  // MARK: - Zoom
+
+  private static let maxZoom: CGFloat = 3
+
+  /// Double-tap toggles between fit (1x) and zoomed-in, centered on the tapped point.
+  @objc private func handleDoubleTap(_ recognizer: UITapGestureRecognizer) {
+    let scrollView = webView.scrollView
+    if scrollView.zoomScale > scrollView.minimumZoomScale {
+      scrollView.setZoomScale(scrollView.minimumZoomScale, animated: true)
+      return
+    }
+    let targetScale = min(2.5, scrollView.maximumZoomScale)
+    let point = recognizer.location(in: webView)  // content coords (== view coords at 1x)
+    let size = CGSize(width: scrollView.bounds.width / targetScale, height: scrollView.bounds.height / targetScale)
+    let rect = CGRect(
+      x: point.x - size.width / 2,
+      y: point.y - size.height / 2,
+      width: size.width,
+      height: size.height,
+    )
+    scrollView.zoom(to: rect, animated: true)
+  }
+
+  // MARK: - HTML
+
+  private static func htmlDocument(svg: String) -> String {
+    // Both appearances are baked in: light is the default, the dark overrides live behind a
+    // prefers-color-scheme media query so WebKit applies them automatically with the trait change.
+    """
+    <!DOCTYPE html>
+    <html>
+    <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=\(Int(maxZoom))">
+    <meta name="color-scheme" content="light dark">
+    <style>
+      :root { color-scheme: light dark; }
+      /* `manipulation` keeps panning and pinch-zoom but turns off WebKit's double-tap-to-zoom, which
+         GoalGraphView replaces with its own tap-centred zoom. */
+      html, body { margin: 0; padding: 0; background: #ffffff; touch-action: manipulation; }
+      svg { display: block; width: 100%; height: auto; touch-action: manipulation; }
+      @media (prefers-color-scheme: dark) {
+        \(SVGImageRenderer.darkThemeCSS)
+      }
+    </style>
+    </head>
+    <body>\(svg)</body>
+    </html>
+    """
+  }
+}

--- a/BeeSwift/Components/GoalGraphView.swift
+++ b/BeeSwift/Components/GoalGraphView.swift
@@ -6,12 +6,8 @@ import WebKit
 
 /// Live, zoomable graph for the goal-detail screen.
 ///
-/// Unlike the gallery thumbnails (`GoalThumbnailView`, which snapshots the SVG to a `UIImage`), this
-/// hosts the SVG in a live `WKWebView`, so pinch- and double-tap-zoom re-rasterize the vector
-/// crisply rather than upscaling a bitmap. Light/dark is handled natively via a
-/// `@media (prefers-color-scheme: dark)` query (WebKit re-themes when the trait collection flips,
-/// in step with the rest of the UI — no JavaScript round-trip), reusing the exact same theme and
-/// download cache as `SVGImageRenderer`.
+/// Unlike the gallery thumbnails, this hosts the SVG in a web view so that pinch and double-tap zoom
+/// re-rasterize the vector rather than upscaling a bitmap.
 @MainActor final class GoalGraphView: UIView {
   private let logger = Logger(subsystem: "com.beeminder.beeminder", category: "GoalGraphView")
 
@@ -39,9 +35,8 @@ import WebKit
     setupView()
   }
 
-  /// The graph is static markup — nothing in it needs to run script — so content JavaScript is off.
-  /// (The SVG is fetched from the CDN, so this also limits what a tampered asset could do.) Zooming is
-  /// handled by the web view's scroll view natively and does not depend on script.
+  /// The graph needs no script, so content JavaScript is off. This also limits what a tampered CDN
+  /// asset could do.
   private static func makeConfiguration() -> WKWebViewConfiguration {
     let configuration = WKWebViewConfiguration()
     configuration.defaultWebpagePreferences.allowsContentJavaScript = false
@@ -63,16 +58,13 @@ import WebKit
     addSubview(webView)
     webView.snp.makeConstraints { (make) in make.edges.equalToSuperview() }
 
-    // Our own double-tap zoom. WebKit's built-in one is disabled from the document side with
-    // `touch-action: manipulation` (see htmlDocument) because it zooms to the top-left of an SVG
-    // rather than to the tapped point.
+    // Replaces WebKit's double-tap zoom, which zooms to the SVG's top-left rather than the tapped
+    // point. The document disables the built-in one via touch-action.
     let doubleTap = UITapGestureRecognizer(target: self, action: #selector(handleDoubleTap(_:)))
     doubleTap.numberOfTapsRequired = 2
     webView.addGestureRecognizer(doubleTap)
 
-    // Reload when the goal's data changes (e.g. a new datapoint regenerates the graph, changing its
-    // cache-busting URL). refresh() is a no-op when nothing relevant changed. (Light/dark needs no
-    // handling here — the @media query re-themes natively.)
+    // A new datapoint regenerates the graph, changing its cache-busting URL.
     NotificationCenter.default.addObserver(
       forName: .NSManagedObjectContextObjectsDidChange,
       object: ServiceLocator.persistentContainer.viewContext,
@@ -127,8 +119,7 @@ import WebKit
   // MARK: - HTML
 
   private static func htmlDocument(svg: String) -> String {
-    // Both appearances are baked in: light is the default, the dark overrides live behind a
-    // prefers-color-scheme media query so WebKit applies them automatically with the trait change.
+    // Light is the default; WebKit applies the dark theme itself when the trait collection changes.
     """
     <!DOCTYPE html>
     <html>
@@ -137,8 +128,7 @@ import WebKit
     <meta name="color-scheme" content="light dark">
     <style>
       :root { color-scheme: light dark; }
-      /* `manipulation` keeps panning and pinch-zoom but turns off WebKit's double-tap-to-zoom, which
-         GoalGraphView replaces with its own tap-centred zoom. */
+      /* Allows pan and pinch-zoom but not WebKit's double-tap zoom, which is replaced natively. */
       html, body { margin: 0; padding: 0; background: #ffffff; touch-action: manipulation; }
       svg { display: block; width: 100%; height: auto; touch-action: manipulation; }
       @media (prefers-color-scheme: dark) {

--- a/BeeSwift/Components/GoalImageView.swift
+++ b/BeeSwift/Components/GoalImageView.swift
@@ -1,23 +1,41 @@
-import Alamofire
-import AlamofireImage
 import BeeKit
 import Foundation
 import OSLog
+import SnapKit
+import UIKit
 
 /// Shows the current graph for a goal
 /// Handles placeholders for loading and queued states, and automatically updates when the goal changes
 class GoalImageView: UIView {
-  private static let downloader = ImageDownloader(imageCache: AutoPurgingImageCache())
   private let logger = Logger(subsystem: "com.beeminder.beeminder", category: "GoalImageView")
 
   private let imageView = UIImageView()
   private let beeLemniscateView = BeeLemniscateView()
 
   private var currentlyShowingGraph = false
-  private var inProgressDownload: RequestReceipt? = nil
-  private var currentDownloadToken: UUID? = nil
+  /// Invalidates in-flight renders so their callbacks no-op (avoids races when the goal changes or
+  /// renders finish out of order).
+  private var currentRenderToken: UUID? = nil
+  private var currentRenderTask: Task<Void, Never>? = nil
+  /// The render key currently displayed, to avoid redundant re-rendering.
+  private var shownRenderKey: String? = nil
+  /// The render key currently being rendered, so a burst of identical requests (e.g. repeated layout
+  /// passes) starts only one render.
+  private var inFlightRenderKey: String? = nil
 
   public let isThumbnail: Bool
+
+  // MARK: Sizing
+  //
+  // GoalImageView owns the resolution it rasterizes at. Thumbnails are a fixed size (so transient
+  // layout passes never change it, and thus never trigger a re-render); the detail view rasterizes
+  // at whatever width its container lays it out to.
+
+  /// The fixed point size of a thumbnail graph view.
+  static let thumbnailSize = CGSize(width: Constants.thumbnailWidth, height: Constants.thumbnailHeight)
+
+  /// The width (in points) the graph is rasterized at.
+  private var renderWidth: CGFloat { isThumbnail ? Self.thumbnailSize.width : bounds.width }
 
   public var goal: Goal? {
     didSet {
@@ -40,6 +58,8 @@ class GoalImageView: UIView {
   }
 
   private func setupView() {
+    if isThumbnail { self.snp.makeConstraints { (make) in make.size.equalTo(Self.thumbnailSize) } }
+
     self.addSubview(imageView)
     imageView.snp.makeConstraints { (make) in make.edges.equalToSuperview() }
     self.imageView.image = UIImage(named: "GraphPlaceholder")
@@ -48,6 +68,17 @@ class GoalImageView: UIView {
     beeLemniscateView.snp.makeConstraints { (make) in make.edges.equalToSuperview() }
     beeLemniscateView.isHidden = true
 
+    // Re-render when the user switches between light and dark mode.
+    registerForTraitChanges([UITraitUserInterfaceStyle.self]) { (self: Self, _: UITraitCollection) in self.refresh() }
+
+    // Re-check appearance when the scene becomes active again — catches genuine light/dark changes
+    // made while we were backgrounded or inactive (where we deliberately skip rendering; see refresh).
+    NotificationCenter.default.addObserver(
+      forName: UIScene.didActivateNotification,
+      object: nil,
+      queue: OperationQueue.main,
+    ) { [weak self] _ in self?.refresh() }
+
     NotificationCenter.default.addObserver(
       forName: .NSManagedObjectContextObjectsDidChange,
       object: ServiceLocator.persistentContainer.viewContext,
@@ -55,7 +86,18 @@ class GoalImageView: UIView {
     ) { [weak self] _ in DispatchQueue.main.async { self?.refresh() } }
     refresh()
   }
+
+  override func layoutSubviews() {
+    super.layoutSubviews()
+    // The detail view rasterizes at its laid-out width (often zero until the first layout pass), so
+    // re-render when that changes. Thumbnails render at a fixed width and don't depend on layout.
+    if !isThumbnail { refresh() }
+  }
+
   @MainActor private func clearGoalGraph() {
+    currentRenderTask?.cancel()
+    currentRenderTask = nil
+    shownRenderKey = nil
     imageView.image = UIImage(named: "GraphPlaceholder")
     currentlyShowingGraph = false
     beeLemniscateView.isHidden = true
@@ -91,16 +133,6 @@ class GoalImageView: UIView {
   }
 
   @MainActor private func refresh() {
-    // Invalidate the download token, meaning that any queued download callbacks
-    // will no-op. This avoids race conditions with downloads finishing out of order.
-    let newDownloadToken = UUID()
-    self.currentDownloadToken = newDownloadToken
-
-    if let downloadReceipt = inProgressDownload {
-      GoalImageView.downloader.cancelRequest(with: downloadReceipt)
-      inProgressDownload = nil
-    }
-
     //  No Goal: Placeholder, no animation
     guard let goal = self.goal else {
       clearGoalGraph()
@@ -117,36 +149,76 @@ class GoalImageView: UIView {
     // but not over the placeholder image.
     if goal.queued { beeLemniscateView.isHidden = !currentlyShowingGraph }
 
-    let urlString = isThumbnail ? goal.cacheBustingThumbUrl : goal.cacheBustingGraphUrl
-    let request = URLRequest(url: URL(string: urlString)!)
+    // The detail view needs a laid-out width before it can rasterize; layoutSubviews calls us again
+    // once it has one. (Thumbnails use a fixed renderWidth, so this is always satisfied for them.)
+    let outputWidth = renderWidth
+    guard outputWidth > 0 else { return }
 
-    // Explicitly check the cache to see if the image is already present, and if so set it directly
-    // This avoids flicker when showing images from the cache, which will otherwise briefly show
-    // the placeholder while waiting for the async download callback
-    if let image = GoalImageView.downloader.imageCache?.image(for: request, withIdentifier: nil) {
-      showGraphImage(image: image)
+    let urlString = goal.cacheBustingSvgUrl
+    guard !urlString.isEmpty else {
+      // No SVG URL yet (e.g. a goal cached before this field existed); leave the placeholder until
+      // the next data refresh populates it.
       return
     }
 
-    // Download the image and show it once downloaded
-    inProgressDownload = GoalImageView.downloader.download(
-      request,
-      completion: { response in
-        if newDownloadToken != self.currentDownloadToken {
-          // Another refresh has happend since we were enqueued. Skip performing any updates
-          return
-        }
+    let darkMode = traitCollection.userInterfaceStyle == .dark
+    let renderKey = "\(urlString)|w\(Int(outputWidth))|\(darkMode)"
 
-        switch response.result {
-        case .success(let image):
-          // Image downloaded. Show it, and have loading indicator match queued state
+    // Already showing — or already rendering — exactly this; nothing to do. (refresh() is called
+    // frequently via Core Data change notifications and, for the detail view, layout passes.)
+    if renderKey == shownRenderKey || renderKey == inFlightRenderKey { return }
+
+    // Don't start a render while the scene is backgrounded. When backgrounding, iOS re-renders the
+    // app in the opposite appearance to cache an app-switcher snapshot, transiently flipping our
+    // trait collection; any refresh() during that window (trait change, layout pass, or Core Data
+    // notification) would otherwise render a wrong-appearance graph that briefly flashes on return.
+    // UIScene.didActivateNotification re-runs refresh() once we're active again.
+    if window?.windowScene?.activationState == .background { return }
+
+    // Synchronous cache hit: display in this same runloop so a reused cell's placeholder is replaced
+    // immediately rather than flashing until an async render completes.
+    if let cached = SVGImageRenderer.shared.cachedImage(
+      urlString: urlString,
+      outputWidth: outputWidth,
+      darkMode: darkMode,
+      cropToPlot: isThumbnail,
+    ) {
+      currentRenderTask?.cancel()
+      currentRenderToken = UUID()
+      inFlightRenderKey = nil
+      shownRenderKey = renderKey
+      showGraphImage(image: cached)
+      return
+    }
+
+    // Invalidate any in-flight render and start a new one.
+    let token = UUID()
+    currentRenderToken = token
+    inFlightRenderKey = renderKey
+    currentRenderTask?.cancel()
+
+    currentRenderTask = Task { [weak self] in
+      guard let self else { return }
+      defer { if token == self.currentRenderToken { self.inFlightRenderKey = nil } }
+      do {
+        // Renders the current appearance (displayed via the callback as soon as it's ready) and, from
+        // the same page load, also caches the opposite appearance so a light/dark switch is instant.
+        try await SVGImageRenderer.shared.renderBothAppearances(
+          urlString: urlString,
+          outputWidth: outputWidth,
+          darkMode: darkMode,
+          cropToPlot: isThumbnail,
+        ) { [weak self] image in
+          guard let self, !Task.isCancelled, token == self.currentRenderToken else { return }
+          self.shownRenderKey = renderKey
           self.showGraphImage(image: image)
-          break
-        case .failure(let error):
-          self.logger.error("Error downloading goal graph: \(error)")
-          self.clearGoalGraph()
         }
-      },
-    )
+      } catch is CancellationError {
+        // Superseded by a newer render; ignore.
+      } catch {
+        if token != self.currentRenderToken { return }
+        self.logger.error("Error rendering goal graph: \(error)")
+      }
+    }
   }
 }

--- a/BeeSwift/Components/GoalThumbnailView.swift
+++ b/BeeSwift/Components/GoalThumbnailView.swift
@@ -6,7 +6,7 @@ import UIKit
 
 /// The graph thumbnail shown for a goal in the gallery. Shows a placeholder until the graph is
 /// rendered and a loading indicator while the goal is queued, and updates when the goal or the
-/// appearance changes. The goal-detail screen uses `GoalGraphView` instead.
+/// appearance changes.
 class GoalThumbnailView: UIView {
   private let logger = Logger(subsystem: "com.beeminder.beeminder", category: "GoalThumbnailView")
 
@@ -74,8 +74,8 @@ class GoalThumbnailView: UIView {
   @MainActor private func clearGoalGraph() {
     currentRenderTask?.cancel()
     currentRenderTask = nil
-    // The cancelled render never displays, so drop its key too: a later request for the same key
-    // (e.g. a reused cell re-bound to the same goal) must start afresh.
+    // Drop the in-flight key too, so a later request for the same key (e.g. a reused cell re-bound
+    // to the same goal) starts a fresh render; the cancelled one will not display.
     currentRenderToken = nil
     inFlightRenderKey = nil
     shownRenderKey = nil
@@ -128,12 +128,9 @@ class GoalThumbnailView: UIView {
     // refresh() runs on every Core Data change; bail if nothing relevant changed.
     if renderKey == shownRenderKey || renderKey == inFlightRenderKey { return }
 
-    // When backgrounding, iOS briefly flips the appearance to capture an app-switcher snapshot for
-    // the other mode. A render started then would show the wrong appearance on return, so skip it;
-    // the scene-activation observer refreshes once active again.
-    if window?.windowScene?.activationState == .background { return }
-
-    // Show cache hits synchronously so a reused cell doesn't flash the placeholder.
+    // Show cache hits synchronously so a reused cell doesn't flash the placeholder. This also covers
+    // the app-switcher snapshot iOS captures for the other appearance when backgrounding, since the
+    // renderer caches both appearances.
     if let cached = SVGImageRenderer.shared.cachedImage(
       urlString: urlString,
       outputWidth: outputWidth,
@@ -147,6 +144,11 @@ class GoalThumbnailView: UIView {
       showGraphImage(image: cached)
       return
     }
+
+    // Start no new render while backgrounded: one begun during the app-switcher snapshot pass would
+    // finish after the appearance has flipped back and show the wrong one. The scene-activation
+    // observer refreshes once active again.
+    if window?.windowScene?.activationState == .background { return }
 
     let token = UUID()
     currentRenderToken = token

--- a/BeeSwift/Components/GoalThumbnailView.swift
+++ b/BeeSwift/Components/GoalThumbnailView.swift
@@ -4,10 +4,9 @@ import OSLog
 import SnapKit
 import UIKit
 
-/// Shows the thumbnail graph for a goal in the gallery: the SVG rasterized (via `SVGImageRenderer`) and
-/// cropped to its plot box, at a fixed size. Handles placeholders for loading and queued states, and
-/// automatically updates when the goal changes or the appearance flips. (The goal-detail screen uses
-/// the live, zoomable `GoalGraphView` instead.)
+/// The graph thumbnail shown for a goal in the gallery. Shows a placeholder until the graph is
+/// rendered and a loading indicator while the goal is queued, and updates when the goal or the
+/// appearance changes. The goal-detail screen uses `GoalGraphView` instead.
 class GoalThumbnailView: UIView {
   private let logger = Logger(subsystem: "com.beeminder.beeminder", category: "GoalThumbnailView")
 
@@ -15,18 +14,15 @@ class GoalThumbnailView: UIView {
   private let beeLemniscateView = BeeLemniscateView()
 
   private var currentlyShowingGraph = false
-  /// Invalidates in-flight renders so their callbacks no-op (avoids races when the goal changes or
-  /// renders finish out of order).
+  /// Identifies the latest render so that callbacks from superseded ones are ignored.
   private var currentRenderToken: UUID? = nil
   private var currentRenderTask: Task<Void, Never>? = nil
-  /// The render key currently displayed, to avoid redundant re-rendering.
+  /// Key of the render currently displayed.
   private var shownRenderKey: String? = nil
-  /// The render key currently being rendered, so a burst of identical requests (e.g. repeated Core
-  /// Data change notifications) starts only one render.
+  /// Key of the render in progress, so repeated refreshes don't start duplicate renders.
   private var inFlightRenderKey: String? = nil
 
-  /// The fixed point size of the view, which is also the resolution the graph is rasterized at. Being
-  /// fixed (rather than layout-driven) means transient layout passes can never trigger a re-render.
+  /// Fixed size, which is also the rasterization resolution, so layout passes never trigger a render.
   static let size = CGSize(width: Constants.thumbnailWidth, height: Constants.thumbnailHeight)
 
   public var goal: Goal? {
@@ -58,11 +54,9 @@ class GoalThumbnailView: UIView {
     beeLemniscateView.snp.makeConstraints { (make) in make.edges.equalToSuperview() }
     beeLemniscateView.isHidden = true
 
-    // Re-render when the user switches between light and dark mode.
     registerForTraitChanges([UITraitUserInterfaceStyle.self]) { (self: Self, _: UITraitCollection) in self.refresh() }
 
-    // Re-check appearance when the scene becomes active again — catches genuine light/dark changes
-    // made while we were backgrounded or inactive (where we deliberately skip rendering; see refresh).
+    // Renders are skipped while backgrounded (see refresh), so re-check on activation.
     NotificationCenter.default.addObserver(
       forName: UIScene.didActivateNotification,
       object: nil,
@@ -80,10 +74,8 @@ class GoalThumbnailView: UIView {
   @MainActor private func clearGoalGraph() {
     currentRenderTask?.cancel()
     currentRenderTask = nil
-    // Invalidate the token so the cancelled task's callbacks (and its deferred cleanup) no-op, and
-    // forget the in-flight key: the cancelled render will never display, so a subsequent request for
-    // the same key (e.g. a reused cell re-bound to the same goal) must start a fresh render rather
-    // than being treated as already in progress.
+    // The cancelled render never displays, so drop its key too: a later request for the same key
+    // (e.g. a reused cell re-bound to the same goal) must start afresh.
     currentRenderToken = nil
     inFlightRenderKey = nil
     shownRenderKey = nil
@@ -99,8 +91,7 @@ class GoalThumbnailView: UIView {
   }
 
   @MainActor private func showGraphImage(image: UIImage) {
-    // Deliberately not animated: a transition interacts badly with cell re-use in the gallery, e.g.
-    // it would briefly show the image from a different goal before animating to the correct one.
+    // Not animated: with cell re-use a transition can briefly show the previous goal's graph.
     imageView.image = image
     beeLemniscateView.isHidden = goal == nil || goal?.queued == false
     updateBorder()
@@ -127,27 +118,22 @@ class GoalThumbnailView: UIView {
     let outputWidth = Self.size.width
     let urlString = goal.cacheBustingSvgUrl
     guard !urlString.isEmpty else {
-      // No SVG URL yet (e.g. a goal cached before this field existed); leave the placeholder until
-      // the next data refresh populates it.
+      // Goals cached before svgUrl existed have none until the next refresh; keep the placeholder.
       return
     }
 
     let darkMode = traitCollection.userInterfaceStyle == .dark
     let renderKey = "\(urlString)|w\(Int(outputWidth))|\(darkMode)"
 
-    // Already showing — or already rendering — exactly this; nothing to do. (refresh() is called
-    // frequently via Core Data change notifications.)
+    // refresh() runs on every Core Data change; bail if nothing relevant changed.
     if renderKey == shownRenderKey || renderKey == inFlightRenderKey { return }
 
-    // Don't start a render while the scene is backgrounded. When backgrounding, iOS re-renders the
-    // app in the opposite appearance to cache an app-switcher snapshot, transiently flipping our
-    // trait collection; any refresh() during that window (trait change or Core Data notification)
-    // would otherwise render a wrong-appearance graph that briefly flashes on return.
-    // UIScene.didActivateNotification re-runs refresh() once we're active again.
+    // When backgrounding, iOS briefly flips the appearance to capture an app-switcher snapshot for
+    // the other mode. A render started then would show the wrong appearance on return, so skip it;
+    // the scene-activation observer refreshes once active again.
     if window?.windowScene?.activationState == .background { return }
 
-    // Synchronous cache hit: display in this same runloop so a reused cell's placeholder is replaced
-    // immediately rather than flashing until an async render completes.
+    // Show cache hits synchronously so a reused cell doesn't flash the placeholder.
     if let cached = SVGImageRenderer.shared.cachedImage(
       urlString: urlString,
       outputWidth: outputWidth,
@@ -162,7 +148,6 @@ class GoalThumbnailView: UIView {
       return
     }
 
-    // Invalidate any in-flight render and start a new one.
     let token = UUID()
     currentRenderToken = token
     inFlightRenderKey = renderKey
@@ -172,8 +157,6 @@ class GoalThumbnailView: UIView {
       guard let self else { return }
       defer { if token == self.currentRenderToken { self.inFlightRenderKey = nil } }
       do {
-        // Renders the current appearance (displayed via the callback as soon as it's ready) and, from
-        // the same page load, also caches the opposite appearance so a light/dark switch is instant.
         try await SVGImageRenderer.shared.renderBothAppearances(
           urlString: urlString,
           outputWidth: outputWidth,
@@ -185,7 +168,7 @@ class GoalThumbnailView: UIView {
           self.showGraphImage(image: image)
         }
       } catch is CancellationError {
-        // Superseded by a newer render; ignore.
+        // Superseded by a newer render.
       } catch {
         if token != self.currentRenderToken { return }
         self.logger.error("Error rendering goal graph: \(error)")

--- a/BeeSwift/Components/GoalThumbnailView.swift
+++ b/BeeSwift/Components/GoalThumbnailView.swift
@@ -4,10 +4,12 @@ import OSLog
 import SnapKit
 import UIKit
 
-/// Shows the current graph for a goal
-/// Handles placeholders for loading and queued states, and automatically updates when the goal changes
-class GoalImageView: UIView {
-  private let logger = Logger(subsystem: "com.beeminder.beeminder", category: "GoalImageView")
+/// Shows the thumbnail graph for a goal in the gallery: the SVG rasterized (via `SVGImageRenderer`) and
+/// cropped to its plot box, at a fixed size. Handles placeholders for loading and queued states, and
+/// automatically updates when the goal changes or the appearance flips. (The goal-detail screen uses
+/// the live, zoomable `GoalGraphView` instead.)
+class GoalThumbnailView: UIView {
+  private let logger = Logger(subsystem: "com.beeminder.beeminder", category: "GoalThumbnailView")
 
   private let imageView = UIImageView()
   private let beeLemniscateView = BeeLemniscateView()
@@ -19,23 +21,13 @@ class GoalImageView: UIView {
   private var currentRenderTask: Task<Void, Never>? = nil
   /// The render key currently displayed, to avoid redundant re-rendering.
   private var shownRenderKey: String? = nil
-  /// The render key currently being rendered, so a burst of identical requests (e.g. repeated layout
-  /// passes) starts only one render.
+  /// The render key currently being rendered, so a burst of identical requests (e.g. repeated Core
+  /// Data change notifications) starts only one render.
   private var inFlightRenderKey: String? = nil
 
-  public let isThumbnail: Bool
-
-  // MARK: Sizing
-  //
-  // GoalImageView owns the resolution it rasterizes at. Thumbnails are a fixed size (so transient
-  // layout passes never change it, and thus never trigger a re-render); the detail view rasterizes
-  // at whatever width its container lays it out to.
-
-  /// The fixed point size of a thumbnail graph view.
-  static let thumbnailSize = CGSize(width: Constants.thumbnailWidth, height: Constants.thumbnailHeight)
-
-  /// The width (in points) the graph is rasterized at.
-  private var renderWidth: CGFloat { isThumbnail ? Self.thumbnailSize.width : bounds.width }
+  /// The fixed point size of the view, which is also the resolution the graph is rasterized at. Being
+  /// fixed (rather than layout-driven) means transient layout passes can never trigger a re-render.
+  static let size = CGSize(width: Constants.thumbnailWidth, height: Constants.thumbnailHeight)
 
   public var goal: Goal? {
     didSet {
@@ -45,20 +37,18 @@ class GoalImageView: UIView {
     }
   }
 
-  init(isThumbnail: Bool) {
-    self.isThumbnail = isThumbnail
-    super.init(frame: CGRect(x: 0, y: 0, width: 0, height: 0))
+  init() {
+    super.init(frame: CGRect(origin: .zero, size: Self.size))
     setupView()
   }
 
   required init?(coder: NSCoder) {
-    self.isThumbnail = false
     super.init(coder: coder)
     setupView()
   }
 
   private func setupView() {
-    if isThumbnail { self.snp.makeConstraints { (make) in make.size.equalTo(Self.thumbnailSize) } }
+    self.snp.makeConstraints { (make) in make.size.equalTo(Self.size) }
 
     self.addSubview(imageView)
     imageView.snp.makeConstraints { (make) in make.edges.equalToSuperview() }
@@ -77,7 +67,7 @@ class GoalImageView: UIView {
       forName: UIScene.didActivateNotification,
       object: nil,
       queue: OperationQueue.main,
-    ) { [weak self] _ in self?.refresh() }
+    ) { [weak self] _ in DispatchQueue.main.async { self?.refresh() } }
 
     NotificationCenter.default.addObserver(
       forName: .NSManagedObjectContextObjectsDidChange,
@@ -87,16 +77,15 @@ class GoalImageView: UIView {
     refresh()
   }
 
-  override func layoutSubviews() {
-    super.layoutSubviews()
-    // The detail view rasterizes at its laid-out width (often zero until the first layout pass), so
-    // re-render when that changes. Thumbnails render at a fixed width and don't depend on layout.
-    if !isThumbnail { refresh() }
-  }
-
   @MainActor private func clearGoalGraph() {
     currentRenderTask?.cancel()
     currentRenderTask = nil
+    // Invalidate the token so the cancelled task's callbacks (and its deferred cleanup) no-op, and
+    // forget the in-flight key: the cancelled render will never display, so a subsequent request for
+    // the same key (e.g. a reused cell re-bound to the same goal) must start a fresh render rather
+    // than being treated as already in progress.
+    currentRenderToken = nil
+    inFlightRenderKey = nil
     shownRenderKey = nil
     imageView.image = UIImage(named: "GraphPlaceholder")
     currentlyShowingGraph = false
@@ -105,31 +94,17 @@ class GoalImageView: UIView {
   }
 
   @MainActor private func updateBorder() {
-    if isThumbnail {
-      imageView.layer.borderColor = goal?.countdownColor.cgColor
-      imageView.layer.borderWidth = goal == nil ? 0 : 1
-    } else {
-      imageView.layer.borderColor = nil
-      imageView.layer.borderWidth = 0
-    }
+    imageView.layer.borderColor = goal?.countdownColor.cgColor
+    imageView.layer.borderWidth = goal == nil ? 0 : 1
   }
 
   @MainActor private func showGraphImage(image: UIImage) {
-    // Animating the thumbnail view interacts badly with cell re-use in the gallery
-    // e.g. it would cause us to show the image from a different goal before animating
-    // to the corrent one.
-    let duration = isThumbnail ? 0 : 0.4
-
-    UIView.transition(
-      with: imageView,
-      duration: duration,
-      options: .transitionCrossDissolve,
-      animations: { [weak self] in
-        self?.imageView.image = image
-        self?.beeLemniscateView.isHidden = self?.goal == nil || self?.goal?.queued == false
-        self?.updateBorder()
-      },
-    ) { [weak self] _ in self?.currentlyShowingGraph = true }
+    // Deliberately not animated: a transition interacts badly with cell re-use in the gallery, e.g.
+    // it would briefly show the image from a different goal before animating to the correct one.
+    imageView.image = image
+    beeLemniscateView.isHidden = goal == nil || goal?.queued == false
+    updateBorder()
+    currentlyShowingGraph = true
   }
 
   @MainActor private func refresh() {
@@ -149,11 +124,7 @@ class GoalImageView: UIView {
     // but not over the placeholder image.
     if goal.queued { beeLemniscateView.isHidden = !currentlyShowingGraph }
 
-    // The detail view needs a laid-out width before it can rasterize; layoutSubviews calls us again
-    // once it has one. (Thumbnails use a fixed renderWidth, so this is always satisfied for them.)
-    let outputWidth = renderWidth
-    guard outputWidth > 0 else { return }
-
+    let outputWidth = Self.size.width
     let urlString = goal.cacheBustingSvgUrl
     guard !urlString.isEmpty else {
       // No SVG URL yet (e.g. a goal cached before this field existed); leave the placeholder until
@@ -165,13 +136,13 @@ class GoalImageView: UIView {
     let renderKey = "\(urlString)|w\(Int(outputWidth))|\(darkMode)"
 
     // Already showing — or already rendering — exactly this; nothing to do. (refresh() is called
-    // frequently via Core Data change notifications and, for the detail view, layout passes.)
+    // frequently via Core Data change notifications.)
     if renderKey == shownRenderKey || renderKey == inFlightRenderKey { return }
 
     // Don't start a render while the scene is backgrounded. When backgrounding, iOS re-renders the
     // app in the opposite appearance to cache an app-switcher snapshot, transiently flipping our
-    // trait collection; any refresh() during that window (trait change, layout pass, or Core Data
-    // notification) would otherwise render a wrong-appearance graph that briefly flashes on return.
+    // trait collection; any refresh() during that window (trait change or Core Data notification)
+    // would otherwise render a wrong-appearance graph that briefly flashes on return.
     // UIScene.didActivateNotification re-runs refresh() once we're active again.
     if window?.windowScene?.activationState == .background { return }
 
@@ -181,7 +152,7 @@ class GoalImageView: UIView {
       urlString: urlString,
       outputWidth: outputWidth,
       darkMode: darkMode,
-      cropToPlot: isThumbnail,
+      cropToPlot: true,
     ) {
       currentRenderTask?.cancel()
       currentRenderToken = UUID()
@@ -207,7 +178,7 @@ class GoalImageView: UIView {
           urlString: urlString,
           outputWidth: outputWidth,
           darkMode: darkMode,
-          cropToPlot: isThumbnail,
+          cropToPlot: true,
         ) { [weak self] image in
           guard let self, !Task.isCancelled, token == self.currentRenderToken else { return }
           self.shownRenderKey = renderKey

--- a/BeeSwift/Components/SVGImageRenderer.swift
+++ b/BeeSwift/Components/SVGImageRenderer.swift
@@ -286,6 +286,17 @@ import WebKit
     .dp.red, .ap.red, .autophages.red, .derails { fill: #ff453a !important; }
     .dp.blu, .ap.blu, .autophages.blu { fill: #5e7bff !important; }
     .horizontext { fill: #6b8cff !important; }
+
+    /* Defensive: elements that are invisible-on-white in light mode but would render wrong on black.
+       None occur in common goals, so these are added pre-emptively (see bgraph dotcolor/arcregion):
+       - black datapoints (dotcolor returns BLCK for points before the goal's start) -> light dot
+       - autophage slash (black) -> light stroke
+       - archived-road region (light gray, only removed in the editor) -> dark gray */
+    .dp.blk, .ap.blk, .autophages.blk { fill: #c7c7cc !important; }
+    .autophage-slash { stroke: #6e6e73 !important; }
+    .arcregion { fill: #2a2a2a !important; }
+    /* odometer tare/restart/archive markers: light-gray zigzag lines (drawn in the static graph) -> dim gray */
+    .tarings, .restarts, .archives { stroke: #48484a !important; }
     """
 
   /// The appearance (background + dark theme) that is injected into the DOM after load.

--- a/BeeSwift/Components/SVGImageRenderer.swift
+++ b/BeeSwift/Components/SVGImageRenderer.swift
@@ -1,0 +1,431 @@
+import Foundation
+import OSLog
+import UIKit
+import WebKit
+
+/// Renders Beeminder goal graph SVGs into `UIImage`s.
+///
+/// SVGs cannot be rasterized natively on iOS, so we render them faithfully with a `WKWebView` and
+/// snapshot the result. Using a web view also lets us inject CSS overrides (e.g. for dark mode).
+///
+/// Rendering goes through a single, reused web view (web views are main-thread only and relatively
+/// expensive), so the actual rasterization is serialized. Downloads run concurrently and both the
+/// downloaded SVG data and the rendered bitmaps are cached so that re-rendering at a new size or for
+/// a different appearance does not hit the network again.
+@MainActor final class SVGImageRenderer {
+  static let shared = SVGImageRenderer()
+
+  enum RenderError: Error {
+    case emptyURL
+    case invalidURL
+    case zeroSize
+    case snapshotFailed
+  }
+
+  private let logger = Logger(subsystem: "com.beeminder.beeminder", category: "SVGImageRenderer")
+
+  /// Cache of downloaded SVG documents, keyed by their (cache-busting) URL string.
+  private let dataCache = NSCache<NSString, NSData>()
+  /// Cache of rendered bitmaps, keyed by URL + size + appearance.
+  private let imageCache = NSCache<NSString, UIImage>()
+
+  /// In-flight downloads, so two views requesting the same goal share a single network request.
+  private var inFlightDownloads: [String: Task<Data, Error>] = [:]
+
+  private init() {
+    imageCache.totalCostLimit = 64 * 1024 * 1024  // ~64MB of rendered graphs
+  }
+
+  /// The natural size of a Beeminder graph SVG (its viewBox). We always lay the SVG out at this size
+  /// — which renders reliably — and downscale the snapshot to the requested output width. Rendering
+  /// directly into a small (e.g. thumbnail-sized) viewport is unreliable: WebKit lays the SVG out at
+  /// a larger default viewport and the snapshot captures only a corner of it.
+  private static let naturalSize = CGSize(width: Constants.graphWidth, height: Constants.graphHeight)
+
+  /// Renders the graph for `darkMode` and, from the *same* page load, also renders and caches the
+  /// opposite appearance, so a later light/dark switch is an instant cache hit. Loading and laying
+  /// out the (large) SVG is the expensive step; the dark theme is a pure recolor, so rather than
+  /// loading the SVG twice we load once, snapshot, swap the theme stylesheet in the DOM, and snapshot
+  /// again.
+  ///
+  /// `primaryReady` is called (on the main actor) with the `darkMode` image as soon as it has been
+  /// captured — before the opposite appearance is rendered — so display latency is unchanged.
+  ///
+  /// When `cropToPlot` is true the snapshot is cropped to just the graph's plot box (no axis labels,
+  /// dates, or margins) — used for thumbnails, matching the old dedicated thumbnail images.
+  func renderBothAppearances(
+    urlString: String,
+    outputWidth: CGFloat,
+    darkMode: Bool,
+    cropToPlot: Bool,
+    primaryReady: @escaping (UIImage) -> Void,
+  ) async throws {
+    guard !urlString.isEmpty else { throw RenderError.emptyURL }
+    guard outputWidth > 0 else { throw RenderError.zeroSize }
+
+    let primaryKey = Self.imageCacheKey(
+      urlString: urlString,
+      outputWidth: outputWidth,
+      darkMode: darkMode,
+      cropToPlot: cropToPlot,
+    )
+    let secondaryKey = Self.imageCacheKey(
+      urlString: urlString,
+      outputWidth: outputWidth,
+      darkMode: !darkMode,
+      cropToPlot: cropToPlot,
+    )
+
+    // Toggle path: the requested appearance was already rendered (as the opposite of an earlier
+    // render), so display it immediately with no web-view work.
+    if let cached = imageCache.object(forKey: primaryKey) {
+      primaryReady(cached)
+      return
+    }
+
+    let data = try await svgData(for: urlString)
+
+    // Rendering must be serialized on the shared web view.
+    await renderLock.acquire()
+    defer { renderLock.release() }
+
+    // Another waiter may have rendered the same thing while we were queued.
+    if let cached = imageCache.object(forKey: primaryKey) {
+      primaryReady(cached)
+      return
+    }
+
+    let secondary = try await rasterizeBoth(
+      svgData: data,
+      outputWidth: outputWidth,
+      primaryDarkMode: darkMode,
+      cropToPlot: cropToPlot,
+    ) { [weak self] primary in
+      self?.imageCache.setObject(primary, forKey: primaryKey, cost: Self.cost(of: primary))
+      primaryReady(primary)
+    }
+    imageCache.setObject(secondary, forKey: secondaryKey, cost: Self.cost(of: secondary))
+  }
+
+  /// Synchronous cache lookup, so a cache hit can be displayed in the same runloop — avoiding a
+  /// placeholder flash when, for example, a reused collection-view cell re-requests a graph it has
+  /// already rendered. Returns nil on a miss, in which case `renderBothAppearances` should be used.
+  func cachedImage(urlString: String, outputWidth: CGFloat, darkMode: Bool, cropToPlot: Bool) -> UIImage? {
+    let key = Self.imageCacheKey(
+      urlString: urlString,
+      outputWidth: outputWidth,
+      darkMode: darkMode,
+      cropToPlot: cropToPlot,
+    )
+    return imageCache.object(forKey: key)
+  }
+
+  // MARK: - Downloading
+
+  private func svgData(for urlString: String) async throws -> Data {
+    if let cached = dataCache.object(forKey: urlString as NSString) { return cached as Data }
+    if let existing = inFlightDownloads[urlString] { return try await existing.value }
+
+    guard let url = URL(string: urlString) else { throw RenderError.invalidURL }
+
+    let task = Task<Data, Error> {
+      let (data, _) = try await URLSession.shared.data(from: url)
+      return data
+    }
+    inFlightDownloads[urlString] = task
+    defer { inFlightDownloads[urlString] = nil }
+
+    let data = try await task.value
+    dataCache.setObject(data as NSData, forKey: urlString as NSString, cost: data.count)
+    return data
+  }
+
+  // MARK: - Rasterization
+
+  private lazy var webView: WKWebView = {
+    let configuration = WKWebViewConfiguration()
+    let webView = WKWebView(frame: .zero, configuration: configuration)
+    webView.isOpaque = false
+    webView.backgroundColor = .clear
+    webView.scrollView.backgroundColor = .clear
+    webView.isUserInteractionEnabled = false
+    // Stop the web view's scroll view from inadvertently insetting (and so shifting/clipping) the
+    // content for safe areas — otherwise the snapshot loses the graph's bottom axis labels.
+    webView.scrollView.contentInsetAdjustmentBehavior = .never
+    webView.navigationDelegate = navigationDelegate
+    return webView
+  }()
+
+  private let navigationDelegate = NavigationDelegate()
+  private let renderLock = AsyncLock()
+
+  /// Loads the SVG once and captures both appearances: snapshots `primaryDarkMode` (invoking
+  /// `onPrimary` with it), then swaps the theme stylesheet in the DOM and snapshots the opposite
+  /// appearance, which is returned. Colours change but geometry doesn't, so the second snapshot only
+  /// costs a recalc + repaint rather than another full load.
+  private func rasterizeBoth(
+    svgData: Data,
+    outputWidth: CGFloat,
+    primaryDarkMode: Bool,
+    cropToPlot: Bool,
+    onPrimary: @escaping (UIImage) -> Void,
+  ) async throws -> UIImage {
+    let svg = String(decoding: svgData, as: UTF8.self)
+    // The document loads with only structural CSS (sizing). Appearance (background + theme) and the
+    // plot-box measurement are applied via the DOM after load — see `themeAndMeasureJS`.
+    let html = Self.htmlDocument(svg: svg, pointSize: Self.naturalSize)
+
+    attachToWindowIfNeeded()
+    // The SVG is always laid out at its natural size; the snapshot is downscaled to the requested
+    // output width. The web view's own content lives at (0, 0); its frame is positioned off-screen so
+    // it is never visible. takeSnapshot's rect is in the web view's coordinate space, so the
+    // off-screen position does not affect it.
+    webView.frame = CGRect(x: -20000, y: -20000, width: Self.naturalSize.width, height: Self.naturalSize.height)
+
+    try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+      navigationDelegate.onComplete = { result in continuation.resume(with: result) }
+      webView.loadHTMLString(html, baseURL: nil)
+    }
+
+    // Apply the primary appearance and read the plot box (in viewBox coordinates, mapped through the
+    // element's CTM so it's robust to transforms) in a single round-trip.
+    let measurement = try await evaluateJavaScript(
+      Self.themeAndMeasureJS(css: Self.appearanceCSS(darkMode: primaryDarkMode))
+    )
+    let plotRect = Self.rect(from: measurement)
+
+    // For thumbnails, capture only the plot box (no axis labels/margins). The SVG renders 1:1 with
+    // its viewBox, so the plot rect is also the snapshot rect in web-view points.
+    let snapshotRect = (cropToPlot ? plotRect : nil) ?? CGRect(origin: .zero, size: Self.naturalSize)
+
+    // The style was just applied; give the web view a moment to repaint before snapshotting (this
+    // also covers the paint lag of a large, complex graph SVG).
+    try? await Task.sleep(for: .milliseconds(80))
+    let primary = try await snapshot(rect: snapshotRect, outputWidth: outputWidth)
+    onPrimary(primary)
+
+    // Swap to the opposite appearance — only the colours change, so this is a recalc + repaint, not
+    // a reload. A short delay lets that repaint land before the second snapshot.
+    _ = try await evaluateJavaScript(Self.setThemeJS(css: Self.appearanceCSS(darkMode: !primaryDarkMode)))
+    try? await Task.sleep(for: .milliseconds(50))
+    return try await snapshot(rect: snapshotRect, outputWidth: outputWidth)
+  }
+
+  /// Snapshots the current web-view content within `rect`, downscaled to `outputWidth` points wide.
+  private func snapshot(rect: CGRect, outputWidth: CGFloat) async throws -> UIImage {
+    let config = WKSnapshotConfiguration()
+    config.rect = rect
+    config.snapshotWidth = NSNumber(value: Double(outputWidth))
+
+    return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<UIImage, Error>) in
+      webView.takeSnapshot(with: config) { [weak self] image, error in
+        if let image {
+          continuation.resume(returning: image)
+        } else {
+          self?.logger.error("SVG snapshot failed: \(String(describing: error))")
+          continuation.resume(throwing: error ?? RenderError.snapshotFailed)
+        }
+      }
+    }
+  }
+
+  /// `WKWebView` only reliably renders (and so snapshots) when it is part of a window.
+  private func attachToWindowIfNeeded() {
+    guard webView.window == nil else { return }
+    let window = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }.flatMap { $0.windows }.first {
+      $0.isKeyWindow
+    }
+    window?.addSubview(webView)
+  }
+
+  /// Runs JavaScript in the web view and returns its result. Uses the completion-handler API (rather
+  /// than the async overload, which can crash bridging a `null`/`undefined` result).
+  private func evaluateJavaScript(_ js: String) async throws -> Any? {
+    try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Any?, Error>) in
+      webView.evaluateJavaScript(js) { result, error in
+        if let error { continuation.resume(throwing: error) } else { continuation.resume(returning: result) }
+      }
+    }
+  }
+
+  // MARK: - HTML / CSS
+
+  /// Dark-mode theme for the graph. Rather than blanket-inverting the image (which turns the bright
+  /// red line pink, the yellow safe region black, etc.), we override Beeminder's own `bgraph` SVG
+  /// classes: invert only the neutrals (dark canvas, light axes/text, dimmed gridlines, dimmed amber
+  /// safe region) and keep the meaningful datapoint/line colors, nudging the darker ones brighter on
+  /// black. Note this couples us to those class names — if they change, affected elements fall back
+  /// to their light-mode colors until updated.
+  private static let darkThemeCSS = """
+    /* page / plot background */
+    html, body { background: #000000; }
+
+    /* neutrals: flip light <-> dark */
+    .axis path, .axis line { stroke: #8e8e93 !important; }
+    .axis .minor line { stroke: #48484a !important; }
+    .grid line { stroke: #1a1a1c !important; }
+    .axis text, .axislabel, .tick text,
+    .pasttext, .ctxtodaytext, .ctxhortext, .hashtag { fill: #c7c7cc !important; }
+    .waterbuf, .waterbux { fill: #ffffff !important; }
+    #svg1 .dp, circle.dots, #svg1 .autophages { stroke: #000000 !important; }
+    circle.hp { fill: #cfcfd4 !important; }
+
+    /* akrasia-horizon lockout band: was a light pink hatch -> subtle dark maroon */
+    .pinkregion { fill: #2c1a1a !important; }
+
+    /* Yellow safe region (bright on white) -> subtle dark on black. Match by fill VALUE, not the
+       `.halfplaneN` index: the yellow half-planes use different indices per goal, and the unused
+       ones are `fill="none"` (which we must leave transparent rather than paint a phantom region). */
+    .ybhp[fill="#ffff88"] { fill: #26210e !important; }
+    .ybhp[fill="#ffffbd"] { fill: #322c16 !important; }
+    .guides { stroke: #2f2a18 !important; }
+    #svg1 .maxflux, #svg1 .stdflux { stroke: #6e5e1c !important; }
+
+    /* meaningful colors: keep; nudge the dark ones brighter on black */
+    #svg1 .razr, .razr { stroke: #ff3b30 !important; }
+    .dp.red, .ap.red, .autophages.red, .derails { fill: #ff453a !important; }
+    .dp.blu, .ap.blu, .autophages.blu { fill: #5e7bff !important; }
+    .horizontext { fill: #6b8cff !important; }
+    """
+
+  /// The appearance (background + dark theme) that is injected into the DOM after load.
+  private static func appearanceCSS(darkMode: Bool) -> String {
+    darkMode ? darkThemeCSS : "html, body { background: #ffffff; }"
+  }
+
+  /// The structural document: pins the layout viewport and the SVG to exactly the target size (in CSS
+  /// px == points). Without this the web view lays the SVG out at a default viewport width and the
+  /// snapshot only captures its top-left corner. Appearance is applied separately via the DOM.
+  private static func htmlDocument(svg: String, pointSize: CGSize) -> String {
+    let width = Int(pointSize.width.rounded())
+    let height = Int(pointSize.height.rounded())
+
+    return """
+      <!DOCTYPE html>
+      <html>
+      <head>
+      <meta name="viewport" content="width=\(width), initial-scale=1, maximum-scale=1, user-scalable=no">
+      <style>
+        html, body { margin: 0; padding: 0; width: \(width)px; height: \(height)px; overflow: hidden; }
+        svg { display: block; width: \(width)px; height: \(height)px; }
+      </style>
+      </head>
+      <body>\(svg)</body>
+      </html>
+      """
+  }
+
+  /// JavaScript that applies the appearance stylesheet (creating the reusable `#bm-theme` style
+  /// element) and returns the `.zoomarea` plot box in viewBox coordinates (mapped through its CTM, so
+  /// it survives ancestor transforms). Returns an empty object if there is no plot box. Always
+  /// returns an object (never `undefined`) to keep the bridged result well-defined.
+  private static func themeAndMeasureJS(css: String) -> String {
+    return """
+      (function() {
+        var style = document.getElementById('bm-theme');
+        if (!style) { style = document.createElement('style'); style.id = 'bm-theme'; \
+      document.head.appendChild(style); }
+        style.textContent = \(jsStringLiteral(css));
+
+        var z = document.querySelector('.zoomarea');
+        if (!z || !z.getBBox) { return {}; }
+        var b = z.getBBox();
+        var m = z.getCTM();
+        if (!m) { return { x: b.x, y: b.y, width: b.width, height: b.height }; }
+        var xs = [b.x, b.x + b.width], ys = [b.y, b.y + b.height], px = [], py = [];
+        for (var i = 0; i < 2; i++) {
+          for (var j = 0; j < 2; j++) {
+            px.push(m.a * xs[i] + m.c * ys[j] + m.e);
+            py.push(m.b * xs[i] + m.d * ys[j] + m.f);
+          }
+        }
+        var minx = Math.min.apply(null, px), maxx = Math.max.apply(null, px);
+        var miny = Math.min.apply(null, py), maxy = Math.max.apply(null, py);
+        return { x: minx, y: miny, width: maxx - minx, height: maxy - miny };
+      })();
+      """
+  }
+
+  /// JavaScript that swaps the `#bm-theme` stylesheet's contents — a recalc + repaint, no reload —
+  /// used to re-theme the already-loaded SVG for its opposite appearance.
+  private static func setThemeJS(css: String) -> String {
+    return """
+      (function() {
+        var style = document.getElementById('bm-theme');
+        if (!style) { style = document.createElement('style'); style.id = 'bm-theme'; \
+      document.head.appendChild(style); }
+        style.textContent = \(jsStringLiteral(css));
+        return {};
+      })();
+      """
+  }
+
+  /// Encodes a Swift string as a JS string literal (a JSON string is also a valid JS string).
+  private static func jsStringLiteral(_ string: String) -> String {
+    guard let data = try? JSONSerialization.data(withJSONObject: string, options: [.fragmentsAllowed]),
+      let literal = String(data: data, encoding: .utf8)
+    else { return "\"\"" }
+    return literal
+  }
+
+  /// Parses a `{x, y, width, height}` object returned from JavaScript into a `CGRect`.
+  private static func rect(from value: Any?) -> CGRect? {
+    guard let dict = value as? [String: Any], let x = (dict["x"] as? NSNumber)?.doubleValue,
+      let y = (dict["y"] as? NSNumber)?.doubleValue, let w = (dict["width"] as? NSNumber)?.doubleValue,
+      let h = (dict["height"] as? NSNumber)?.doubleValue, w > 0, h > 0
+    else { return nil }
+    return CGRect(x: x, y: y, width: w, height: h)
+  }
+
+  // MARK: - Cache keys
+
+  private static func imageCacheKey(urlString: String, outputWidth: CGFloat, darkMode: Bool, cropToPlot: Bool)
+    -> NSString
+  {
+    let scale = UITraitCollection.current.displayScale
+    return
+      "\(urlString)|w\(Int(outputWidth.rounded()))@\(scale)|\(darkMode ? "dark" : "light")|\(cropToPlot ? "plot" : "full")"
+      as NSString
+  }
+
+  private static func cost(of image: UIImage) -> Int {
+    Int(image.size.width * image.scale * image.size.height * image.scale * 4)
+  }
+}
+
+/// Bridges `WKNavigationDelegate` callbacks into a single completion closure.
+private final class NavigationDelegate: NSObject, WKNavigationDelegate {
+  var onComplete: ((Result<Void, Error>) -> Void)?
+
+  func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) { finish(.success(())) }
+
+  func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+    finish(.failure(error))
+  }
+
+  func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+    finish(.failure(error))
+  }
+
+  private func finish(_ result: Result<Void, Error>) {
+    let completion = onComplete
+    onComplete = nil
+    completion?(result)
+  }
+}
+
+/// A minimal FIFO async mutex used to serialize access to the shared rendering web view.
+@MainActor private final class AsyncLock {
+  private var isLocked = false
+  private var waiters: [CheckedContinuation<Void, Never>] = []
+
+  func acquire() async {
+    if !isLocked {
+      isLocked = true
+      return
+    }
+    await withCheckedContinuation { waiters.append($0) }
+  }
+
+  func release() { if waiters.isEmpty { isLocked = false } else { waiters.removeFirst().resume() } }
+}

--- a/BeeSwift/Components/SVGImageRenderer.swift
+++ b/BeeSwift/Components/SVGImageRenderer.swift
@@ -329,6 +329,11 @@ import WebKit
     .axis text, .axislabel, .tick text,
     .pasttext, .ctxtodaytext, .ctxhortext, .hashtag { fill: #c7c7cc !important; }
     .waterbuf, .waterbux { fill: #ffffff !important; }
+    /* The ∞ safe-days watermark is a <use> of #inf: a solid black ∞ with the two loop holes painted
+       white on top. Those paths carry their own fill attributes, so the .waterbuf override above does
+       not reach them; swap both so the holes read as background on black, as they do on white. */
+    #inf path[fill="black"] { fill: #ffffff !important; }
+    #inf path[fill="white"] { fill: #000000 !important; }
     /* Datapoint outlines are black (to separate dots from the white page and from each other). On
        black they'd vanish and densely-packed dots would merge into a blob, so make them light. */
     #svg1 .dp, circle.dots, #svg1 .autophages { stroke: #c7c7cc !important; }

--- a/BeeSwift/Components/SVGImageRenderer.swift
+++ b/BeeSwift/Components/SVGImageRenderer.swift
@@ -139,8 +139,8 @@ import WebKit
     webView.isUserInteractionEnabled = false
     // Off-screen rendering surface; keep VoiceOver out of it.
     webView.accessibilityElementsHidden = true
-    // Otherwise the scroll view insets the content for the safe area and the snapshot loses the
-    // graph's bottom axis labels.
+    // Keeps the scroll view from insetting the content for the safe area, which would clip the
+    // graph's bottom axis labels from the snapshot.
     webView.scrollView.contentInsetAdjustmentBehavior = .never
     webView.navigationDelegate = navigationDelegate
     return webView
@@ -276,11 +276,10 @@ import WebKit
   // MARK: - HTML / CSS
 
   /// Dark-mode theme for the graph, overriding bgraph's SVG classes. Only the neutrals are inverted
-  /// (canvas, axes, text, grid, safe region); the meaningful datapoint and line colors are kept. A
-  /// blanket inversion would turn the red line pink and the safe region black. If bgraph renames a
-  /// class, the affected elements keep their light-mode colors.
+  /// (canvas, axes, text, grid, safe region); the meaningful datapoint and line colors are kept. If
+  /// bgraph renames a class, the affected elements keep their light-mode colors.
   ///
-  /// `GoalGraphView` applies the same CSS behind a `prefers-color-scheme: dark` media query.
+  /// Used for both the rasterized thumbnails and the live detail graph.
   static let darkThemeCSS = """
     /* page / plot background */
     html, body { background: #000000; }

--- a/BeeSwift/Components/SVGImageRenderer.swift
+++ b/BeeSwift/Components/SVGImageRenderer.swift
@@ -20,6 +20,8 @@ import WebKit
     case invalidURL
     case zeroSize
     case snapshotFailed
+    case webContentProcessTerminated
+    case loadTimedOut
   }
 
   private let logger = Logger(subsystem: "com.beeminder.beeminder", category: "SVGImageRenderer")
@@ -89,6 +91,10 @@ import WebKit
     await renderLock.acquire()
     defer { renderLock.release() }
 
+    // If the requester gave up while we were queued (e.g. a gallery cell scrolled off-screen), don't
+    // spend web-view time rendering something nobody will display.
+    try Task.checkCancellation()
+
     // Another waiter may have rendered the same thing while we were queued.
     if let cached = imageCache.object(forKey: primaryKey) {
       primaryReady(cached)
@@ -151,6 +157,9 @@ import WebKit
     webView.backgroundColor = .clear
     webView.scrollView.backgroundColor = .clear
     webView.isUserInteractionEnabled = false
+    // The web view is an off-screen rendering surface attached to the key window; keep VoiceOver
+    // from discovering (and trying to read) the graph SVG's text inside it.
+    webView.accessibilityElementsHidden = true
     // Stop the web view's scroll view from inadvertently insetting (and so shifting/clipping) the
     // content for safe areas — otherwise the snapshot loses the graph's bottom axis labels.
     webView.scrollView.contentInsetAdjustmentBehavior = .never
@@ -184,10 +193,7 @@ import WebKit
     // off-screen position does not affect it.
     webView.frame = CGRect(x: -20000, y: -20000, width: Self.naturalSize.width, height: Self.naturalSize.height)
 
-    try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-      navigationDelegate.onComplete = { result in continuation.resume(with: result) }
-      webView.loadHTMLString(html, baseURL: nil)
-    }
+    try await load(html: html)
 
     // Apply the primary appearance and read the plot box (in viewBox coordinates, mapped through the
     // element's CTM so it's robust to transforms) in a single round-trip.
@@ -200,17 +206,58 @@ import WebKit
     // its viewBox, so the plot rect is also the snapshot rect in web-view points.
     let snapshotRect = (cropToPlot ? plotRect : nil) ?? CGRect(origin: .zero, size: Self.naturalSize)
 
-    // The style was just applied; give the web view a moment to repaint before snapshotting (this
-    // also covers the paint lag of a large, complex graph SVG).
-    try? await Task.sleep(for: .milliseconds(80))
+    // The style was just applied; wait for the web view to paint a frame with it before snapshotting
+    // (this also covers the layout/paint lag of a large, complex graph SVG right after load).
+    try await waitForPaint()
     let primary = try await snapshot(rect: snapshotRect, outputWidth: outputWidth)
     onPrimary(primary)
 
     // Swap to the opposite appearance — only the colours change, so this is a recalc + repaint, not
-    // a reload. A short delay lets that repaint land before the second snapshot.
+    // a reload — and wait for that repaint before the second snapshot.
     _ = try await evaluateJavaScript(Self.setThemeJS(css: Self.appearanceCSS(darkMode: !primaryDarkMode)))
-    try? await Task.sleep(for: .milliseconds(50))
+    try await waitForPaint()
     return try await snapshot(rect: snapshotRect, outputWidth: outputWidth)
+  }
+
+  /// How long a document load may take before the render is abandoned. Loads normally complete in
+  /// well under a second; this only guards against a load that never reports completion, which would
+  /// otherwise hold the render lock forever and stop every graph in the app from rendering.
+  private static let loadTimeout: Duration = .seconds(15)
+
+  /// Loads `html` into the shared web view and returns once the document has finished loading.
+  private func load(html: String) async throws {
+    let timeout = Task { [weak self] in
+      try await Task.sleep(for: Self.loadTimeout)
+      guard let self else { return }
+      self.logger.error("SVG document load timed out")
+      self.navigationDelegate.finish(.failure(RenderError.loadTimedOut))
+      self.webView.stopLoading()
+    }
+    defer { timeout.cancel() }
+
+    try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+      navigationDelegate.onComplete = { result in continuation.resume(with: result) }
+      navigationDelegate.expectedNavigation = webView.loadHTMLString(html, baseURL: nil)
+    }
+  }
+
+  /// Returns once the web view has painted a frame reflecting the current DOM, so a snapshot taken
+  /// afterwards includes any style or content change made before the call. Two
+  /// `requestAnimationFrame`s are needed: the first callback runs just *before* the next frame is
+  /// rendered, the second only after that frame has been committed. A timer fallback ensures this
+  /// can never stall a render if animation frames are throttled for the off-screen web view.
+  private func waitForPaint() async throws {
+    let winner = try await callAsyncJavaScript(
+      """
+      return await Promise.race([
+        new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(() => resolve('frame')))),
+        new Promise(resolve => setTimeout(() => resolve('timeout'), 250)),
+      ]);
+      """
+    )
+    if winner as? String != "frame" {
+      logger.debug("Paint wait fell back to the timer (animation frames not delivered)")
+    }
   }
 
   /// Snapshots the current web-view content within `rect`, downscaled to `outputWidth` points wide.
@@ -250,6 +297,16 @@ import WebKit
     }
   }
 
+  /// Runs an async JavaScript function body (it may `await`) and returns its result. The body must
+  /// return a non-null value — see `evaluateJavaScript` for why.
+  private func callAsyncJavaScript(_ functionBody: String) async throws -> Any {
+    try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Any, Error>) in
+      webView.callAsyncJavaScript(functionBody, arguments: [:], in: nil, in: .page) { result in
+        continuation.resume(with: result)
+      }
+    }
+  }
+
   // MARK: - HTML / CSS
 
   /// Dark-mode theme for the graph. Rather than blanket-inverting the image (which turns the bright
@@ -258,8 +315,9 @@ import WebKit
   /// safe region) and keep the meaningful datapoint/line colors, nudging the darker ones brighter on
   /// black. Note this couples us to those class names — if they change, affected elements fall back
   /// to their light-mode colors until updated.
-  /// The dark-appearance overrides (shared with the live detail graph view, which wraps them in a
-  /// `@media (prefers-color-scheme: dark)` query). Includes the `html, body` dark background.
+  ///
+  /// Shared with the live detail graph view (`GoalGraphView`), which wraps these overrides in a
+  /// `@media (prefers-color-scheme: dark)` query. Includes the `html, body` dark background.
   static let darkThemeCSS = """
     /* page / plot background */
     html, body { background: #000000; }
@@ -414,20 +472,39 @@ import WebKit
 /// Bridges `WKNavigationDelegate` callbacks into a single completion closure.
 private final class NavigationDelegate: NSObject, WKNavigationDelegate {
   var onComplete: ((Result<Void, Error>) -> Void)?
+  /// The navigation `onComplete` is waiting on. Callbacks for any other navigation are ignored — in
+  /// particular the failure WebKit reports for a load we abandoned (timed out and stopped), which can
+  /// arrive after the next load has already started and must not complete *that* one.
+  var expectedNavigation: WKNavigation?
 
-  func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) { finish(.success(())) }
+  func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) { finish(.success(()), for: navigation) }
 
   func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
-    finish(.failure(error))
+    finish(.failure(error), for: navigation)
   }
 
   func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
-    finish(.failure(error))
+    finish(.failure(error), for: navigation)
   }
 
-  private func finish(_ result: Result<Void, Error>) {
+  private func finish(_ result: Result<Void, Error>, for navigation: WKNavigation?) {
+    if let navigation, let expectedNavigation, navigation !== expectedNavigation { return }
+    finish(result)
+  }
+
+  /// If WebKit's content process is killed mid-load (e.g. under memory pressure) no didFinish/didFail
+  /// callback arrives. Fail the pending load so the render lock is released and later renders (which
+  /// relaunch the process on their next load) aren't blocked forever.
+  func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
+    finish(.failure(SVGImageRenderer.RenderError.webContentProcessTerminated))
+  }
+
+  /// Completes the pending load (if any) regardless of navigation; used for whole-web-view events
+  /// (process termination, timeout).
+  func finish(_ result: Result<Void, Error>) {
     let completion = onComplete
     onComplete = nil
+    expectedNavigation = nil
     completion?(result)
   }
 }

--- a/BeeSwift/Components/SVGImageRenderer.swift
+++ b/BeeSwift/Components/SVGImageRenderer.swift
@@ -122,7 +122,9 @@ import WebKit
 
   // MARK: - Downloading
 
-  private func svgData(for urlString: String) async throws -> Data {
+  /// Downloads (and caches) the SVG document for a cache-busting URL. Shared with the live detail
+  /// graph view so it reuses any SVG already fetched for the thumbnail.
+  func svgData(for urlString: String) async throws -> Data {
     if let cached = dataCache.object(forKey: urlString as NSString) { return cached as Data }
     if let existing = inFlightDownloads[urlString] { return try await existing.value }
 
@@ -256,7 +258,9 @@ import WebKit
   /// safe region) and keep the meaningful datapoint/line colors, nudging the darker ones brighter on
   /// black. Note this couples us to those class names — if they change, affected elements fall back
   /// to their light-mode colors until updated.
-  private static let darkThemeCSS = """
+  /// The dark-appearance overrides (shared with the live detail graph view, which wraps them in a
+  /// `@media (prefers-color-scheme: dark)` query). Includes the `html, body` dark background.
+  static let darkThemeCSS = """
     /* page / plot background */
     html, body { background: #000000; }
 
@@ -267,7 +271,9 @@ import WebKit
     .axis text, .axislabel, .tick text,
     .pasttext, .ctxtodaytext, .ctxhortext, .hashtag { fill: #c7c7cc !important; }
     .waterbuf, .waterbux { fill: #ffffff !important; }
-    #svg1 .dp, circle.dots, #svg1 .autophages { stroke: #000000 !important; }
+    /* Datapoint outlines are black (to separate dots from the white page and from each other). On
+       black they'd vanish and densely-packed dots would merge into a blob, so make them light. */
+    #svg1 .dp, circle.dots, #svg1 .autophages { stroke: #c7c7cc !important; }
     circle.hp { fill: #cfcfd4 !important; }
 
     /* akrasia-horizon lockout band: was a light pink hatch -> subtle dark maroon */
@@ -299,8 +305,9 @@ import WebKit
     .tarings, .restarts, .archives { stroke: #48484a !important; }
     """
 
-  /// The appearance (background + dark theme) that is injected into the DOM after load.
-  private static func appearanceCSS(darkMode: Bool) -> String {
+  /// The appearance (background + dark theme) applied to a graph SVG. Shared with the live detail
+  /// graph view so the snapshot and live renderings stay identical.
+  static func appearanceCSS(darkMode: Bool) -> String {
     darkMode ? darkThemeCSS : "html, body { background: #ffffff; }"
   }
 

--- a/BeeSwift/Components/SVGImageRenderer.swift
+++ b/BeeSwift/Components/SVGImageRenderer.swift
@@ -5,13 +5,8 @@ import WebKit
 
 /// Renders Beeminder goal graph SVGs into `UIImage`s.
 ///
-/// SVGs cannot be rasterized natively on iOS, so we render them faithfully with a `WKWebView` and
-/// snapshot the result. Using a web view also lets us inject CSS overrides (e.g. for dark mode).
-///
-/// Rendering goes through a single, reused web view (web views are main-thread only and relatively
-/// expensive), so the actual rasterization is serialized. Downloads run concurrently and both the
-/// downloaded SVG data and the rendered bitmaps are cached so that re-rendering at a new size or for
-/// a different appearance does not hit the network again.
+/// iOS has no native SVG rasterizer, so the SVG is loaded into an off-screen `WKWebView` and
+/// snapshotted. That also lets the dark-mode theme be applied as CSS.
 @MainActor final class SVGImageRenderer {
   static let shared = SVGImageRenderer()
 
@@ -26,35 +21,25 @@ import WebKit
 
   private let logger = Logger(subsystem: "com.beeminder.beeminder", category: "SVGImageRenderer")
 
-  /// Cache of downloaded SVG documents, keyed by their (cache-busting) URL string.
+  /// Downloaded SVG documents, keyed by cache-busting URL.
   private let dataCache = NSCache<NSString, NSData>()
-  /// Cache of rendered bitmaps, keyed by URL + size + appearance.
+  /// Rendered bitmaps, keyed by URL, size and appearance.
   private let imageCache = NSCache<NSString, UIImage>()
 
-  /// In-flight downloads, so two views requesting the same goal share a single network request.
+  /// Shared so that concurrent requests for the same goal download it once.
   private var inFlightDownloads: [String: Task<Data, Error>] = [:]
 
-  private init() {
-    imageCache.totalCostLimit = 64 * 1024 * 1024  // ~64MB of rendered graphs
-  }
+  private init() { imageCache.totalCostLimit = 64 * 1024 * 1024 }
 
-  /// The natural size of a Beeminder graph SVG (its viewBox). We always lay the SVG out at this size
-  /// — which renders reliably — and downscale the snapshot to the requested output width. Rendering
-  /// directly into a small (e.g. thumbnail-sized) viewport is unreliable: WebKit lays the SVG out at
-  /// a larger default viewport and the snapshot captures only a corner of it.
+  /// The graph SVG's viewBox size. The SVG is always laid out at this size and the snapshot downscaled,
+  /// because laying it out directly in a small (thumbnail-sized) viewport is unreliable: WebKit falls
+  /// back to a larger default viewport and the snapshot captures only a corner of it.
   private static let naturalSize = CGSize(width: Constants.graphWidth, height: Constants.graphHeight)
 
-  /// Renders the graph for `darkMode` and, from the *same* page load, also renders and caches the
-  /// opposite appearance, so a later light/dark switch is an instant cache hit. Loading and laying
-  /// out the (large) SVG is the expensive step; the dark theme is a pure recolor, so rather than
-  /// loading the SVG twice we load once, snapshot, swap the theme stylesheet in the DOM, and snapshot
-  /// again.
+  /// Renders the graph for `darkMode`, passing the image to `primaryReady` as soon as it is captured,
+  /// then also renders and caches the opposite appearance so a later light/dark switch is instant.
   ///
-  /// `primaryReady` is called (on the main actor) with the `darkMode` image as soon as it has been
-  /// captured — before the opposite appearance is rendered — so display latency is unchanged.
-  ///
-  /// When `cropToPlot` is true the snapshot is cropped to just the graph's plot box (no axis labels,
-  /// dates, or margins) — used for thumbnails, matching the old dedicated thumbnail images.
+  /// `cropToPlot` restricts the image to the plot box (no axis labels or margins), as thumbnails need.
   func renderBothAppearances(
     urlString: String,
     outputWidth: CGFloat,
@@ -78,8 +63,7 @@ import WebKit
       cropToPlot: cropToPlot,
     )
 
-    // Toggle path: the requested appearance was already rendered (as the opposite of an earlier
-    // render), so display it immediately with no web-view work.
+    // Typically already rendered as the opposite appearance of an earlier render.
     if let cached = imageCache.object(forKey: primaryKey) {
       primaryReady(cached)
       return
@@ -91,8 +75,7 @@ import WebKit
     await renderLock.acquire()
     defer { renderLock.release() }
 
-    // If the requester gave up while we were queued (e.g. a gallery cell scrolled off-screen), don't
-    // spend web-view time rendering something nobody will display.
+    // The requester may have given up (e.g. its cell scrolled off-screen) while we were queued.
     try Task.checkCancellation()
 
     // Another waiter may have rendered the same thing while we were queued.
@@ -113,9 +96,7 @@ import WebKit
     imageCache.setObject(secondary, forKey: secondaryKey, cost: Self.cost(of: secondary))
   }
 
-  /// Synchronous cache lookup, so a cache hit can be displayed in the same runloop — avoiding a
-  /// placeholder flash when, for example, a reused collection-view cell re-requests a graph it has
-  /// already rendered. Returns nil on a miss, in which case `renderBothAppearances` should be used.
+  /// Synchronous cache lookup, so a hit can be shown in the same runloop without a placeholder flash.
   func cachedImage(urlString: String, outputWidth: CGFloat, darkMode: Bool, cropToPlot: Bool) -> UIImage? {
     let key = Self.imageCacheKey(
       urlString: urlString,
@@ -128,8 +109,7 @@ import WebKit
 
   // MARK: - Downloading
 
-  /// Downloads (and caches) the SVG document for a cache-busting URL. Shared with the live detail
-  /// graph view so it reuses any SVG already fetched for the thumbnail.
+  /// Downloads and caches the SVG document at `urlString`. Concurrent callers share one download.
   func svgData(for urlString: String) async throws -> Data {
     if let cached = dataCache.object(forKey: urlString as NSString) { return cached as Data }
     if let existing = inFlightDownloads[urlString] { return try await existing.value }
@@ -157,11 +137,10 @@ import WebKit
     webView.backgroundColor = .clear
     webView.scrollView.backgroundColor = .clear
     webView.isUserInteractionEnabled = false
-    // The web view is an off-screen rendering surface attached to the key window; keep VoiceOver
-    // from discovering (and trying to read) the graph SVG's text inside it.
+    // Off-screen rendering surface; keep VoiceOver out of it.
     webView.accessibilityElementsHidden = true
-    // Stop the web view's scroll view from inadvertently insetting (and so shifting/clipping) the
-    // content for safe areas — otherwise the snapshot loses the graph's bottom axis labels.
+    // Otherwise the scroll view insets the content for the safe area and the snapshot loses the
+    // graph's bottom axis labels.
     webView.scrollView.contentInsetAdjustmentBehavior = .never
     webView.navigationDelegate = navigationDelegate
     return webView
@@ -170,10 +149,9 @@ import WebKit
   private let navigationDelegate = NavigationDelegate()
   private let renderLock = AsyncLock()
 
-  /// Loads the SVG once and captures both appearances: snapshots `primaryDarkMode` (invoking
-  /// `onPrimary` with it), then swaps the theme stylesheet in the DOM and snapshots the opposite
-  /// appearance, which is returned. Colours change but geometry doesn't, so the second snapshot only
-  /// costs a recalc + repaint rather than another full load.
+  /// Loads the SVG once and snapshots both appearances: `primaryDarkMode` first (passed to
+  /// `onPrimary`), then the opposite, which is returned. Swapping the theme stylesheet is only a
+  /// recolor, so the second snapshot avoids a second load and layout of the large SVG.
   private func rasterizeBoth(
     svgData: Data,
     outputWidth: CGFloat,
@@ -182,46 +160,36 @@ import WebKit
     onPrimary: @escaping (UIImage) -> Void,
   ) async throws -> UIImage {
     let svg = String(decoding: svgData, as: UTF8.self)
-    // The document loads with only structural CSS (sizing). Appearance (background + theme) and the
-    // plot-box measurement are applied via the DOM after load — see `themeAndMeasureJS`.
     let html = Self.htmlDocument(svg: svg, pointSize: Self.naturalSize)
 
     attachToWindowIfNeeded()
-    // The SVG is always laid out at its natural size; the snapshot is downscaled to the requested
-    // output width. The web view's own content lives at (0, 0); its frame is positioned off-screen so
-    // it is never visible. takeSnapshot's rect is in the web view's coordinate space, so the
-    // off-screen position does not affect it.
+    // Laid out at natural size (see naturalSize) and parked off-screen. Snapshot rects are in the web
+    // view's own coordinates, so its position is irrelevant.
     webView.frame = CGRect(x: -20000, y: -20000, width: Self.naturalSize.width, height: Self.naturalSize.height)
 
     try await load(html: html)
 
-    // Apply the primary appearance and read the plot box (in viewBox coordinates, mapped through the
-    // element's CTM so it's robust to transforms) in a single round-trip.
+    // Theme and measure the plot box in one round-trip.
     let measurement = try await evaluateJavaScript(
       Self.themeAndMeasureJS(css: Self.appearanceCSS(darkMode: primaryDarkMode))
     )
     let plotRect = Self.rect(from: measurement)
 
-    // For thumbnails, capture only the plot box (no axis labels/margins). The SVG renders 1:1 with
-    // its viewBox, so the plot rect is also the snapshot rect in web-view points.
+    // The SVG renders 1:1 with its viewBox, so the plot box is also the snapshot rect in points.
     let snapshotRect = (cropToPlot ? plotRect : nil) ?? CGRect(origin: .zero, size: Self.naturalSize)
 
-    // The style was just applied; wait for the web view to paint a frame with it before snapshotting
-    // (this also covers the layout/paint lag of a large, complex graph SVG right after load).
+    // Let the theme (and, right after load, the initial layout) paint before snapshotting.
     try await waitForPaint()
     let primary = try await snapshot(rect: snapshotRect, outputWidth: outputWidth)
     onPrimary(primary)
 
-    // Swap to the opposite appearance — only the colours change, so this is a recalc + repaint, not
-    // a reload — and wait for that repaint before the second snapshot.
+    // Recolor only; no reload.
     _ = try await evaluateJavaScript(Self.setThemeJS(css: Self.appearanceCSS(darkMode: !primaryDarkMode)))
     try await waitForPaint()
     return try await snapshot(rect: snapshotRect, outputWidth: outputWidth)
   }
 
-  /// How long a document load may take before the render is abandoned. Loads normally complete in
-  /// well under a second; this only guards against a load that never reports completion, which would
-  /// otherwise hold the render lock forever and stop every graph in the app from rendering.
+  /// Guards against a load that never reports completion, which would hold the render lock forever.
   private static let loadTimeout: Duration = .seconds(15)
 
   /// Loads `html` into the shared web view and returns once the document has finished loading.
@@ -241,11 +209,9 @@ import WebKit
     }
   }
 
-  /// Returns once the web view has painted a frame reflecting the current DOM, so a snapshot taken
-  /// afterwards includes any style or content change made before the call. Two
-  /// `requestAnimationFrame`s are needed: the first callback runs just *before* the next frame is
-  /// rendered, the second only after that frame has been committed. A timer fallback ensures this
-  /// can never stall a render if animation frames are throttled for the off-screen web view.
+  /// Returns once the web view has painted the current DOM. The first requestAnimationFrame callback
+  /// runs before the next frame renders; the second runs after it has been committed. The timer is a
+  /// fallback in case frames are throttled for the off-screen view.
   private func waitForPaint() async throws {
     let winner = try await callAsyncJavaScript(
       """
@@ -287,8 +253,8 @@ import WebKit
     window?.addSubview(webView)
   }
 
-  /// Runs JavaScript in the web view and returns its result. Uses the completion-handler API (rather
-  /// than the async overload, which can crash bridging a `null`/`undefined` result).
+  /// Runs JavaScript and returns its result. Uses the completion-handler API: the async overload can
+  /// crash bridging a `null`/`undefined` result.
   private func evaluateJavaScript(_ js: String) async throws -> Any? {
     try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Any?, Error>) in
       webView.evaluateJavaScript(js) { result, error in
@@ -297,8 +263,8 @@ import WebKit
     }
   }
 
-  /// Runs an async JavaScript function body (it may `await`) and returns its result. The body must
-  /// return a non-null value — see `evaluateJavaScript` for why.
+  /// Runs an async JavaScript function body and returns its result, which must be non-null (see
+  /// `evaluateJavaScript`).
   private func callAsyncJavaScript(_ functionBody: String) async throws -> Any {
     try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Any, Error>) in
       webView.callAsyncJavaScript(functionBody, arguments: [:], in: nil, in: .page) { result in
@@ -309,15 +275,12 @@ import WebKit
 
   // MARK: - HTML / CSS
 
-  /// Dark-mode theme for the graph. Rather than blanket-inverting the image (which turns the bright
-  /// red line pink, the yellow safe region black, etc.), we override Beeminder's own `bgraph` SVG
-  /// classes: invert only the neutrals (dark canvas, light axes/text, dimmed gridlines, dimmed amber
-  /// safe region) and keep the meaningful datapoint/line colors, nudging the darker ones brighter on
-  /// black. Note this couples us to those class names — if they change, affected elements fall back
-  /// to their light-mode colors until updated.
+  /// Dark-mode theme for the graph, overriding bgraph's SVG classes. Only the neutrals are inverted
+  /// (canvas, axes, text, grid, safe region); the meaningful datapoint and line colors are kept. A
+  /// blanket inversion would turn the red line pink and the safe region black. If bgraph renames a
+  /// class, the affected elements keep their light-mode colors.
   ///
-  /// Shared with the live detail graph view (`GoalGraphView`), which wraps these overrides in a
-  /// `@media (prefers-color-scheme: dark)` query. Includes the `html, body` dark background.
+  /// `GoalGraphView` applies the same CSS behind a `prefers-color-scheme: dark` media query.
   static let darkThemeCSS = """
     /* page / plot background */
     html, body { background: #000000; }
@@ -329,22 +292,19 @@ import WebKit
     .axis text, .axislabel, .tick text,
     .pasttext, .ctxtodaytext, .ctxhortext, .hashtag { fill: #c7c7cc !important; }
     .waterbuf, .waterbux { fill: #ffffff !important; }
-    /* The ∞ safe-days watermark is a <use> of #inf: a solid black ∞ with the two loop holes painted
-       white on top. Those paths carry their own fill attributes, so the .waterbuf override above does
-       not reach them; swap both so the holes read as background on black, as they do on white. */
+    /* The ∞ watermark is a <use> of #inf: a black ∞ with the loop holes painted white on top. Its
+       paths set their own fills, so the .waterbuf rule above doesn't reach them. */
     #inf path[fill="black"] { fill: #ffffff !important; }
     #inf path[fill="white"] { fill: #000000 !important; }
-    /* Datapoint outlines are black (to separate dots from the white page and from each other). On
-       black they'd vanish and densely-packed dots would merge into a blob, so make them light. */
+    /* Black datapoint outlines would vanish, merging dense dots into a blob. */
     #svg1 .dp, circle.dots, #svg1 .autophages { stroke: #c7c7cc !important; }
     circle.hp { fill: #cfcfd4 !important; }
 
     /* akrasia-horizon lockout band: was a light pink hatch -> subtle dark maroon */
     .pinkregion { fill: #2c1a1a !important; }
 
-    /* Yellow safe region (bright on white) -> subtle dark on black. Match by fill VALUE, not the
-       `.halfplaneN` index: the yellow half-planes use different indices per goal, and the unused
-       ones are `fill="none"` (which we must leave transparent rather than paint a phantom region). */
+    /* Safe region. Match by fill value: which .halfplaneN is yellow varies per goal, and the unused
+       ones are fill="none". */
     .ybhp[fill="#ffff88"] { fill: #26210e !important; }
     .ybhp[fill="#ffffbd"] { fill: #322c16 !important; }
     .guides { stroke: #2f2a18 !important; }
@@ -356,27 +316,23 @@ import WebKit
     .dp.blu, .ap.blu, .autophages.blu { fill: #5e7bff !important; }
     .horizontext { fill: #6b8cff !important; }
 
-    /* Defensive: elements that are invisible-on-white in light mode but would render wrong on black.
-       None occur in common goals, so these are added pre-emptively (see bgraph dotcolor/arcregion):
-       - black datapoints (dotcolor returns BLCK for points before the goal's start) -> light dot
-       - autophage slash (black) -> light stroke
-       - archived-road region (light gray, only removed in the editor) -> dark gray */
+    /* Rare in practice but would render wrong on black (see bgraph dotcolor/arcregion): black
+       datapoints, the autophage slash, and the archived-road region. */
     .dp.blk, .ap.blk, .autophages.blk { fill: #c7c7cc !important; }
     .autophage-slash { stroke: #6e6e73 !important; }
     .arcregion { fill: #2a2a2a !important; }
-    /* odometer tare/restart/archive markers: light-gray zigzag lines (drawn in the static graph) -> dim gray */
+    /* odometer tare/restart/archive markers */
     .tarings, .restarts, .archives { stroke: #48484a !important; }
     """
 
-  /// The appearance (background + dark theme) applied to a graph SVG. Shared with the live detail
-  /// graph view so the snapshot and live renderings stay identical.
+  /// The CSS applied to the loaded SVG for an appearance.
   static func appearanceCSS(darkMode: Bool) -> String {
     darkMode ? darkThemeCSS : "html, body { background: #ffffff; }"
   }
 
-  /// The structural document: pins the layout viewport and the SVG to exactly the target size (in CSS
-  /// px == points). Without this the web view lays the SVG out at a default viewport width and the
-  /// snapshot only captures its top-left corner. Appearance is applied separately via the DOM.
+  /// Wraps the SVG in a document whose viewport and SVG are pinned to `pointSize` (CSS px = points).
+  /// Without this WebKit lays the SVG out at a default viewport width and the snapshot captures only
+  /// its top-left corner.
   private static func htmlDocument(svg: String, pointSize: CGSize) -> String {
     let width = Int(pointSize.width.rounded())
     let height = Int(pointSize.height.rounded())
@@ -396,10 +352,9 @@ import WebKit
       """
   }
 
-  /// JavaScript that applies the appearance stylesheet (creating the reusable `#bm-theme` style
-  /// element) and returns the `.zoomarea` plot box in viewBox coordinates (mapped through its CTM, so
-  /// it survives ancestor transforms). Returns an empty object if there is no plot box. Always
-  /// returns an object (never `undefined`) to keep the bridged result well-defined.
+  /// JavaScript that installs `css` as the `#bm-theme` stylesheet and returns the `.zoomarea` plot box
+  /// in viewBox coordinates (mapped through its CTM to account for ancestor transforms), or an empty
+  /// object if there is none. Always returns an object so the bridged result is well-defined.
   private static func themeAndMeasureJS(css: String) -> String {
     return """
       (function() {
@@ -427,8 +382,7 @@ import WebKit
       """
   }
 
-  /// JavaScript that swaps the `#bm-theme` stylesheet's contents — a recalc + repaint, no reload —
-  /// used to re-theme the already-loaded SVG for its opposite appearance.
+  /// JavaScript that replaces the `#bm-theme` stylesheet's contents.
   private static func setThemeJS(css: String) -> String {
     return """
       (function() {
@@ -477,9 +431,8 @@ import WebKit
 /// Bridges `WKNavigationDelegate` callbacks into a single completion closure.
 private final class NavigationDelegate: NSObject, WKNavigationDelegate {
   var onComplete: ((Result<Void, Error>) -> Void)?
-  /// The navigation `onComplete` is waiting on. Callbacks for any other navigation are ignored — in
-  /// particular the failure WebKit reports for a load we abandoned (timed out and stopped), which can
-  /// arrive after the next load has already started and must not complete *that* one.
+  /// Callbacks for other navigations are ignored, in particular the failure WebKit reports for a load
+  /// we timed out and stopped, which can arrive after the next load has started.
   var expectedNavigation: WKNavigation?
 
   func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) { finish(.success(()), for: navigation) }
@@ -497,15 +450,13 @@ private final class NavigationDelegate: NSObject, WKNavigationDelegate {
     finish(result)
   }
 
-  /// If WebKit's content process is killed mid-load (e.g. under memory pressure) no didFinish/didFail
-  /// callback arrives. Fail the pending load so the render lock is released and later renders (which
-  /// relaunch the process on their next load) aren't blocked forever.
+  /// No didFinish/didFail arrives when the content process dies; fail the load so the render lock is
+  /// released.
   func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
     finish(.failure(SVGImageRenderer.RenderError.webContentProcessTerminated))
   }
 
-  /// Completes the pending load (if any) regardless of navigation; used for whole-web-view events
-  /// (process termination, timeout).
+  /// Completes the pending load regardless of navigation (process termination, timeout).
   func finish(_ result: Result<Void, Error>) {
     let completion = onComplete
     onComplete = nil

--- a/BeeSwift/GoalView/GoalViewController.swift
+++ b/BeeSwift/GoalView/GoalViewController.swift
@@ -6,7 +6,6 @@
 //  Copyright 2015 APB. All rights reserved.
 //
 
-import AlamofireImage
 import BeeKit
 import CoreData
 import Foundation

--- a/BeeSwift/GoalView/GoalViewController.swift
+++ b/BeeSwift/GoalView/GoalViewController.swift
@@ -16,8 +16,8 @@ import OSLog
 import SafariServices
 import SwiftyJSON
 
-class GoalViewController: UIViewController, UIScrollViewDelegate, DatapointTableViewControllerDelegate,
-  UITextFieldDelegate, SFSafariViewControllerDelegate
+class GoalViewController: UIViewController, DatapointTableViewControllerDelegate, UITextFieldDelegate,
+  SFSafariViewControllerDelegate
 {
   let elementSpacing = 10
   let sideMargin = 10
@@ -33,7 +33,7 @@ class GoalViewController: UIViewController, UIScrollViewDelegate, DatapointTable
   private let viewContext: NSManagedObjectContext
   private weak var coordinator: MainCoordinator?
   private let timeElapsedView = FreshnessIndicatorView()
-  fileprivate var goalImageView = GoalImageView(isThumbnail: false)
+  fileprivate var goalGraphView = GoalGraphView()
   fileprivate var datapointTableController = DatapointTableViewController()
   fileprivate var dateTextField = UITextField()
   fileprivate var valueTextField = UITextField()
@@ -41,7 +41,6 @@ class GoalViewController: UIViewController, UIScrollViewDelegate, DatapointTable
   fileprivate var dateStepper = UIStepper()
   fileprivate var valueStepper = UIStepper()
   fileprivate var valueDecimalRemnant: Double = 0.0
-  fileprivate var goalImageScrollView = UIScrollView()
   fileprivate var countdownLabel = BSLabel()
   private lazy var deltasLabel: BSLabel = {
     let label = BSLabel()
@@ -129,43 +128,28 @@ class GoalViewController: UIViewController, UIScrollViewDelegate, DatapointTable
       make.width.equalTo(countdownView)
     }
 
-    self.scrollView.addSubview(self.goalImageScrollView)
-    self.goalImageScrollView.showsHorizontalScrollIndicator = false
-    self.goalImageScrollView.showsVerticalScrollIndicator = false
-    self.goalImageScrollView.minimumZoomScale = 1.0
-    self.goalImageScrollView.maximumZoomScale = 3.0
-    self.goalImageScrollView.delegate = self
-    self.goalImageScrollView.snp.makeConstraints { (make) -> Void in
+    // The graph is a live web view that handles its own pinch/double-tap zoom (re-rasterizing the
+    // SVG crisply), so it isn't wrapped in a zooming scroll view.
+    self.scrollView.addSubview(self.goalGraphView)
+    self.goalGraphView.snp.makeConstraints { (make) -> Void in
       make.centerX.equalTo(self.view)
       make.left.greaterThanOrEqualTo(self.scrollView.safeAreaLayoutGuide.snp.leftMargin)
       make.right.lessThanOrEqualTo(self.scrollView.safeAreaLayoutGuide.snp.rightMargin)
 
       make.top.equalTo(countdownView.snp.bottom)
       make.width.equalTo(self.scrollView)
-      make.height.equalTo(self.goalImageScrollView.snp.width).multipliedBy(
+      make.height.equalTo(self.goalGraphView.snp.width).multipliedBy(
         Float(Constants.graphHeight) / Float(Constants.graphWidth)
       )
     }
+    self.goalGraphView.goal = self.goal
 
-    self.goalImageScrollView.addSubview(self.goalImageView)
-    let tapGR = UITapGestureRecognizer(target: self, action: #selector(GoalViewController.goalImageTapped))
-    tapGR.numberOfTapsRequired = 2
-    self.goalImageScrollView.addGestureRecognizer(tapGR)
-    self.goalImageView.snp.makeConstraints { (make) -> Void in
-      make.top.equalTo(0)
-      make.bottom.equalTo(0)
-      make.width.equalTo(self.goalImageScrollView)
-      make.height.equalTo(self.goalImageScrollView)
-      make.left.equalTo(self.goalImageScrollView)
-      make.right.equalTo(self.goalImageScrollView)
-    }
-    self.goalImageView.goal = self.goal
     self.scrollView.addSubview(deltasLabel)
     self.deltasLabel.snp.makeConstraints { make in
-      make.top.equalTo(self.goalImageScrollView.snp.bottom).offset(elementSpacing)
+      make.top.equalTo(self.goalGraphView.snp.bottom).offset(elementSpacing)
       make.height.equalTo(Constants.defaultFontSize)
-      make.left.equalTo(self.goalImageScrollView).offset(sideMargin)
-      make.right.equalTo(self.goalImageScrollView).offset(-sideMargin)
+      make.left.equalTo(self.goalGraphView).offset(sideMargin)
+      make.right.equalTo(self.goalGraphView).offset(-sideMargin)
     }
 
     self.addChild(self.datapointTableController)
@@ -173,8 +157,8 @@ class GoalViewController: UIViewController, UIScrollViewDelegate, DatapointTable
     self.datapointTableController.delegate = self
     self.datapointTableController.view.snp.makeConstraints { (make) -> Void in
       make.top.equalTo(self.deltasLabel.snp.bottom).offset(elementSpacing)
-      make.left.equalTo(self.goalImageScrollView).offset(sideMargin)
-      make.right.equalTo(self.goalImageScrollView).offset(-sideMargin)
+      make.left.equalTo(self.goalGraphView).offset(sideMargin)
+      make.right.equalTo(self.goalGraphView).offset(-sideMargin)
     }
 
     let dataEntryView = UIView()
@@ -397,10 +381,6 @@ class GoalViewController: UIViewController, UIScrollViewDelegate, DatapointTable
     self.countdownLabel.text = self.goal.capitalSafesum()
   }
 
-  @objc func goalImageTapped() {
-    self.goalImageScrollView.setZoomScale(self.goalImageScrollView.zoomScale == 1.0 ? 2.0 : 1.0, animated: true)
-  }
-
   func datapointTableViewController(
     _ datapointTableViewController: DatapointTableViewController,
     didSelectDatapoint datapoint: BeeDataPoint,
@@ -542,7 +522,6 @@ class GoalViewController: UIViewController, UIScrollViewDelegate, DatapointTable
     self.updateLastUpdatedLabel()
   }
 
-  func viewForZooming(in scrollView: UIScrollView) -> UIView? { return self.goalImageView }
   private static func makeInitialDateStepperValue(date: Date = Date(), for goal: Goal) -> Double {
     let daystampAccountingForTheGoalsDeadline = Daystamp(fromDate: date, deadline: goal.deadline)
     let daystampAssumingMidnightDeadline = Daystamp(fromDate: date, deadline: 0)

--- a/BeeSwift/GoalView/GoalViewController.swift
+++ b/BeeSwift/GoalView/GoalViewController.swift
@@ -127,7 +127,6 @@ class GoalViewController: UIViewController, DatapointTableViewControllerDelegate
       make.width.equalTo(countdownView)
     }
 
-    // The graph view handles its own zooming.
     self.scrollView.addSubview(self.goalGraphView)
     self.goalGraphView.snp.makeConstraints { (make) -> Void in
       make.centerX.equalTo(self.view)

--- a/BeeSwift/GoalView/GoalViewController.swift
+++ b/BeeSwift/GoalView/GoalViewController.swift
@@ -127,8 +127,7 @@ class GoalViewController: UIViewController, DatapointTableViewControllerDelegate
       make.width.equalTo(countdownView)
     }
 
-    // The graph is a live web view that handles its own pinch/double-tap zoom (re-rasterizing the
-    // SVG crisply), so it isn't wrapped in a zooming scroll view.
+    // The graph view handles its own zooming.
     self.scrollView.addSubview(self.goalGraphView)
     self.goalGraphView.snp.makeConstraints { (make) -> Void in
       make.centerX.equalTo(self.view)

--- a/BeeSwiftTests/GoalTests.swift
+++ b/BeeSwiftTests/GoalTests.swift
@@ -31,6 +31,7 @@ final class GoalTests: XCTestCase {
           "slug": "test-goal",
           "title": "Goal for Testing Purposes",
           "graph_url": "https://cdn.beeminder.com/uploads/879fb101-0111-4f06-a704-1e5e316c5afc.png",
+          "svg_url": "https://cdn.beeminder.com/uploads/879fb101-0111-4f06-a704-1e5e316c5afc.svg",
           "thumb_url": "https://cdn.beeminder.com/uploads/879fb101-0111-4f06-a704-1e5e316c5afc-thumb.png",
           "deadline": 0,
           "leadtime": 0,
@@ -90,6 +91,7 @@ final class GoalTests: XCTestCase {
     XCTAssertEqual(goal.slug, "test-goal")
     XCTAssertEqual(goal.title, "Goal for Testing Purposes")
     XCTAssertEqual(goal.graphUrl, "https://cdn.beeminder.com/uploads/879fb101-0111-4f06-a704-1e5e316c5afc.png")
+    XCTAssertEqual(goal.svgUrl, "https://cdn.beeminder.com/uploads/879fb101-0111-4f06-a704-1e5e316c5afc.svg")
     XCTAssertEqual(goal.thumbUrl, "https://cdn.beeminder.com/uploads/879fb101-0111-4f06-a704-1e5e316c5afc-thumb.png")
     XCTAssertEqual(goal.deadline, 0)
     XCTAssertEqual(goal.leadTime, 0)


### PR DESCRIPTION
## Summary
Improves thumbnail and graph images
* Both are now powered by SVGs from the server. Thumbnails render locally to images, in GoalView render the SVG for high quality scaling
* Mess with the CSS of the SVG so the images render as dark in dark mode.

## Test plan
- [x] Unit tests pass (`MigrationTests`, `GoalTests`)
- [x] Gallery thumbnails render in dark mode in the simulator
- [x] ∞ watermark renders with correct hole colors in dark mode (verified via WebKit render of a real graph SVG)
- [x] Open a goal: pinch zoom, double-tap zoom, and light/dark switching on the detail graph
- [x] Switch light/dark mode with the gallery open and confirm thumbnails re-theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)